### PR TITLE
fix(tezos-ts): Mutez conversion was flipped in transfer function

### DIFF
--- a/packages/tezos-ts/src/contract/rpc-contract-provider.ts
+++ b/packages/tezos-ts/src/contract/rpc-contract-provider.ts
@@ -365,7 +365,7 @@ export class RpcContractProvider implements ContractProvider {
       fee,
       gas_limit: gasLimit,
       storage_limit: storageLimit,
-      amount: mutez ? format('tz', 'mutez', amount).toString() : amount.toString(),
+      amount: mutez ? amount.toString() : format('tz', 'mutez', amount).toString(),
       destination: to,
     };
     if (parameter) {

--- a/packages/tezos-ts/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/tezos-ts/test/contract/rpc-contract-provider.spec.ts
@@ -171,7 +171,7 @@ describe('RpcContractProvider test', () => {
       mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
       mockSigner.publicKey.mockResolvedValue('test_pub_key');
       mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
-      const result = await rpcContractProvider.transfer({ to: 'test_to', amount: 200 });
+      const result = await rpcContractProvider.transfer({ to: 'test_to', amount: 2 });
       expect(result.raw).toEqual({
         counter: 0,
         opOb: {
@@ -187,7 +187,7 @@ describe('RpcContractProvider test', () => {
               storage_limit: '300',
             },
             {
-              amount: '200',
+              amount: '2000000',
               counter: '2',
               destination: 'test_to',
               fee: '10000',


### PR DESCRIPTION
BREAKING CHANGE: Transfer will now send tz instead of mutez by default