### PR TITLE
feat(taquito): Add fees estimation feature

### DIFF
--- a/example/contract-origination.ts
+++ b/example/contract-origination.ts
@@ -25,7 +25,7 @@ async function example() {
     try {
         console.log('Deploying Hello world contract...')
         const op = await Tezos.contract.originate({
-            balance: "1",
+            balance: "0",
             code: `parameter string;
             storage string;
             code {CAR;
@@ -33,13 +33,14 @@ async function example() {
                   CONCAT;
                   NIL operation; PAIR};
             `,
-            init: `"test"`,
-            fee: 30000,
-            storageLimit: 2000,
-            gasLimit: 90000,
+            init: `"test1234"`
         })
+
         console.log('Awaiting confirmation...')
         const contract = await op.contract()
+        console.log('Gas Used', op.consumedGas)
+        console.log('Storage Paid', op.storageDiff)
+        console.log('Storage Size', op.storageSize)
         console.log('Storage', await contract.storage())
         console.log("Operation hash:", op.hash, "Included in block level:", op.includedInBlock)
     } catch (ex) {

--- a/integration-tests/contract-api-scenario.spec.ts
+++ b/integration-tests/contract-api-scenario.spec.ts
@@ -16,10 +16,7 @@ CONFIGS.forEach(({ lib, rpc }) => {
               CONCAT;
               NIL operation; PAIR};
         `,
-        init: `"test"`,
-        fee: 30000,
-        storageLimit: 2000,
-        gasLimit: 90000,
+        init: `"test"`
       })
       await op.confirmation()
       expect(op.hash).toBeDefined();
@@ -32,9 +29,6 @@ CONFIGS.forEach(({ lib, rpc }) => {
         balance: "1",
         code: ligoSample,
         storage: 0,
-        fee: 30000,
-        storageLimit: 2000,
-        gasLimit: 90000,
       })
       await op.confirmation()
       expect(op.hash).toBeDefined();
@@ -42,11 +36,7 @@ CONFIGS.forEach(({ lib, rpc }) => {
       const contract = await op.contract();
       const storage: any = await contract.storage()
       expect(storage.toString()).toEqual("0")
-      const opMethod = await contract.methods.main("2").send({
-        fee: 30000,
-        storageLimit: 2000,
-        gasLimit: 90000,
-      });
+      const opMethod = await contract.methods.main("2").send();
 
       await opMethod.confirmation();
       expect(op.hash).toBeDefined();
@@ -69,11 +59,7 @@ CONFIGS.forEach(({ lib, rpc }) => {
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
       const contract = await op.contract();
-      const opMethod = await contract.methods.mint(await Tezos.signer.publicKeyHash(), 100).send({
-        fee: 150000,
-        storageLimit: 10000,
-        gasLimit: 400000,
-      });
+      const opMethod = await contract.methods.mint(await Tezos.signer.publicKeyHash(), 100).send();
 
       await opMethod.confirmation();
       expect(op.hash).toBeDefined();
@@ -88,15 +74,13 @@ CONFIGS.forEach(({ lib, rpc }) => {
         storage: {
           mgr1: {
             addr: await Tezos.signer.publicKeyHash(),
+            key: null,
           },
           mgr2: {
             addr: await Tezos.signer.publicKeyHash(),
             key: await Tezos.signer.publicKeyHash(),
           },
-        },
-        fee: 150000,
-        storageLimit: 10000,
-        gasLimit: 400000,
+        }
       })
       await op.confirmation()
       expect(op.hash).toBeDefined();

--- a/packages/taquito-rpc/src/taquito-rpc.ts
+++ b/packages/taquito-rpc/src/taquito-rpc.ts
@@ -61,7 +61,7 @@ export class RpcClient {
     private url: string = defaultRPC,
     private chain: string = defaultChain,
     private httpBackend: HttpBackend = new HttpBackend()
-  ) { }
+  ) {}
 
   /**
    *
@@ -612,6 +612,27 @@ export class RpcClient {
         method: 'POST',
       },
       ops
+    );
+
+    return response;
+  }
+
+  /**
+   *
+   * @param op Operation to run
+   * @param options contains generic configuration for rpc calls
+   *
+   * @description Run an operation without signature checks
+   *
+   * @see https://tezos.gitlab.io/mainnet/api/rpc.html#post-block-id-helpers-scripts-run-operation
+   */
+  async runOperation(op: OperationObject, { block }: RPCOptions = defaultRPCOptions): Promise<any> {
+    const response = await this.httpBackend.createRequest<any>(
+      {
+        url: `${this.url}/chains/${this.chain}/blocks/${block}/helpers/scripts/run_operation`,
+        method: 'POST',
+      },
+      op
     );
 
     return response;

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -875,4 +875,21 @@ describe('RpcClient test', () => {
       done();
     });
   });
+
+  describe('runOperation', () => {
+    it('query the right url and data', async done => {
+      const testData = {};
+
+      await client.runOperation(testData);
+
+      expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
+        method: 'POST',
+        url: 'root/chains/test/blocks/head/helpers/scripts/run_operation',
+      });
+
+      expect(httpBackend.createRequest.mock.calls[0][1]).toEqual(testData);
+
+      done();
+    });
+  });
 });

--- a/packages/taquito/src/contract/estimate.ts
+++ b/packages/taquito/src/contract/estimate.ts
@@ -1,0 +1,77 @@
+const MINIMAL_FEE_MUTEZ = 100;
+const MINIMAL_FEE_PER_BYTE_MUTEZ = 1;
+const MINIMAL_FEE_PER_STORAGE_BYTE_MUTEZ = 1000;
+const MINIMAL_FEE_PER_GAS_MUTEZ = 0.1;
+
+const GAS_BUFFER = 100;
+
+export class Estimate {
+  constructor(
+    private readonly _gasLimit: number | string,
+    private readonly _storageLimit: number | string,
+    private readonly opSize: number | string,
+    /**
+     * @description Base fee in mutez (1 mutez = 1e10−6 tez)
+     */
+    private readonly baseFeeMutez: number | string = MINIMAL_FEE_MUTEZ
+  ) {}
+
+  /**
+   * @description Burn fee in mutez
+   */
+  get burnFeeMutez() {
+    return this.roundUp(Number(this.storageLimit) * MINIMAL_FEE_PER_STORAGE_BYTE_MUTEZ);
+  }
+
+  /**
+   * @description Get the estimated storage limit
+   */
+  get storageLimit() {
+    const limit = Math.max(Number(this._storageLimit), 0);
+    return limit > 0 ? limit : 0;
+  }
+
+  /**
+   * @description Suggested gasLimit for operation
+   */
+  get gasLimit() {
+    return Number(this._gasLimit) + GAS_BUFFER;
+  }
+
+  private get operationFeeMutez() {
+    return (
+      this.gasLimit * MINIMAL_FEE_PER_GAS_MUTEZ + Number(this.opSize) * MINIMAL_FEE_PER_BYTE_MUTEZ
+    );
+  }
+
+  private roundUp(nanotez: number) {
+    return Math.ceil(Number(nanotez));
+  }
+
+  /**
+   * @description Minimum fees for operation according to baker defaults
+   */
+  get minimalFeeMutez() {
+    return this.roundUp(MINIMAL_FEE_MUTEZ + this.operationFeeMutez);
+  }
+
+  /**
+   * @description Suggested fee for operation (minimal fees plus a small buffer)
+   */
+  get suggestedFeeMutez() {
+    return this.roundUp(this.operationFeeMutez + MINIMAL_FEE_MUTEZ * 2);
+  }
+
+  /**
+   * @description Fees according to your specified base fee will ensure that at least minimum fees are used
+   */
+  get usingBaseFeeMutez() {
+    return (
+      Math.max(Number(this.baseFeeMutez), MINIMAL_FEE_MUTEZ) + this.roundUp(this.operationFeeMutez)
+    );
+  }
+
+  get totalCost() {
+    return this.minimalFeeMutez + this.burnFeeMutez;
+  }
+}

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -3,8 +3,31 @@ import { Operation } from '../operations/operations';
 import { Contract } from './contract';
 import { DelegateParams, OriginateParams, TransferParams } from '../operations/types';
 import { OriginationOperation } from '../operations/origination-operation';
+import { Estimate } from './estimate';
 
 export type ContractSchema = Schema | unknown;
+
+export interface EstimationProvider {
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an origination operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param OriginationOperation Originate operation parameter
+   */
+  originate(params: OriginateParams): Promise<Estimate>;
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an transfer operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param TransferOperation Originate operation parameter
+   */
+  transfer({ fee, storageLimit, gasLimit, ...rest }: TransferParams): Promise<Estimate>;
+}
 
 export interface ContractProvider {
   /**

--- a/packages/taquito/src/contract/naive-estimate-provider.ts
+++ b/packages/taquito/src/contract/naive-estimate-provider.ts
@@ -1,0 +1,41 @@
+import { DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT, DEFAULT_FEE } from '../constants';
+import { OriginateParams, TransferParams } from '../operations/types';
+import { Estimate } from './estimate';
+import { EstimationProvider } from './interface';
+
+/**
+ * @description Naïve implementation of an estimate provider. Will work for basic transaction but your operation risk to fail if they are more complex (smart contract interaction)
+ */
+export class NaiveEstimateProvider implements EstimationProvider {
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an origination operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param OriginationOperation Originate operation parameter
+   */
+  async originate({
+    fee = DEFAULT_FEE.ORIGINATION,
+    storageLimit = DEFAULT_STORAGE_LIMIT.ORIGINATION,
+    gasLimit = DEFAULT_GAS_LIMIT.ORIGINATION,
+  }: OriginateParams) {
+    return new Estimate(gasLimit, storageLimit, 185, fee);
+  }
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an transfer operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param TransferOperation Originate operation parameter
+   */
+  async transfer({
+    fee = DEFAULT_FEE.TRANSFER,
+    storageLimit = DEFAULT_STORAGE_LIMIT.TRANSFER,
+    gasLimit = DEFAULT_GAS_LIMIT.TRANSFER,
+  }: TransferParams) {
+    return new Estimate(gasLimit, storageLimit, 162, fee);
+  }
+}

--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -1,0 +1,89 @@
+import {
+  OriginateParams,
+  RPCOriginationOperation,
+  TransferParams,
+  RPCTransferOperation,
+} from '../operations/types';
+import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT } from '../constants';
+import { ml2mic, sexp2mic } from '@taquito/utils';
+import { Schema } from '@taquito/michelson-encoder';
+import { format } from '../format';
+
+export const createOriginationOperation = async (
+  {
+    code,
+    init,
+    balance = '0',
+    spendable = false,
+    delegatable = false,
+    delegate,
+    storage,
+    fee = DEFAULT_FEE.ORIGINATION,
+    gasLimit = DEFAULT_GAS_LIMIT.ORIGINATION,
+    storageLimit = DEFAULT_STORAGE_LIMIT.ORIGINATION,
+  }: OriginateParams,
+  publicKeyHash: string
+) => {
+  // tslint:disable-next-line: strict-type-predicates
+  if (storage !== undefined && init !== undefined) {
+    throw new Error(
+      'Storage and Init cannot be set a the same time. Please either use storage or init but not both.'
+    );
+  }
+
+  const contractCode = Array.isArray(code) ? code : ml2mic(code);
+
+  let contractStorage: object;
+  if (storage !== undefined) {
+    const schema = new Schema(contractCode[1].args[0]);
+    contractStorage = schema.Encode(storage);
+  } else {
+    contractStorage = typeof init === 'string' ? sexp2mic(init) : init;
+  }
+
+  const script = {
+    code: Array.isArray(code) ? code : ml2mic(code),
+    storage: contractStorage,
+  };
+
+  const operation: RPCOriginationOperation = {
+    kind: 'origination',
+    fee,
+    gas_limit: gasLimit,
+    storage_limit: storageLimit,
+    balance: format('tz', 'mutez', balance).toString(),
+    manager_pubkey: publicKeyHash,
+    spendable,
+    delegatable,
+    script,
+  };
+
+  if (delegate) {
+    operation.delegate = delegate;
+  }
+  return operation;
+};
+
+export const createTransferOperation = async ({
+  to,
+  amount,
+  parameter,
+  fee = DEFAULT_FEE.TRANSFER,
+  gasLimit = DEFAULT_GAS_LIMIT.TRANSFER,
+  storageLimit = DEFAULT_STORAGE_LIMIT.TRANSFER,
+  mutez = false,
+  rawParam = false,
+}: TransferParams) => {
+  const operation: RPCTransferOperation = {
+    kind: 'transaction',
+    fee,
+    gas_limit: gasLimit,
+    storage_limit: storageLimit,
+    amount: mutez ? amount.toString() : format('tz', 'mutez', amount).toString(),
+    destination: to,
+  };
+  if (parameter) {
+    operation.parameters = rawParam ? parameter : sexp2mic(parameter);
+  }
+  return operation;
+};

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -1,5 +1,6 @@
 import { Schema } from '@taquito/michelson-encoder';
-import { ml2mic, sexp2mic } from '@taquito/utils';
+import { ScriptResponse } from '@taquito/rpc';
+import { sexp2mic } from '@taquito/utils';
 import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT } from '../constants';
 import { Context } from '../context';
 import { format } from '../format';
@@ -7,19 +8,19 @@ import { OperationEmitter } from '../operations/operation-emitter';
 import { Operation } from '../operations/operations';
 import { OriginationOperation } from '../operations/origination-operation';
 import {
-  RPCDelegateOperation,
   DelegateParams,
   OriginateParams,
-  RPCOriginationOperation,
+  RPCDelegateOperation,
   RPCTransferOperation,
   TransferParams,
 } from '../operations/types';
 import { Contract } from './contract';
-import { ContractProvider, ContractSchema } from './interface';
-import { ScriptResponse } from '@taquito/rpc';
+import { ContractProvider, ContractSchema, EstimationProvider } from './interface';
+import { createOriginationOperation, createTransferOperation } from './prepare';
+import { Estimate } from './estimate';
 
 export class RpcContractProvider extends OperationEmitter implements ContractProvider {
-  constructor(context: Context) {
+  constructor(context: Context, private estimator: EstimationProvider) {
     super(context);
   }
 
@@ -78,70 +79,61 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
     return contractSchema.ExecuteOnBigMapValue(val) as T; // Cast into T because only the caller can know the true type of the storage
   }
 
+  private async estimate<T extends { fee?: number; gasLimit?: number; storageLimit?: number }>(
+    { fee, gasLimit, storageLimit, ...rest }: T,
+    estimator: (param: T) => Promise<Estimate>
+  ) {
+    let calculatedFee = fee;
+    let calculatedGas = gasLimit;
+    let calculatedStorage = storageLimit;
+
+    if (fee === undefined || gasLimit === undefined || storageLimit === undefined) {
+      const estimation = await estimator({ fee, gasLimit, storageLimit, ...(rest as any) });
+
+      if (calculatedFee === undefined) {
+        calculatedFee = estimation.suggestedFeeMutez;
+      }
+
+      if (calculatedGas === undefined) {
+        calculatedGas = estimation.gasLimit;
+      }
+
+      if (calculatedStorage === undefined) {
+        calculatedStorage = estimation.storageLimit;
+      }
+    }
+
+    return {
+      fee: calculatedFee!,
+      gasLimit: calculatedGas!,
+      storageLimit: calculatedStorage!,
+    };
+  }
+
   /**
    *
    * @description Originate a new contract according to the script in parameters. Will sign and inject an operation using the current context
    *
    * @returns An operation handle with the result from the rpc node
    *
-   * @warn You cannot specify storage and init at the same time (use init to pass the raw michelson representation of storage)
+   * * @warn You cannot specify storage and init at the same time (use init to pass the raw michelson representation of storage)
    *
    * @param OriginationOperation Originate operation parameter
    */
-  async originate({
-    code,
-    init,
-    balance = '0',
-    spendable = false,
-    delegatable = false,
-    delegate,
-    storage,
-    fee = DEFAULT_FEE.ORIGINATION,
-    gasLimit = DEFAULT_GAS_LIMIT.ORIGINATION,
-    storageLimit = DEFAULT_STORAGE_LIMIT.ORIGINATION,
-  }: OriginateParams) {
-    // tslint:disable-next-line: strict-type-predicates
-    if (storage !== undefined && init !== undefined) {
-      throw new Error(
-        'Storage and Init cannot be set a the same time. Please either use storage or init but not both.'
-      );
-    }
-
-    const contractCode = Array.isArray(code) ? code : ml2mic(code);
-
-    let contractStorage: object;
-    if (storage !== undefined) {
-      const schema = new Schema(contractCode[1].args[0]);
-      contractStorage = schema.Encode(storage);
-    } else {
-      contractStorage = typeof init === 'string' ? sexp2mic(init) : init;
-    }
-
-    const script = {
-      code: Array.isArray(code) ? code : ml2mic(code),
-      storage: contractStorage,
-    };
+  async originate(params: OriginateParams) {
+    const estimate = await this.estimate(params, this.estimator.originate.bind(this.estimator));
 
     const publicKeyHash = await this.signer.publicKeyHash();
-    const operation: RPCOriginationOperation = {
-      kind: 'origination',
-      fee,
-      gas_limit: gasLimit,
-      storage_limit: storageLimit,
-      balance: format('tz', 'mutez', balance).toString(),
-      manager_pubkey: publicKeyHash,
-      spendable,
-      delegatable,
-      script,
-    };
-
-    if (delegate) {
-      operation.delegate = delegate;
-    }
-
-    const opBytes = await this.prepareOperation({ operation, source: publicKeyHash });
-
-    const { hash, context, forgedBytes, opResponse } = await this.signAndInject(opBytes);
+    const operation = await createOriginationOperation(
+      {
+        ...params,
+        ...estimate,
+      },
+      publicKeyHash
+    );
+    const preparedOrigination = await this.prepareOperation({ operation, source: publicKeyHash });
+    const forgedOrigination = await this.forge(preparedOrigination);
+    const { hash, context, forgedBytes, opResponse } = await this.signAndInject(forgedOrigination);
     return new OriginationOperation(hash, forgedBytes, opResponse, context, this);
   }
 
@@ -168,7 +160,7 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
       storage_limit: storageLimit,
       delegate,
     };
-    const opBytes = await this.prepareOperation({
+    const opBytes = await this.prepareAndForge({
       operation,
       source: source || (await this.signer.publicKeyHash()),
     });
@@ -196,7 +188,7 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
       storage_limit: storageLimit,
       delegate: await this.signer.publicKeyHash(),
     };
-    const opBytes = await this.prepareOperation({ operation });
+    const opBytes = await this.prepareAndForge({ operation });
     const { hash, context, forgedBytes, opResponse } = await this.signAndInject(opBytes);
     return new Operation(hash, forgedBytes, opResponse, context);
   }
@@ -209,30 +201,13 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
    *
    * @param Transfer operation parameter
    */
-  async transfer({
-    to,
-    source,
-    amount,
-    parameter,
-    fee = DEFAULT_FEE.TRANSFER,
-    gasLimit = DEFAULT_GAS_LIMIT.TRANSFER,
-    storageLimit = DEFAULT_STORAGE_LIMIT.TRANSFER,
-    mutez = false,
-    rawParam = false,
-  }: TransferParams) {
-    const operation: RPCTransferOperation = {
-      kind: 'transaction',
-      fee,
-      gas_limit: gasLimit,
-      storage_limit: storageLimit,
-      amount: mutez ? amount.toString() : format('tz', 'mutez', amount).toString(),
-      destination: to,
-    };
-    if (parameter) {
-      operation.parameters = rawParam ? parameter : sexp2mic(parameter);
-    }
-
-    const opBytes = await this.prepareOperation({ operation, source });
+  async transfer(params: TransferParams) {
+    const estimate = await this.estimate(params, this.estimator.transfer.bind(this.estimator));
+    const operation = await createTransferOperation({
+      ...params,
+      ...estimate,
+    });
+    const opBytes = await this.prepareAndForge({ operation, source: params.source });
     const { hash, context, forgedBytes, opResponse } = await this.signAndInject(opBytes);
     return new Operation(hash, forgedBytes, opResponse, context);
   }

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -116,7 +116,7 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
    *
    * @returns An operation handle with the result from the rpc node
    *
-   * * @warn You cannot specify storage and init at the same time (use init to pass the raw michelson representation of storage)
+   * @warn You cannot specify storage and init at the same time (use init to pass the raw michelson representation of storage)
    *
    * @param OriginationOperation Originate operation parameter
    */

--- a/packages/taquito/src/contract/rpc-estimate-provider.ts
+++ b/packages/taquito/src/contract/rpc-estimate-provider.ts
@@ -1,0 +1,88 @@
+import { OperationEmitter } from '../operations/operation-emitter';
+import { OriginateParams, TransferParams } from '../operations/types';
+import { createOriginationOperation, createTransferOperation } from './prepare';
+import { Estimate } from './estimate';
+import { DEFAULT_STORAGE_LIMIT } from '../constants';
+import { EstimationProvider } from './interface';
+
+// RPC require a signature but do not verify it
+const SIGNATURE_STUB =
+  'edsigtkpiSSschcaCt9pUVrpNPf7TTcgvgDEDD6NCEHMy8NNQJCGnMfLZzYoQj74yLjo9wx6MPVV29CvVzgi7qEcEUok3k7AuMg';
+
+export class RPCEstimateProvider extends OperationEmitter implements EstimationProvider {
+  // Maximum values defined by the protocol
+  private readonly DEFAULT_PARAMS = {
+    fee: 30000,
+    storageLimit: 60000,
+    gasLimit: 800000,
+  };
+
+  private getOperationResult(opResponse: any, kind: 'origination' | 'transaction') {
+    const results = opResponse.contents;
+    const originationOp = Array.isArray(results) && results.find(op => op.kind === kind);
+    return originationOp && originationOp.metadata && originationOp.metadata.operation_result;
+  }
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an origination operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param OriginationOperation Originate operation parameter
+   */
+  async originate({ fee, storageLimit, gasLimit, ...rest }: OriginateParams) {
+    const pkh = await this.signer.publicKeyHash();
+    const op = await createOriginationOperation(
+      {
+        ...rest,
+        ...this.DEFAULT_PARAMS,
+      },
+      pkh
+    );
+    const {
+      opbytes,
+      opOb: { branch, contents },
+    } = await this.prepareAndForge({ operation: op, source: pkh });
+    const { opResponse } = await this.simulate({ branch, contents, signature: SIGNATURE_STUB });
+    const operationResults = this.getOperationResult(opResponse, 'origination');
+    const consumedGas = operationResults && operationResults.consumed_gas;
+    const storageDiff = operationResults && operationResults.paid_storage_size_diff;
+
+    return new Estimate(
+      consumedGas,
+      Number(storageDiff) + DEFAULT_STORAGE_LIMIT.ORIGINATION,
+      opbytes.length / 2
+    );
+  }
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an transfer operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param TransferOperation Originate operation parameter
+   */
+  async transfer({ fee, storageLimit, gasLimit, ...rest }: TransferParams) {
+    const pkh = await this.signer.publicKeyHash();
+    const op = await createTransferOperation({
+      ...rest,
+      ...this.DEFAULT_PARAMS,
+    });
+    const {
+      opbytes,
+      opOb: { branch, contents },
+    } = await this.prepareAndForge({ operation: op, source: pkh });
+    const { opResponse } = await this.simulate({ branch, contents, signature: SIGNATURE_STUB });
+    const operationResults = this.getOperationResult(opResponse, 'transaction');
+
+    const consumedGas = operationResults && operationResults.consumed_gas;
+    const storageDiff = operationResults && operationResults.paid_storage_size_diff;
+
+    return new Estimate(
+      consumedGas,
+      Number(storageDiff) + DEFAULT_STORAGE_LIMIT.TRANSFER,
+      opbytes.length / 2
+    );
+  }
+}

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -2,6 +2,8 @@ import { Context } from '../context';
 import { RpcContractProvider } from '../contract/rpc-contract-provider';
 import { Operation } from './operations';
 
+type Results = any[];
+
 /**
  * @description Origination operation provide utility function to fetch newly originated contract
  *
@@ -16,22 +18,38 @@ export class OriginationOperation extends Operation {
   constructor(
     hash: string,
     raw: {},
-    results: any,
+    results: Results,
     context: Context,
     private contractProvider: RpcContractProvider
   ) {
     super(hash, raw, results, context);
 
-    const originationOp = Array.isArray(results) && results.find(op => op.kind === 'origination');
-
-    const originatedContracts =
-      originationOp &&
-      originationOp.metadata &&
-      originationOp.metadata.operation_result &&
-      originationOp.metadata.operation_result.originated_contracts;
+    const originatedContracts = this.operationResults && this.operationResults.originated_contracts;
     if (Array.isArray(originatedContracts)) {
       this.contractAddress = originatedContracts[0];
     }
+  }
+
+  private get operationResults() {
+    const originationOp =
+      Array.isArray(this.results) && this.results.find(op => op.kind === 'origination');
+    return originationOp && originationOp.metadata && originationOp.metadata.operation_result;
+  }
+
+  get consumedGas() {
+    return this.operationResults && this.operationResults.consumed_gas;
+  }
+
+  get storageDiff() {
+    return this.operationResults && this.operationResults.paid_storage_size_diff;
+  }
+
+  get storageSize() {
+    return this.operationResults && this.operationResults.storage_size;
+  }
+
+  get errors() {
+    return this.operationResults && this.operationResults.errors;
   }
 
   /**

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -2,7 +2,7 @@ import { IndexerClient } from '@taquito/indexer';
 import { RpcClient } from '@taquito/rpc';
 import { InMemorySigner } from '@taquito/signer';
 
-import { ContractProvider } from './contract/interface';
+import { ContractProvider, EstimationProvider } from './contract/interface';
 import { RpcContractProvider } from './contract/rpc-contract-provider';
 import { IndexerProvider } from './query/indexer-provider';
 import { QueryProvider } from './query/interface';
@@ -14,6 +14,7 @@ import { format } from './format';
 import { Signer } from './signer/interface';
 import { Context } from './context';
 import { NoopSigner } from './signer/noop';
+import { RPCEstimateProvider } from './contract/rpc-estimate-provider';
 export { SubscribeProvider } from './subscribe/interface';
 export interface SetProviderOptions {
   rpc?: string | RpcClient;
@@ -35,7 +36,8 @@ export class TezosToolkit {
   private _context: Context = new Context();
 
   private _tz = new RpcTzProvider(this._context);
-  private _contract = new RpcContractProvider(this._context);
+  private _estimate = new RPCEstimateProvider(this._context);
+  private _contract = new RpcContractProvider(this._context, this._estimate);
 
   public readonly format = format;
 
@@ -112,6 +114,13 @@ export class TezosToolkit {
    */
   get contract(): ContractProvider {
     return this._contract;
+  }
+
+  /**
+   * @description Provide access to operation estimation utilities
+   */
+  get estimate(): EstimationProvider {
+    return this._estimate;
   }
 
   /**

--- a/packages/taquito/src/tz/rpc-tz-provider.ts
+++ b/packages/taquito/src/tz/rpc-tz-provider.ts
@@ -25,7 +25,7 @@ export class RpcTzProvider extends OperationEmitter implements TzProvider {
       secret,
     };
 
-    const forgedBytes = await this.prepareOperation({ operation: [operation], source: pkh });
+    const forgedBytes = await this.prepareAndForge({ operation: [operation], source: pkh });
     const bytes = `${forgedBytes.opbytes}00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000`;
     return new Operation(
       await this.rpc.injectOperation(bytes),

--- a/packages/taquito/test/contract/estimate.spec.ts
+++ b/packages/taquito/test/contract/estimate.spec.ts
@@ -1,0 +1,20 @@
+import { Estimate } from '../../src/contract/estimate';
+
+describe('Estimate', () => {
+  it('Calculate fees in mutez properly', () => {
+    const estimate = new Estimate(27147, 960, 861);
+    expect(estimate.minimalFeeMutez).toStrictEqual(3686);
+    expect(estimate.suggestedFeeMutez).toStrictEqual(3786);
+    expect(estimate.totalCost).toStrictEqual(963686);
+    expect(estimate.burnFeeMutez).toStrictEqual(960000);
+  });
+
+  it('Calculate fees in mutez properly with string', () => {
+    const estimate = new Estimate('17311', '300', '180', '10000');
+    expect(estimate.minimalFeeMutez).toStrictEqual(2022);
+    expect(estimate.suggestedFeeMutez).toStrictEqual(2122);
+    expect(estimate.usingBaseFeeMutez).toStrictEqual(11922);
+    expect(estimate.burnFeeMutez).toStrictEqual(300000);
+    expect(estimate.totalCost).toEqual(302022);
+  });
+});

--- a/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
@@ -1,0 +1,129 @@
+import { Context } from '../../src/context';
+import { RPCEstimateProvider } from '../../src/contract/rpc-estimate-provider';
+import { miStr } from './data';
+
+/**
+ * RPCEstimateProvider test
+ */
+describe('RPCEstimateProvider test', () => {
+  let estimateProvider: RPCEstimateProvider;
+  let mockRpcClient: {
+    getScript: jest.Mock<any, any>;
+    getStorage: jest.Mock<any, any>;
+    getBigMapKey: jest.Mock<any, any>;
+    getBlockHeader: jest.Mock<any, any>;
+    getManagerKey: jest.Mock<any, any>;
+    getBlock: jest.Mock<any, any>;
+    getContract: jest.Mock<any, any>;
+    getBlockMetadata: jest.Mock<any, any>;
+    forgeOperations: jest.Mock<any, any>;
+    runOperation: jest.Mock<any, any>;
+    injectOperation: jest.Mock<any, any>;
+    preapplyOperations: jest.Mock<any, any>;
+  };
+
+  let mockSigner: {
+    publicKeyHash: jest.Mock<any, any>;
+    publicKey: jest.Mock<any, any>;
+    sign: jest.Mock<any, any>;
+  };
+
+  beforeEach(() => {
+    mockRpcClient = {
+      runOperation: jest.fn(),
+      getBlock: jest.fn(),
+      getScript: jest.fn(),
+      getManagerKey: jest.fn(),
+      getStorage: jest.fn(),
+      getBigMapKey: jest.fn(),
+      getBlockHeader: jest.fn(),
+      getBlockMetadata: jest.fn(),
+      getContract: jest.fn(),
+      forgeOperations: jest.fn(),
+      injectOperation: jest.fn(),
+      preapplyOperations: jest.fn(),
+    };
+
+    mockSigner = {
+      publicKeyHash: jest.fn(),
+      publicKey: jest.fn(),
+      sign: jest.fn(),
+    };
+
+    // Required for operations confirmation polling
+    mockRpcClient.getBlock.mockResolvedValue({
+      operations: [[], [], [], []],
+      header: {
+        level: 0,
+      },
+    });
+
+    mockRpcClient.getManagerKey.mockResolvedValue('test');
+    mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+    mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+    mockRpcClient.getBlockMetadata.mockResolvedValue({ nextProtocol: 'test_proto' });
+    mockRpcClient.forgeOperations.mockResolvedValue('1234');
+    mockRpcClient.preapplyOperations.mockResolvedValue([]);
+
+    mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
+    mockSigner.publicKey.mockResolvedValue('test_pub_key');
+    mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
+    estimateProvider = new RPCEstimateProvider(
+      new Context(mockRpcClient as any, mockSigner as any)
+    );
+  });
+
+  describe('originate', () => {
+    it('should produce a reveal and origination operation', async done => {
+      mockRpcClient.runOperation.mockResolvedValue({
+        contents: [
+          {
+            kind: 'origination',
+            metadata: {
+              operation_result: {
+                consumed_gas: 1000,
+              },
+            },
+          },
+        ],
+      });
+      const estimate = await estimateProvider.originate({
+        delegate: 'test_delegate',
+        balance: '200',
+        code: miStr,
+        init: '{}',
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 257,
+      });
+      expect(estimate.gasLimit).toEqual(1100);
+      done();
+    });
+  });
+
+  describe('transfer', () => {
+    it('should produce a reveal and transaction operation', async done => {
+      mockRpcClient.runOperation.mockResolvedValue({
+        contents: [
+          {
+            kind: 'transaction',
+            metadata: {
+              operation_result: {
+                consumed_gas: 1000,
+              },
+            },
+          },
+        ],
+      });
+      const estimate = await estimateProvider.transfer({
+        to: 'test_to',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      });
+      expect(estimate.gasLimit).toEqual(1100);
+      done();
+    });
+  });
+});

--- a/packages/taquito/test/operations/origination-operation.spec.ts
+++ b/packages/taquito/test/operations/origination-operation.spec.ts
@@ -142,7 +142,7 @@ describe('Origination operation', () => {
       const op = new OriginationOperation(
         'test_hash',
         {},
-        'wrong_result',
+        'wrong_result' as any,
         fakeContext,
         fakeContractProvider
       );


### PR DESCRIPTION
Now expose an estimation api to estimate origination and transfer. 

The same api is used internally
to infer default gas, storage and fee parameter when sending transaction or originating contract

re #88, #121 