### PR TITLE
Extract forger provider into it's own provider

### DIFF
--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -2,6 +2,8 @@ import { RpcClient } from '@taquito/rpc';
 import { Signer } from './signer/interface';
 import { NoopSigner } from './signer/noop';
 import { Protocols } from './constants';
+import { Forger } from './forger/interface';
+import { RpcForger } from './forger/rpc-forger';
 
 export interface Config {
   confirmationPollingIntervalSecond?: number;
@@ -19,13 +21,17 @@ export const defaultConfig: Required<Config> = {
  * @description Encapsulate common service used throughout different part of the library
  */
 export class Context {
+  private _forger: Forger;
+
   constructor(
     private _rpcClient: RpcClient = new RpcClient(),
     private _signer: Signer = new NoopSigner(),
     private _proto?: Protocols,
-    private _config?: Partial<Config>
+    private _config?: Partial<Config>,
+    forger?: Forger
   ) {
     this.config = _config as any;
+    this._forger = forger ? forger : new RpcForger(this);
   }
 
   get config(): Required<Config> {
@@ -45,6 +51,14 @@ export class Context {
 
   set rpc(value: RpcClient) {
     this._rpcClient = value;
+  }
+
+  get forger() {
+    return this._forger;
+  }
+
+  set forger(value: Forger) {
+    this._forger = value;
   }
 
   get signer() {
@@ -76,6 +90,6 @@ export class Context {
    * @description Create a copy of the current context. Useful when you have long running operation and you do not want a context change to affect the operation
    */
   clone(): Context {
-    return new Context(this.rpc, this.signer);
+    return new Context(this.rpc, this.signer, this.proto, this.config, this.forger);
   }
 }

--- a/packages/taquito/src/forger/interface.ts
+++ b/packages/taquito/src/forger/interface.ts
@@ -1,0 +1,12 @@
+import { ConstructedOperation } from '@taquito/rpc';
+
+export interface ForgeParams {
+  branch: string;
+  contents: ConstructedOperation[];
+}
+
+export type ForgeResponse = string; // hex string
+
+export interface Forger {
+  forge(params: ForgeParams): Promise<ForgeResponse>;
+}

--- a/packages/taquito/src/forger/rpc-forger.ts
+++ b/packages/taquito/src/forger/rpc-forger.ts
@@ -2,9 +2,9 @@ import { Forger, ForgeParams, ForgeResponse } from './interface';
 import { Context } from '../context';
 
 export class RpcForger implements Forger {
-  constructor(private context: Context) {}
+  constructor(private context: Context) { }
 
-  forge(params: ForgeParams): Promise<ForgeResponse> {
-    return this.context.rpc.forgeOperations(params);
+  forge({ branch, contents }: ForgeParams): Promise<ForgeResponse> {
+    return this.context.rpc.forgeOperations({ branch, contents });
   }
 }

--- a/packages/taquito/src/forger/rpc-forger.ts
+++ b/packages/taquito/src/forger/rpc-forger.ts
@@ -1,0 +1,10 @@
+import { Forger, ForgeParams, ForgeResponse } from './interface';
+import { Context } from '../context';
+
+export class RpcForger implements Forger {
+  constructor(private context: Context) {}
+
+  forge(params: ForgeParams): Promise<ForgeResponse> {
+    return this.context.rpc.forgeOperations(params);
+  }
+}

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -69,18 +69,12 @@ export abstract class OperationEmitter {
   }: PrepareOperationParams): Promise<PreparedOperation> {
     let counter;
     const counters: { [key: string]: number } = {};
-    const promises: [
-      Promise<BlockHeaderResponse>,
-      Promise<BlockMetadata>,
-      Promise<string | undefined>,
-      Promise<ManagerKeyResponse | undefined>
-    ] = [] as any;
     let requiresReveal = false;
     let ops: RPCOperation[] = [];
     let head: BlockHeaderResponse;
 
-    promises.push(this.rpc.getBlockHeader());
-    promises.push(this.rpc.getBlockMetadata());
+    const blockHeaderPromise = this.rpc.getBlockHeader();
+    const blockMetaPromise = this.rpc.getBlockMetadata();
 
     if (Array.isArray(operation)) {
       ops = [...operation];
@@ -90,17 +84,19 @@ export abstract class OperationEmitter {
 
     const publicKeyHash = source || (await this.signer.publicKeyHash());
 
+    let counterPromise: Promise<string | undefined> = Promise.resolve(undefined);
+    let managerPromise: Promise<ManagerKeyResponse | undefined> = Promise.resolve(undefined);
     for (let i = 0; i < ops.length; i++) {
       if (['transaction', 'origination', 'delegation'].includes(ops[i].kind)) {
         requiresReveal = true;
         const { counter } = await this.rpc.getContract(publicKeyHash);
-        promises.push(Promise.resolve(counter));
-        promises.push(this.rpc.getManagerKey(publicKeyHash));
+        counterPromise = Promise.resolve(counter);
+        managerPromise = this.rpc.getManagerKey(publicKeyHash);
         break;
       }
     }
 
-    const [header, metadata, headCounter, manager] = await Promise.all(promises);
+    const [header, metadata, headCounter, manager] = await Promise.all([blockHeaderPromise, blockMetaPromise, counterPromise, managerPromise]);
 
     if (!header) {
       throw new Error('Unable to latest block header');

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -43,7 +43,7 @@ export abstract class OperationEmitter {
     return this.context.signer;
   }
 
-  constructor(protected context: Context) { }
+  constructor(protected context: Context) {}
 
   private isSourceOp(
     op: RPCOperation
@@ -59,7 +59,8 @@ export abstract class OperationEmitter {
     | RPCTransferOperation
     | RPCOriginationOperation
     | RPCDelegateOperation
-    | RPCRevealOperation) & { source?: string } {
+    | RPCRevealOperation
+  ) & { source?: string } {
     return ['reveal', 'transaction', 'origination', 'delegation'].includes(op.kind);
   }
 
@@ -96,7 +97,12 @@ export abstract class OperationEmitter {
       }
     }
 
-    const [header, metadata, headCounter, manager] = await Promise.all([blockHeaderPromise, blockMetaPromise, counterPromise, managerPromise]);
+    const [header, metadata, headCounter, manager] = await Promise.all([
+      blockHeaderPromise,
+      blockMetaPromise,
+      counterPromise,
+      managerPromise,
+    ]);
 
     if (!header) {
       throw new Error('Unable to latest block header');
@@ -202,10 +208,10 @@ export abstract class OperationEmitter {
   }
 
   protected async forge({ opOb: { branch, contents, protocol }, counter }: PreparedOperation) {
-    let remoteForgedBytes = await this.rpc.forgeOperations({ branch, contents });
+    let forgedBytes = await this.context.forger.forge({ branch, contents });
 
     return {
-      opbytes: remoteForgedBytes,
+      opbytes: forgedBytes,
       opOb: {
         branch,
         contents,

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -18,6 +18,7 @@ import { RpcTzProvider } from './tz/rpc-tz-provider';
 
 export * from './query/interface';
 export * from './signer/interface';
+export * from './forger/interface';
 export * from './tz/interface';
 export * from './contract';
 export * from './contract/big-map';


### PR DESCRIPTION
Abstract operation forging with a forger interface and move the actual implementation to an RPC provider as the default

This change will be useful to allow swapping operation forging implementation when we implement #108 