### PR TITLE
fix(taquito): Fix wrong confirmation count for operation.confirmation

### DIFF
--- a/integration-tests/contract-api-scenario.spec.ts
+++ b/integration-tests/contract-api-scenario.spec.ts
@@ -136,13 +136,13 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
 
     it('Transfer and wait 2 confirmations', async (done) => {
       const op = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
-      const conf = await op.confirmation()
+      await op.confirmation()
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
       const [first, second] = await Promise.all([op.confirmation(), op.confirmation(2)])
-      expect(second - first).toEqual(2)
+      expect(second - first).toEqual(1)
       // Retrying another time should be instant
       const [first2, second2] = await Promise.all([op.confirmation(), op.confirmation(2)])
-      expect(second2 - first2).toEqual(2)
+      expect(second2 - first2).toEqual(1)
       done();
     })
 

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -15,7 +15,7 @@ export interface Config {
 
 export const defaultConfig: Required<Config> = {
   confirmationPollingIntervalSecond: 10,
-  defaultConfirmationCount: 0,
+  defaultConfirmationCount: 1,
   confirmationPollingTimeoutSecond: 180,
 };
 

--- a/packages/taquito/test/operations/origination-operation.spec.ts
+++ b/packages/taquito/test/operations/origination-operation.spec.ts
@@ -79,7 +79,7 @@ describe('Origination operation', () => {
     fakeContext.rpc.getBlock.mockResolvedValue({
       operations: [[{ hash: 'test_hash' }], [], [], []],
       header: {
-        level: 0,
+        level: 200,
       },
     });
   });
@@ -136,7 +136,7 @@ describe('Origination operation', () => {
         fakeContractProvider
       );
       const confirmation = await op.confirmation();
-      expect(confirmation).toEqual(0);
+      expect(confirmation).toEqual(200);
       done();
     });
 


### PR DESCRIPTION
BREAKING CHANGE: Default confirmation counter is now 1 and it must be greater than 1 if specified

fix #202