### PR TITLE
Sensible error for failed operation

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -1,17 +1,35 @@
 import { TezosToolkit } from '@taquito/taquito'
 import fs from 'fs'
 
-const providers = (process.env['TEZOS_RPC_NODE'] && process.env['TEZOS_RPC_NODE'].split(',')) || ['https://api.tez.ie/rpc/babylonnet', 'https://api.tez.ie/rpc/carthagenet'];
+const envConfig = process.env['TEZOS_RPC_NODE'];
+
+interface Config {
+  rpc: string,
+  knownBaker: string,
+  knownContract: string,
+}
+
+const providers: Config[] = envConfig ? JSON.parse(envConfig) : [{
+  rpc: 'https://api.tez.ie/rpc/carthagenet',
+  knownBaker: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+  knownContract: 'KT1XYa1JPKYVJYVJge89r4w2tShS8JYb1NQh'
+},
+{
+  rpc: 'https://api.tez.ie/rpc/babylonnet',
+  knownBaker: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh',
+  knownContract: 'KT1EM2LvxxFGB3Svh9p9HCP2jEEYyHjABMbK'
+}
+];
 
 const faucetKeyFile = process.env['TEZOS_FAUCET_KEY_FILE']
 
 jest.setTimeout(60000 * 10);
 
-export const CONFIGS = providers.map((provider) => {
+export const CONFIGS = providers.map(({ rpc, knownBaker, knownContract }) => {
   const Tezos = new TezosToolkit();
-  Tezos.setProvider({ rpc: provider })
+  Tezos.setProvider({ rpc })
   return {
-    rpc: provider, lib: Tezos, setup: async () => {
+    rpc, knownBaker, knownContract, lib: Tezos, setup: async () => {
       let faucetKey = {
         email: "peqjckge.qkrrajzs@tezos.example.org",
         password: "y4BX7qS1UE", mnemonic: [
@@ -41,3 +59,4 @@ export const CONFIGS = providers.map((provider) => {
     }
   };
 });
+

--- a/integration-tests/contract-api-scenario.spec.ts
+++ b/integration-tests/contract-api-scenario.spec.ts
@@ -13,7 +13,7 @@ import { booleanCode } from "./data/boolean_parameter";
 import { failwithContractCode } from "./data/failwith"
 import { badCode } from "./data/badCode";
 
-CONFIGS.forEach(({ lib, rpc, setup }) => {
+CONFIGS.forEach(({ lib, rpc, setup, knownBaker }) => {
   const Tezos = lib;
   describe(`Test contract api using: ${rpc}`, () => {
 
@@ -76,7 +76,7 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
     });
 
     it('Simple set delegate', async (done) => {
-      const delegate = 'tz1PirboZKFVqkfE45hVLpkpXaZtLk3mqC17'
+      const delegate = knownBaker
       const op = await Tezos.contract.setDelegate({
         delegate,
         source: await Tezos.signer.publicKeyHash(),
@@ -93,7 +93,7 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
     });
 
     it('Set delegate with automatic estimate', async (done) => {
-      const delegate = 'tz1PirboZKFVqkfE45hVLpkpXaZtLk3mqC17'
+      const delegate = knownBaker
       const op = await Tezos.contract.setDelegate({
         delegate,
         source: await Tezos.signer.publicKeyHash(),

--- a/integration-tests/contract-api-scenario.spec.ts
+++ b/integration-tests/contract-api-scenario.spec.ts
@@ -53,8 +53,10 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
         await contract.methods.main(null).send({ fee: 20000, gasLimit: 20000, storageLimit: 0 })
       } catch ({ message }) {
         const ex = JSON.parse(message);
+
         expect(ex.error).toEqual('Operation Failed')
         expect(ex.errors[1].id).toMatch('michelson_v1.script_rejected')
+        expect(ex.errors[1].with).toEqual({ string: 'test' })
       }
       done();
     });

--- a/integration-tests/data/badCode.ts
+++ b/integration-tests/data/badCode.ts
@@ -1,0 +1,13 @@
+export const badCode = [{ "prim": "parameter", "args": [{ "prim": "unit" }] },
+{ "prim": "storage", "args": [{ "prim": "unit" }] },
+{
+  "prim": "code",
+  "args":
+    [[{
+      "prim": "PUSH",
+      "args":
+        [{ "prim": "string" },
+        { "string": "test" }]
+    },
+    { "prim": "FAILWITH_TYPO" }]]
+}]

--- a/integration-tests/data/failwith.ts
+++ b/integration-tests/data/failwith.ts
@@ -1,0 +1,13 @@
+export const failwithContractCode = [{ "prim": "parameter", "args": [{ "prim": "unit" }] },
+{ "prim": "storage", "args": [{ "prim": "unit" }] },
+{
+  "prim": "code",
+  "args":
+    [[{
+      "prim": "PUSH",
+      "args":
+        [{ "prim": "string" },
+        { "string": "test" }]
+    },
+    { "prim": "FAILWITH" }]]
+}]

--- a/integration-tests/manager-contract-scenario.spec.ts
+++ b/integration-tests/manager-contract-scenario.spec.ts
@@ -2,7 +2,7 @@ import { CONFIGS } from "./config";
 import { managerCode } from "./data/manager_code";
 import { MANAGER_LAMBDA } from "@taquito/taquito";
 
-CONFIGS.forEach(({ lib, rpc, setup }) => {
+CONFIGS.forEach(({ lib, rpc, setup, knownBaker, knownContract }) => {
   const Tezos = lib;
 
   describe(`Manager TZ: ${rpc}`, () => {
@@ -30,7 +30,7 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
       await opTransfer.confirmation();
       expect(opTransfer.status).toEqual('applied')
       // Set delegate on contract kt1_alice by passing a lambda function to kt1_alice's `do` entrypoint
-      const opSetDelegate = await contract.methods.do(MANAGER_LAMBDA.setDelegate("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh")).send({ amount: 0 })
+      const opSetDelegate = await contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)).send({ amount: 0 })
       await opSetDelegate.confirmation();
       expect(opSetDelegate.status).toEqual('applied')
       // Remove delegate on contract kt1_alice by passing a lambda function to kt1_alice's `do` entrypoint
@@ -42,7 +42,7 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
       // lambda helper function. The transfer amount in the actual transfer operation is 0. We are not transferring the token
       // in the transfer operation, we are instructing the contract to transfer the token using the `do` entrypoint of the kt1_alice
       // contract.
-      const transferToContractOp = await contract.methods.do(MANAGER_LAMBDA.transferToContract("KT1EM2LvxxFGB3Svh9p9HCP2jEEYyHjABMbK", 1)).send({ amount: 0 })
+      const transferToContractOp = await contract.methods.do(MANAGER_LAMBDA.transferToContract(knownContract, 1)).send({ amount: 0 })
       await transferToContractOp.confirmation();
       expect(transferToContractOp.status).toEqual('applied')
 

--- a/integration-tests/manager-contract-scenario.spec.ts
+++ b/integration-tests/manager-contract-scenario.spec.ts
@@ -45,6 +45,13 @@ CONFIGS.forEach(({ lib, rpc, setup }) => {
       const transferToContractOp = await contract.methods.do(MANAGER_LAMBDA.transferToContract("KT1EM2LvxxFGB3Svh9p9HCP2jEEYyHjABMbK", 1)).send({ amount: 0 })
       await transferToContractOp.confirmation();
       expect(transferToContractOp.status).toEqual('applied')
+
+      try {
+        await contract.methods.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 50 * 1000000)).send({ amount: 0 })
+        fail('Should throw during transfer with amount higher than balance')
+      } catch (ex) {
+        expect(ex.message).toMatch('balance_too_low')
+      }
       done();
     })
   })

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -523,7 +523,7 @@ export type InternalOperationResultEnum =
 export interface OperationResultDelegation {
   status: OperationResultStatusEnum;
   consumed_gas?: string;
-  errors?: any;
+  errors?: TezosGenericOperationError[];
 }
 
 export interface ContractBigMapDiffItem {
@@ -533,6 +533,11 @@ export interface ContractBigMapDiffItem {
 }
 
 export type ContractBigMapDiff = ContractBigMapDiffItem[];
+
+export interface TezosGenericOperationError {
+  kind: string;
+  id: string;
+}
 
 export interface OperationResultTransaction {
   status: OperationResultStatusEnum;
@@ -544,13 +549,13 @@ export interface OperationResultTransaction {
   storage_size?: string;
   paid_storage_size_diff?: string;
   allocated_destination_contract?: boolean;
-  errors?: any;
+  errors?: TezosGenericOperationError[];
 }
 
 export interface OperationResultReveal {
   status: OperationResultStatusEnum;
   consumed_gas?: string;
-  errors?: any;
+  errors?: TezosGenericOperationError[];
 }
 
 export interface InternalOperationResult {
@@ -588,7 +593,7 @@ export interface OperationResultOrigination {
   consumed_gas?: string;
   storage_size?: string;
   paid_storage_size_diff?: string;
-  errors?: any;
+  errors?: TezosGenericOperationError[];
 }
 
 export interface OperationContentsAndResultMetadataOrigination {

--- a/packages/taquito/src/contract/rpc-estimate-provider.ts
+++ b/packages/taquito/src/contract/rpc-estimate-provider.ts
@@ -22,6 +22,7 @@ import {
   createSetDelegateOperation,
   createTransferOperation,
 } from './prepare';
+import { flattenErrors, TezosOperationError } from '../operations/operation-errors';
 
 // RPC require a signature but do not verify it
 const SIGNATURE_STUB =
@@ -73,6 +74,14 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     };
 
     const { opResponse } = await this.simulate(operation);
+
+    const errors = flattenErrors(opResponse);
+
+    // Fail early in case of errors
+    if (errors.length) {
+      throw new TezosOperationError(errors);
+    }
+
     const operationResults = this.getOperationResult(opResponse, kind);
 
     let totalGas = 0;

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -8,7 +8,7 @@ import {
 } from '@taquito/rpc';
 import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT, Protocols } from '../constants';
 import { Context } from '../context';
-import { flattenErrors, TezosOperationError } from './operation-errors';
+import { flattenErrors, TezosOperationError, TezosPreapplyFailureError } from './operation-errors';
 import {
   ForgedBytes,
   PrepareOperationParams,
@@ -37,7 +37,7 @@ export abstract class OperationEmitter {
     return this.context.signer;
   }
 
-  constructor(protected context: Context) {}
+  constructor(protected context: Context) { }
 
   private isSourceOp(
     op: RPCOperation
@@ -249,11 +249,4 @@ export abstract class OperationEmitter {
       context: this.context.clone(),
     };
   }
-}
-
-export class TezosPreapplyFailureError implements Error {
-  name: string = 'TezosPreapplyFailureError';
-  message: string = 'Preapply returned an unexpected result';
-
-  constructor(public result: any) {}
 }

--- a/packages/taquito/src/operations/operation-errors.ts
+++ b/packages/taquito/src/operations/operation-errors.ts
@@ -1,0 +1,66 @@
+import {
+  PreapplyResponse,
+  MichelsonV1ExpressionBase,
+  TezosGenericOperationError,
+} from '@taquito/rpc';
+
+export interface TezosOperationErrorWithMessage extends TezosGenericOperationError {
+  with: MichelsonV1ExpressionBase;
+}
+
+const isErrorWithMessage = (error: any): error is TezosOperationErrorWithMessage => {
+  return 'with' in error;
+};
+
+export class TezosOperationError implements Error {
+  name: string = 'TezosOperationError';
+  id: string;
+  kind: string;
+  message: string;
+
+  constructor(public errors: TezosGenericOperationError[]) {
+    // Last error is 'often' the one with more detail
+    const lastError = errors[errors.length - 1];
+
+    this.id = lastError.id;
+    this.kind = lastError.kind;
+
+    this.message = `(${this.kind}) ${this.id}`;
+
+    if (isErrorWithMessage(lastError) && lastError.with.string) {
+      this.message = lastError.with.string;
+    }
+  }
+}
+
+/***
+ * @description Flatten all error from preapply response (including internal error)
+ */
+export const flattenErrors = (response: PreapplyResponse | PreapplyResponse[]) => {
+  let results = Array.isArray(response) ? response : [response];
+
+  let errors: TezosGenericOperationError[] = [];
+  // Transaction that do not fail will be backtracked in case one failure occur
+  for (let i = 0; i < results.length; i++) {
+    for (let j = 0; j < results[i].contents.length; j++) {
+      const content = results[i].contents[j];
+      if ('metadata' in content) {
+        if (
+          typeof content.metadata.operation_result !== 'undefined' &&
+          content.metadata.operation_result.status === 'failed'
+        ) {
+          errors = errors.concat(content.metadata.operation_result.errors);
+        }
+        if (Array.isArray(content.metadata.internal_operation_results)) {
+          for (const internalResult of content.metadata.internal_operation_results) {
+            if ('result' in internalResult && internalResult.result.status === 'failed') {
+              errors = errors.concat(internalResult.result.errors);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+};

--- a/packages/taquito/src/operations/operation-errors.ts
+++ b/packages/taquito/src/operations/operation-errors.ts
@@ -33,6 +33,13 @@ export class TezosOperationError implements Error {
   }
 }
 
+export class TezosPreapplyFailureError implements Error {
+  name: string = 'TezosPreapplyFailureError';
+  message: string = 'Preapply returned an unexpected result';
+
+  constructor(public result: any) { }
+}
+
 /***
  * @description Flatten all error from preapply response (including internal error)
  */

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -24,6 +24,7 @@ export * from './tz/interface';
 export * from './contract';
 export * from './contract/big-map';
 export * from './constants';
+export { TezosOperationError, TezosOperationErrorWithMessage, TezosPreapplyFailureError } from './operations/operation-errors'
 
 export { SubscribeProvider } from './subscribe/interface';
 export interface SetProviderOptions {

--- a/packages/taquito/test/contract/helper.ts
+++ b/packages/taquito/test/contract/helper.ts
@@ -1,0 +1,115 @@
+import { TransferParams } from '../../src/operations/types';
+
+export const preapplyResultFrom = (_params: TransferParams) => {
+  const result = [
+    {
+      contents: [
+        {
+          kind: 'transaction',
+          source: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+          fee: '20000',
+          counter: '121528',
+          gas_limit: '20000',
+          storage_limit: '0',
+          amount: '0',
+          destination: 'KT1BjNCteztvGsjvbHTtQ5ynWqhjSVdR285M',
+          metadata: {
+            balance_updates: [
+              {
+                kind: 'contract',
+                contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+                change: '-20000',
+              },
+              {
+                kind: 'freezer',
+                category: 'fees',
+                delegate: 'tz1Ke2h7sDdakHJQh8WX4Z372du1KChsksyU',
+                cycle: 48,
+                change: '20000',
+              },
+            ],
+            operation_result: {},
+          },
+        },
+      ],
+      signature:
+        'edsigtood4PgwEsysYdC2UTUCftkov56JYmLBU6eAYP7Knsf2HMJYcs9JjC4ufKGz115EE5Pa6A223ysscdwksEW6scK2b6aNEc',
+    },
+  ];
+  return {
+    withError: () => {
+      result[0].contents[0].metadata.operation_result = {
+        status: 'failed',
+        errors: [
+          {
+            kind: 'temporary',
+            id: 'proto.006-PsCARTHA.michelson_v1.runtime_error',
+            contract_handle: 'KT1BjNCteztvGsjvbHTtQ5ynWqhjSVdR285M',
+            contract_code: [
+              { prim: 'parameter', args: [{ prim: 'unit' }] },
+              { prim: 'storage', args: [{ prim: 'unit' }] },
+              {
+                prim: 'code',
+                args: [
+                  [
+                    { prim: 'PUSH', args: [{ prim: 'string' }, { string: 'test' }] },
+                    { prim: 'FAILWITH' },
+                  ],
+                ],
+              },
+            ],
+          },
+          {
+            kind: 'temporary',
+            id: 'proto.006-PsCARTHA.michelson_v1.script_rejected',
+            location: 10,
+            with: { string: 'test' },
+          },
+        ],
+      };
+      return result;
+    },
+    withInternalError: () => {
+      result[0].contents[0].metadata.operation_result = {
+        status: 'backtracked',
+        storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
+        consumed_gas: '15953',
+        storage_size: '232',
+      };
+      (result[0].contents[0].metadata as any).internal_operation_results = [
+        {
+          kind: 'transaction',
+          source: 'KT1Rod9ZzsJXLhzDNrrFSh3yaWTjEJriYXjo',
+          nonce: 0,
+          amount: '50000000',
+          destination: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh',
+          result: {
+            status: 'failed',
+            errors: [
+              {
+                kind: 'temporary',
+                id: 'proto.005-PsBabyM1.gas_exhausted.operation',
+              },
+            ],
+          },
+        },
+      ];
+      return result;
+    },
+    withBalanceTooLowError: () => {
+      result[0].contents[0].metadata.operation_result = {
+        status: 'failed',
+        errors: [
+          {
+            kind: 'temporary',
+            id: 'proto.006-PsCARTHA.contract.balance_too_low',
+            contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+            balance: '31106391540',
+            amount: '31106411541000000',
+          },
+        ],
+      };
+      return result;
+    },
+  };
+};

--- a/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
@@ -2,6 +2,7 @@ import { Context } from '../../src/context';
 import { RPCEstimateProvider } from '../../src/contract/rpc-estimate-provider';
 import { miStr } from './data';
 import BigNumber from 'bignumber.js';
+import { preapplyResultFrom } from './helper';
 
 /**
  * RPCEstimateProvider test
@@ -133,6 +134,77 @@ describe('RPCEstimateProvider test', () => {
         storageLimit: 300,
       });
       expect(estimate.gasLimit).toEqual(1100);
+      done();
+    });
+
+    it('should return parsed error from RPC result', async done => {
+      const params = {
+        to: 'test_to',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.runOperation.mockResolvedValue(preapplyResultFrom(params).withError()[0]);
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
+      await expect(estimateProvider.transfer(params)).rejects.toMatchObject({
+        id: 'proto.006-PsCARTHA.michelson_v1.script_rejected',
+        message: 'test',
+      });
+      done();
+    });
+
+    it('should return parsed error from RPC result', async done => {
+      const params = {
+        to: 'test_to',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.runOperation.mockResolvedValue(
+        preapplyResultFrom(params).withBalanceTooLowError()[0]
+      );
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
+      await expect(estimateProvider.transfer(params)).rejects.toMatchObject({
+        id: 'proto.006-PsCARTHA.contract.balance_too_low',
+        message: '(temporary) proto.006-PsCARTHA.contract.balance_too_low',
+      });
+      done();
+    });
+
+    it('should return internal error when received from preapply', async done => {
+      const params = {
+        to: 'test_to',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.runOperation.mockResolvedValue(
+        preapplyResultFrom(params).withInternalError()[0]
+      );
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
+      await expect(estimateProvider.transfer(params)).rejects.toMatchObject({
+        id: 'proto.005-PsBabyM1.gas_exhausted.operation',
+        message: '(temporary) proto.005-PsBabyM1.gas_exhausted.operation',
+      });
       done();
     });
   });


### PR DESCRIPTION
Failed operation will now throw compliant JS error with more information attached to it

BREAKING CHANGE: 
- Operation failed error API changed to be compliant with standard JS error
- RPC estimator can now throw operation failed error

fix #223

Misc:
- Add configuration for known baker and contract in integration test
- Add integration test with a contract that use the FAILWITH operation