### PR TITLE
WIP: feat(taquito): Add batch api to send operation in batch

### DIFF
--- a/integration-tests/batch-api.spec.ts
+++ b/integration-tests/batch-api.spec.ts
@@ -1,0 +1,94 @@
+import { CONFIGS } from "./config";
+import { ligoSample } from "./data/ligo-simple-contract";
+import { managerCode } from "./data/manager_code";
+import { MANAGER_LAMBDA } from "@taquito/taquito";
+
+CONFIGS.forEach(({ lib, rpc, setup, knownBaker }) => {
+  const Tezos = lib;
+  describe(`Test batch api using: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup()
+      done()
+    })
+    it('Simple transfers with origination', async (done) => {
+      const batch = await Tezos.batch()
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withOrigination({
+          balance: "1",
+          code: ligoSample,
+          storage: 0,
+        })
+
+      const op = await batch.send();
+      await op.confirmation();
+      expect(op.status).toEqual('applied')
+      done();
+    })
+
+    it('Simple transfers with origination using with', async (done) => {
+      const op = await Tezos.batch([
+        {
+          kind: 'transaction',
+          to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+          amount: 2
+        },
+        {
+          kind: 'origination',
+          balance: "1",
+          code: ligoSample,
+          storage: 0,
+        }
+      ])
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .send();
+      await op.confirmation();
+      expect(op.status).toEqual('applied')
+      done();
+    })
+
+    it('Simple transfers with bad origination', async (done) => {
+      const op = await Tezos.batch()
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+        .withOrigination({
+          balance: "1",
+          code: ligoSample,
+          storage: 0,
+          storageLimit: 0,
+        })
+        .send();
+      await op.confirmation();
+      expect(op.status).toEqual('backtracked')
+      done();
+    })
+
+    it('Chain contract calls', async (done) => {
+      const op = await Tezos.contract.originate({
+        balance: "1",
+        code: managerCode,
+        init: { "string": await Tezos.signer.publicKeyHash() },
+      })
+
+      const contract = await op.contract();
+      expect(op.status).toEqual('applied')
+
+      const batch = Tezos.batch()
+        .withTransfer({ to: contract.address, amount: 1 })
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 50)))
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)))
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()))
+
+      const batchOp = await batch.send();
+
+      await batchOp.confirmation();
+
+      expect(batchOp.status).toEqual('applied')
+      done();
+    })
+  });
+})

--- a/packages/taquito/src/batch/rpc-batch-provider.ts
+++ b/packages/taquito/src/batch/rpc-batch-provider.ts
@@ -1,0 +1,230 @@
+import { Context } from '../context';
+import { ContractMethod } from '../contract/contract';
+import { EstimationProvider } from '../contract/interface';
+import {
+  createOriginationOperation,
+  createSetDelegateOperation,
+  createTransferOperation,
+} from '../contract/prepare';
+import { BatchOperation } from '../operations/batch-operation';
+import { OperationEmitter } from '../operations/operation-emitter';
+import {
+  ActivationParams,
+  DelegateParams,
+  OriginateParams,
+  RPCActivateOperation,
+  RPCDelegateOperation,
+  RPCOperation,
+  RPCOriginationOperation,
+  RPCTransferOperation,
+  TransferParams,
+} from '../operations/types';
+
+type withKind<T, K> = T & { kind: K };
+
+type withParams =
+  | withKind<OriginateParams, 'origination'>
+  | withKind<DelegateParams, 'delegation'>
+  | withKind<TransferParams, 'transaction'>
+  | withKind<ActivationParams, 'activate_account'>;
+
+export class OperationBatch extends OperationEmitter {
+  private operations: (() => Promise<RPCOperation>)[] = [];
+
+  constructor(context: Context, private estimator: EstimationProvider) {
+    super(context);
+  }
+
+  /**
+   *
+   * @description Add a transaction operation to the batch
+   *
+   * @param params Transfer operation parameter
+   */
+  withTransfer(params: TransferParams) {
+    const opFactory = async () => {
+      const estimate = await this.estimate(params, this.estimator.transfer.bind(this.estimator));
+      return createTransferOperation({
+        ...params,
+        ...estimate,
+      });
+    };
+
+    this.operations.push(opFactory);
+    return this;
+  }
+
+  /**
+   *
+   * @description Add a transaction operation to the batch
+   *
+   * @param params Transfer operation parameter
+   */
+  withContractCall(params: ContractMethod) {
+    return this.withTransfer(params.toTransferParams());
+  }
+
+  /**
+   *
+   * @description Add a delegation operation to the batch
+   *
+   * @param params Delegation operation parameter
+   */
+  withDelegation(params: DelegateParams) {
+    const opFactory = async () => {
+      const estimate = await this.estimate(params, this.estimator.setDelegate.bind(this.estimator));
+      return createSetDelegateOperation({
+        ...params,
+        ...estimate,
+      });
+    };
+
+    this.operations.push(opFactory);
+    return this;
+  }
+
+  /**
+   *
+   * @description Add an activation operation to the batch
+   *
+   * @param params Activation operation parameter
+   */
+  withActivation({ pkh, secret }: ActivationParams) {
+    const opFactory = async () => {
+      const operation: RPCActivateOperation = {
+        kind: 'activate_account',
+        pkh,
+        secret,
+      };
+      return operation;
+    };
+
+    this.operations.push(opFactory);
+    return this;
+  }
+
+  /**
+   *
+   * @description Add an origination operation to the batch
+   *
+   * @param params Origination operation parameter
+   */
+  withOrigination(params: OriginateParams) {
+    const opFactory = async () => {
+      const estimate = await this.estimate(params, this.estimator.originate.bind(this.estimator));
+      return createOriginationOperation({
+        ...params,
+        ...estimate,
+      });
+    };
+
+    this.operations.push(opFactory);
+    return this;
+  }
+
+  private isOpWithFee(
+    op: RPCOperation
+  ): op is RPCDelegateOperation | RPCOriginationOperation | RPCTransferOperation {
+    return ['transaction', 'delegation', 'origination'].indexOf(op.kind) !== -1;
+  }
+
+  /**
+   * @description Provide an estimate of total fees, gas and storage (does not account for reveal)
+   */
+  async getTotals() {
+    let totalGas = 0;
+    let totalStorage = 0;
+    let totalFee = 0;
+
+    const operations = await this.getOperations();
+
+    for (const op of operations) {
+      if (this.isOpWithFee(op)) {
+        totalFee += op.fee;
+        totalGas += op.gas_limit;
+        totalStorage += op.storage_limit;
+      }
+    }
+
+    return {
+      totalFee,
+      totalGas,
+      totalStorage,
+    };
+  }
+
+  private async getOperations() {
+    const operations: RPCOperation[] = [];
+    for (const opFactory of this.operations) {
+      const op = await opFactory();
+      operations.push(op);
+    }
+    return operations;
+  }
+
+  /**
+   *
+   * @description Add a group operation to the batch. Operation will be applied in the order they are in the params array
+   *
+   * @param params Operations parameter
+   */
+  with(params: withParams[]) {
+    for (const param of params) {
+      switch (param.kind) {
+        case 'transaction':
+          this.withTransfer(param);
+          break;
+        case 'origination':
+          this.withOrigination(param);
+          break;
+        case 'delegation':
+          this.withDelegation(param);
+          break;
+        case 'activate_account':
+          this.withActivation(param);
+          break;
+        default:
+          throw new Error(`Unsupported operation kind: ${(param as any).kind}`);
+      }
+    }
+
+    return this;
+  }
+
+  /**
+   *
+   * @description Forge and Inject the operation batch
+   *
+   * @param params Optionally specify the source of the operation
+   */
+  async send(params?: { source?: string }) {
+    const operation = await this.getOperations();
+    const source = (params && params.source) || (await this.signer.publicKeyHash());
+    const opBytes = await this.prepareAndForge({
+      operation,
+      source,
+    });
+    const { hash, context, forgedBytes, opResponse } = await this.signAndInject(opBytes);
+    return new BatchOperation(hash, operation, source, forgedBytes, opResponse, context);
+  }
+}
+
+export class RPCBatchProvider {
+  constructor(private context: Context, private estimator: EstimationProvider) {}
+
+  /***
+   *
+   * @description Batch a group of operation together. Operations will be applied in the order in which they are added to the batch
+   *
+   * @param params List of operation to batch together
+   */
+  batch(params?: withParams[]) {
+    const batch = new OperationBatch(this.context, this.estimator);
+
+    if (Array.isArray(params)) {
+      batch.with(params);
+    }
+
+    return batch;
+  }
+}

--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -2,6 +2,7 @@ import { ParameterSchema, Schema } from '@taquito/michelson-encoder';
 import { EntrypointsResponse, ScriptResponse } from '@taquito/rpc';
 import { ContractProvider } from './interface';
 import { InvalidParameterError } from './errors';
+import { TransferParams } from '../operations/types';
 
 interface SendParams {
   fee?: number;
@@ -41,8 +42,17 @@ export class ContractMethod {
    *
    * @param Options generic operation parameter
    */
-  send({ fee, gasLimit, storageLimit, amount = 0 }: Partial<SendParams> = {}) {
-    return this.provider.transfer({
+  send(params: Partial<SendParams> = {}) {
+    return this.provider.transfer(this.toTransferParams(params));
+  }
+
+  toTransferParams({
+    fee,
+    gasLimit,
+    storageLimit,
+    amount = 0,
+  }: Partial<SendParams> = {}): TransferParams {
+    return {
       to: this.address,
       amount,
       fee,
@@ -55,7 +65,7 @@ export class ContractMethod {
           : this.parameterSchema.Encode(...this.args),
       } as any,
       rawParam: true,
-    });
+    };
   }
 }
 

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -1,7 +1,6 @@
 import { Schema } from '@taquito/michelson-encoder';
 import { ScriptResponse } from '@taquito/rpc';
 import { encodeExpr } from '@taquito/utils';
-import { protocols } from '../constants';
 import { Context } from '../context';
 import { DelegateOperation } from '../operations/delegate-operation';
 import { OperationEmitter } from '../operations/operation-emitter';
@@ -15,7 +14,6 @@ import {
 } from '../operations/types';
 import { Contract } from './contract';
 import { InvalidDelegationSource } from './errors';
-import { Estimate } from './estimate';
 import { ContractProvider, ContractSchema, EstimationProvider } from './interface';
 import {
   createOriginationOperation,
@@ -106,37 +104,6 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
     const bigMapValue = await this.context.rpc.getBigMapExpr(id.toString(), encodedExpr);
 
     return schema.ExecuteOnBigMapValue(bigMapValue, smartContractAbstractionSemantic(this)) as T;
-  }
-
-  private async estimate<T extends { fee?: number; gasLimit?: number; storageLimit?: number }>(
-    { fee, gasLimit, storageLimit, ...rest }: T,
-    estimator: (param: T) => Promise<Estimate>
-  ) {
-    let calculatedFee = fee;
-    let calculatedGas = gasLimit;
-    let calculatedStorage = storageLimit;
-
-    if (fee === undefined || gasLimit === undefined || storageLimit === undefined) {
-      const estimation = await estimator({ fee, gasLimit, storageLimit, ...(rest as any) });
-
-      if (calculatedFee === undefined) {
-        calculatedFee = estimation.suggestedFeeMutez;
-      }
-
-      if (calculatedGas === undefined) {
-        calculatedGas = estimation.gasLimit;
-      }
-
-      if (calculatedStorage === undefined) {
-        calculatedStorage = estimation.storageLimit;
-      }
-    }
-
-    return {
-      fee: calculatedFee!,
-      gasLimit: calculatedGas!,
-      storageLimit: calculatedStorage!,
-    };
   }
 
   /**

--- a/packages/taquito/src/operations/batch-operation.ts
+++ b/packages/taquito/src/operations/batch-operation.ts
@@ -1,0 +1,57 @@
+import {
+  RPCOperation,
+  GasConsumingOperation,
+  StorageConsumingOperation,
+  FeeConsumingOperation,
+  ForgedBytes,
+} from './types';
+import { Operation } from './operations';
+import { OperationContentsAndResult } from '@taquito/rpc';
+import { Context } from '../context';
+import { flattenOperationResult, flattenErrors } from './operation-errors';
+
+export class BatchOperation extends Operation
+  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation {
+  constructor(
+    hash: string,
+    private readonly params: RPCOperation[],
+    public readonly source: string,
+    raw: ForgedBytes,
+    results: OperationContentsAndResult[],
+    context: Context
+  ) {
+    super(hash, raw, results, context);
+  }
+
+  private sumProp(arr: any[], prop: string) {
+    return arr.reduce((prev, current) => {
+      return prop in current ? Number(current[prop]) + prev : prev;
+    }, 0);
+  }
+
+  get fee() {
+    return this.sumProp(this.params, 'fee');
+  }
+
+  get gasLimit() {
+    return this.sumProp(this.params, 'gas_limit');
+  }
+
+  get storageLimit() {
+    return this.sumProp(this.params, 'storage_limit');
+  }
+
+  get consumedGas() {
+    return String(this.sumProp(flattenOperationResult({ contents: this.results }), 'consumed_gas'));
+  }
+
+  get storageDiff() {
+    return String(
+      this.sumProp(flattenOperationResult({ contents: this.results }), 'paid_storage_size_diff')
+    );
+  }
+
+  get errors() {
+    return flattenErrors({ contents: this.results });
+  }
+}

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -18,6 +18,7 @@ import {
   RPCRevealOperation,
   RPCTransferOperation,
 } from './types';
+import { Estimate } from '../contract/estimate';
 
 export interface PreparedOperation {
   opOb: {
@@ -37,7 +38,7 @@ export abstract class OperationEmitter {
     return this.context.signer;
   }
 
-  constructor(protected context: Context) { }
+  constructor(protected context: Context) {}
 
   private isSourceOp(
     op: RPCOperation
@@ -214,6 +215,37 @@ export abstract class OperationEmitter {
       opResponse: await this.rpc.runOperation(op),
       op,
       context: this.context.clone(),
+    };
+  }
+
+  protected async estimate<T extends { fee?: number; gasLimit?: number; storageLimit?: number }>(
+    { fee, gasLimit, storageLimit, ...rest }: T,
+    estimator: (param: T) => Promise<Estimate>
+  ) {
+    let calculatedFee = fee;
+    let calculatedGas = gasLimit;
+    let calculatedStorage = storageLimit;
+
+    if (fee === undefined || gasLimit === undefined || storageLimit === undefined) {
+      const estimation = await estimator({ fee, gasLimit, storageLimit, ...(rest as any) });
+
+      if (calculatedFee === undefined) {
+        calculatedFee = estimation.suggestedFeeMutez;
+      }
+
+      if (calculatedGas === undefined) {
+        calculatedGas = estimation.gasLimit;
+      }
+
+      if (calculatedStorage === undefined) {
+        calculatedStorage = estimation.storageLimit;
+      }
+    }
+
+    return {
+      fee: calculatedFee!,
+      gasLimit: calculatedGas!,
+      storageLimit: calculatedStorage!,
     };
   }
 

--- a/packages/taquito/src/operations/operation-errors.ts
+++ b/packages/taquito/src/operations/operation-errors.ts
@@ -1,6 +1,6 @@
 import {
-  PreapplyResponse,
   MichelsonV1ExpressionBase,
+  PreapplyResponse,
   TezosGenericOperationError,
 } from '@taquito/rpc';
 
@@ -37,8 +37,30 @@ export class TezosPreapplyFailureError implements Error {
   name: string = 'TezosPreapplyFailureError';
   message: string = 'Preapply returned an unexpected result';
 
-  constructor(public result: any) { }
+  constructor(public result: any) {}
 }
+
+export const flattenOperationResult = (response: PreapplyResponse | PreapplyResponse[]) => {
+  let results = Array.isArray(response) ? response : [response];
+
+  let returnedResults: any[] = [];
+  for (let i = 0; i < results.length; i++) {
+    for (let j = 0; j < results[i].contents.length; j++) {
+      const content = results[i].contents[j];
+      if ('metadata' in content && typeof content.metadata.operation_result !== 'undefined') {
+        returnedResults.push(content.metadata.operation_result);
+
+        if (Array.isArray(content.metadata.internal_operation_results)) {
+          content.metadata.internal_operation_results.forEach((x: any) =>
+            returnedResults.push(x.result)
+          );
+        }
+      }
+    }
+  }
+
+  return returnedResults;
+};
 
 /***
  * @description Flatten all error from preapply response (including internal error)

--- a/packages/taquito/src/operations/transaction-operation.ts
+++ b/packages/taquito/src/operations/transaction-operation.ts
@@ -1,18 +1,15 @@
-import {
-  OperationContentsAndResult,
-  OperationContentsAndResultTransaction,
-  OperationResultTransaction,
-} from '@taquito/rpc';
+import { OperationContentsAndResult, OperationContentsAndResultTransaction } from '@taquito/rpc';
+import BigNumber from 'bignumber.js';
 import { Context } from '../context';
+import { flattenErrors, flattenOperationResult } from './operation-errors';
 import { Operation } from './operations';
 import {
+  FeeConsumingOperation,
   ForgedBytes,
   GasConsumingOperation,
-  StorageConsumingOperation,
   RPCTransferOperation,
-  FeeConsumingOperation,
+  StorageConsumingOperation,
 } from './types';
-import BigNumber from 'bignumber.js';
 
 /**
  * @description Transaction operation provide utility function to fetch newly issued transaction
@@ -36,9 +33,7 @@ export class TransactionOperation extends Operation
     const transactionOp =
       Array.isArray(this.results) &&
       (this.results.find(op => op.kind === 'transaction') as OperationContentsAndResultTransaction);
-    const result =
-      transactionOp && transactionOp.metadata && transactionOp.metadata.operation_result;
-    return result ? result : undefined;
+    return transactionOp ? [transactionOp] : [];
   }
 
   get amount() {
@@ -61,22 +56,34 @@ export class TransactionOperation extends Operation
     return this.params.storage_limit;
   }
 
+  private sumProp(arr: any[], prop: string) {
+    return arr.reduce((prev, current) => {
+      return prop in current ? Number(current[prop]) + prev : prev;
+    }, 0);
+  }
+
   get consumedGas() {
-    const consumedGas = this.operationResults && this.operationResults.consumed_gas;
-    return consumedGas ? consumedGas : undefined;
+    return String(
+      this.sumProp(flattenOperationResult({ contents: this.operationResults }), 'consumed_gas')
+    );
   }
 
   get storageDiff() {
-    const storageDiff = this.operationResults && this.operationResults.paid_storage_size_diff;
-    return storageDiff ? storageDiff : undefined;
+    return String(
+      this.sumProp(
+        flattenOperationResult({ contents: this.operationResults }),
+        'paid_storage_size_diff'
+      )
+    );
   }
 
   get storageSize() {
-    const storageSize = this.operationResults && this.operationResults.storage_size;
-    return storageSize ? storageSize : undefined;
+    return String(
+      this.sumProp(flattenOperationResult({ contents: this.operationResults }), 'storage_size')
+    );
   }
 
   get errors() {
-    return this.operationResults && this.operationResults.errors;
+    return flattenErrors({ contents: this.operationResults });
   }
 }

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -39,6 +39,11 @@ export type OriginateParams = OriginateParamsBase &
       }
   );
 
+export interface ActivationParams {
+  pkh: string;
+  secret: string;
+}
+
 /**
  * @description RPC origination operation
  */

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -15,6 +15,7 @@ import { SubscribeProvider } from './subscribe/interface';
 import { PollingSubscribeProvider } from './subscribe/polling-provider';
 import { TzProvider } from './tz/interface';
 import { RpcTzProvider } from './tz/rpc-tz-provider';
+import { RPCBatchProvider } from './batch/rpc-batch-provider';
 
 export * from './query/interface';
 export * from './signer/interface';
@@ -24,7 +25,11 @@ export * from './tz/interface';
 export * from './contract';
 export * from './contract/big-map';
 export * from './constants';
-export { TezosOperationError, TezosOperationErrorWithMessage, TezosPreapplyFailureError } from './operations/operation-errors'
+export {
+  TezosOperationError,
+  TezosOperationErrorWithMessage,
+  TezosPreapplyFailureError,
+} from './operations/operation-errors';
 
 export { SubscribeProvider } from './subscribe/interface';
 export interface SetProviderOptions {
@@ -51,6 +56,7 @@ export class TezosToolkit {
   private _tz = new RpcTzProvider(this._context);
   private _estimate = new RPCEstimateProvider(this._context);
   private _contract = new RpcContractProvider(this._context, this._estimate);
+  private _batch = new RPCBatchProvider(this._context, this._estimate);
 
   public readonly format = format;
 
@@ -131,6 +137,8 @@ export class TezosToolkit {
   get contract(): ContractProvider {
     return this._contract;
   }
+
+  public batch = this._batch.batch.bind(this._batch);
 
   /**
    * @description Provide access to operation estimation utilities

--- a/packages/taquito/test/operations/batch-operation.spec.ts
+++ b/packages/taquito/test/operations/batch-operation.spec.ts
@@ -1,0 +1,247 @@
+import { ForgedBytes } from '../../src/operations/types';
+import { OperationContentsAndResult } from '@taquito/rpc';
+import { BatchOperation } from '../../src/operations/batch-operation';
+import { defaultConfig } from '../../src/context';
+
+describe('Batch operation', () => {
+  let fakeContext: any;
+  let fakeForgedBytes = {} as ForgedBytes;
+
+  const successfulResult = ([
+    {
+      kind: 'transaction',
+      source: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+      fee: '1831',
+      counter: '121636',
+      gas_limit: '15385',
+      storage_limit: '257',
+      amount: '1000000',
+      destination: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+      metadata: {
+        balance_updates: [
+          { kind: 'contract', contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys', change: '-1831' },
+          {
+            kind: 'freezer',
+            category: 'fees',
+            delegate: 'tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf',
+            cycle: 55,
+            change: '1831',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
+          balance_updates: [
+            {
+              kind: 'contract',
+              contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+              change: '-1000000',
+            },
+            {
+              kind: 'contract',
+              contract: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+              change: '1000000',
+            },
+          ],
+          consumed_gas: '15285',
+          storage_size: '232',
+        },
+      },
+    },
+    {
+      kind: 'transaction',
+      source: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+      fee: '2991',
+      counter: '121637',
+      gas_limit: '26260',
+      storage_limit: '257',
+      amount: '0',
+      destination: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+      parameters: {
+        entrypoint: 'do',
+        value: [
+          { prim: 'DROP' },
+          { prim: 'NIL', args: [{ prim: 'operation' }] },
+          {
+            prim: 'PUSH',
+            args: [{ prim: 'key_hash' }, { string: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh' }],
+          },
+          { prim: 'IMPLICIT_ACCOUNT' },
+          { prim: 'PUSH', args: [{ prim: 'mutez' }, { int: '50' }] },
+          { prim: 'UNIT' },
+          { prim: 'TRANSFER_TOKENS' },
+          { prim: 'CONS' },
+        ],
+      },
+      metadata: {
+        balance_updates: [
+          { kind: 'contract', contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys', change: '-2991' },
+          {
+            kind: 'freezer',
+            category: 'fees',
+            delegate: 'tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf',
+            cycle: 55,
+            change: '2991',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
+          consumed_gas: '15953',
+          storage_size: '232',
+        },
+        internal_operation_results: [
+          {
+            kind: 'transaction',
+            source: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+            nonce: 0,
+            amount: '50',
+            destination: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh',
+            result: {
+              status: 'applied',
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+                  change: '-50',
+                },
+                {
+                  kind: 'contract',
+                  contract: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh',
+                  change: '50',
+                },
+              ],
+              consumed_gas: '10207',
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: 'transaction',
+      source: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+      fee: '2947',
+      counter: '121638',
+      gas_limit: '25894',
+      storage_limit: '257',
+      amount: '0',
+      destination: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+      parameters: {
+        entrypoint: 'do',
+        value: [
+          { prim: 'DROP' },
+          { prim: 'NIL', args: [{ prim: 'operation' }] },
+          {
+            prim: 'PUSH',
+            args: [{ prim: 'key_hash' }, { string: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9' }],
+          },
+          { prim: 'SOME' },
+          { prim: 'SET_DELEGATE' },
+          { prim: 'CONS' },
+        ],
+      },
+      metadata: {
+        balance_updates: [
+          { kind: 'contract', contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys', change: '-2947' },
+          {
+            kind: 'freezer',
+            category: 'fees',
+            delegate: 'tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf',
+            cycle: 55,
+            change: '2947',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
+          consumed_gas: '15794',
+          storage_size: '232',
+        },
+        internal_operation_results: [
+          {
+            kind: 'delegation',
+            source: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+            nonce: 1,
+            delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+            result: { status: 'applied', consumed_gas: '10000' },
+          },
+        ],
+      },
+    },
+    {
+      kind: 'transaction',
+      source: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+      fee: '2897',
+      counter: '121639',
+      gas_limit: '25822',
+      storage_limit: '257',
+      amount: '0',
+      destination: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+      parameters: {
+        entrypoint: 'do',
+        value: [
+          { prim: 'DROP' },
+          { prim: 'NIL', args: [{ prim: 'operation' }] },
+          { prim: 'NONE', args: [{ prim: 'key_hash' }] },
+          { prim: 'SET_DELEGATE' },
+          { prim: 'CONS' },
+        ],
+      },
+      metadata: {
+        balance_updates: [
+          { kind: 'contract', contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys', change: '-2897' },
+          {
+            kind: 'freezer',
+            category: 'fees',
+            delegate: 'tz1VxS7ff4YnZRs8b4mMP4WaMVpoQjuo1rjf',
+            cycle: 55,
+            change: '2897',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
+          consumed_gas: '15722',
+          storage_size: '232',
+        },
+        internal_operation_results: [
+          {
+            kind: 'delegation',
+            source: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
+            nonce: 2,
+            result: { status: 'applied', consumed_gas: '10000' },
+          },
+        ],
+      },
+    },
+  ] as unknown) as OperationContentsAndResult[];
+
+  beforeEach(() => {
+    fakeContext = {
+      rpc: {
+        getBlock: jest.fn(),
+      },
+      config: { ...defaultConfig },
+    };
+
+    fakeContext.rpc.getBlock.mockResolvedValue({
+      operations: [[{ hash: 'test_hash' }], [], [], []],
+      header: {
+        level: 200,
+      },
+    });
+  });
+  it('should contains compute the consummed gas, storage diff and storage size properly', () => {
+    const op = new BatchOperation(
+      'test_hash',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.storageDiff).toEqual('0');
+    expect(op.consumedGas).toEqual(String(15285 + 15953 + 10207 + 15794 + 10000 + 15722 + 10000));
+    console.log(op.consumedGas);
+  });
+});

--- a/packages/taquito/test/operations/transaction-operation.spec.ts
+++ b/packages/taquito/test/operations/transaction-operation.spec.ts
@@ -1,0 +1,110 @@
+import { ForgedBytes } from '../../src/operations/types';
+import { OperationContentsAndResult } from '@taquito/rpc';
+import { TransactionOperation } from '../../src/operations/transaction-operation';
+import { defaultConfig } from '../../src/context';
+
+describe('Transfer operation', () => {
+  let fakeContext: any;
+  let fakeForgedBytes = {} as ForgedBytes;
+
+  const successfulResult = ([
+    {
+      kind: 'transaction',
+      source: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys',
+      fee: '2991',
+      counter: '121619',
+      gas_limit: '26260',
+      storage_limit: '257',
+      amount: '0',
+      destination: 'KT1AiWmfuCGSttuMBKbDUqZG6SzKQNrySFei',
+      parameters: {
+        entrypoint: 'do',
+        value: [
+          { prim: 'DROP' },
+          { prim: 'NIL', args: [{ prim: 'operation' }] },
+          {
+            prim: 'PUSH',
+            args: [{ prim: 'key_hash' }, { string: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh' }],
+          },
+          { prim: 'IMPLICIT_ACCOUNT' },
+          { prim: 'PUSH', args: [{ prim: 'mutez' }, { int: '50' }] },
+          { prim: 'UNIT' },
+          { prim: 'TRANSFER_TOKENS' },
+          { prim: 'CONS' },
+        ],
+      },
+      metadata: {
+        balance_updates: [
+          { kind: 'contract', contract: 'tz1bwsEWCwSEXdRvnJxvegQZKeX5dj6oKEys', change: '-2991' },
+          {
+            kind: 'freezer',
+            category: 'fees',
+            delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+            cycle: 54,
+            change: '2991',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
+          consumed_gas: '15953',
+          storage_size: '232',
+        },
+        internal_operation_results: [
+          {
+            kind: 'transaction',
+            source: 'KT1AiWmfuCGSttuMBKbDUqZG6SzKQNrySFei',
+            nonce: 0,
+            amount: '50',
+            destination: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh',
+            result: {
+              status: 'applied',
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'KT1AiWmfuCGSttuMBKbDUqZG6SzKQNrySFei',
+                  change: '-50',
+                },
+                {
+                  kind: 'contract',
+                  contract: 'tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh',
+                  change: '50',
+                },
+              ],
+              consumed_gas: '10207',
+            },
+          },
+        ],
+      },
+    },
+  ] as unknown) as OperationContentsAndResult[];
+
+  beforeEach(() => {
+    fakeContext = {
+      rpc: {
+        getBlock: jest.fn(),
+      },
+      config: { ...defaultConfig },
+    };
+
+    fakeContext.rpc.getBlock.mockResolvedValue({
+      operations: [[{ hash: 'test_hash' }], [], [], []],
+      header: {
+        level: 200,
+      },
+    });
+  });
+  it('should contains compute the consummed gas, storage diff and storage size properly', () => {
+    const op = new TransactionOperation(
+      'test_hash',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.storageDiff).toEqual('0');
+    expect(op.storageSize).toEqual(String(232));
+    expect(op.consumedGas).toEqual(String(15953 + 10207));
+  });
+});


### PR DESCRIPTION
Introduce the batch API allowing to send multiple operation in one operation group

Support:
- Origination
- Transaction
- Delegation
- Smart contract call

```
const op = Tezos.batch()
  .withTransfer({ to: contract.address, amount: 1 })
  .withContractCall(contract.methods.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 50)))
  .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)))
  .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()))
  .send()
```

WIP: Currently make a call to the RPC for every operations in order to get the fees estimation

re #177