### PR TITLE
build(taquito): Compute checksum and update cdn script example on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,5 @@ compiled
 .awcache
 .rpt2_cache
 website/build/
+manifest.json
 !.vscode/extensions.json

--- a/packages/taquito/README.md
+++ b/packages/taquito/README.md
@@ -4,6 +4,13 @@
 
 The `@taquito/taquito` package contains higher level functionality that builds upon the other packages in the Tezos Typescript Library Suite.
 
+## CDN Bundle
+
+```html
+<script src="https://unpkg.com/@taquito/taquito@6.0.2-beta.0/dist/taquito.min.js"
+crossorigin="anonymous" integrity="sha384-gIjWpwSahQXCejt3IXr83Lxmcfe13gZX97Yp7bpdCMpX/fD0XV3V4hxRHhCVX9+k"></script>
+```
+
 ## API Documentation
 
 TypeDoc style documentation is available on-line [here](https://tezostaquito.io/typedoc/modules/_taquito_taquito.html)

--- a/packages/taquito/package-lock.json
+++ b/packages/taquito/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/taquito",
-	"version": "6.0.1-beta.0",
+	"version": "6.0.2-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5073,6 +5073,18 @@
 			"integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
 			"dev": true
 		},
+		"lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+			"dev": true
+		},
+		"lodash.has": {
+			"version": "4.5.2",
+			"resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+			"integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
+			"dev": true
+		},
 		"lodash.sortby": {
 			"version": "4.7.0",
 			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -7970,6 +7982,34 @@
 				}
 			}
 		},
+		"webpack-assets-manifest": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-3.1.1.tgz",
+			"integrity": "sha512-JV9V2QKc5wEWQptdIjvXDUL1ucbPLH2f27toAY3SNdGZp+xSaStAgpoMcvMZmqtFrBc9a5pTS1058vxyMPOzRQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0",
+				"lodash.get": "^4.0",
+				"lodash.has": "^4.0",
+				"mkdirp": "^0.5",
+				"schema-utils": "^1.0.0",
+				"tapable": "^1.0.0",
+				"webpack-sources": "^1.0.0"
+			},
+			"dependencies": {
+				"schema-utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+					"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+					"dev": true,
+					"requires": {
+						"ajv": "^6.1.0",
+						"ajv-errors": "^1.0.0",
+						"ajv-keywords": "^3.1.0"
+					}
+				}
+			}
+		},
 		"webpack-cli": {
 			"version": "3.3.10",
 			"resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.10.tgz",
@@ -8038,6 +8078,15 @@
 			"requires": {
 				"source-list-map": "^2.0.0",
 				"source-map": "~0.6.1"
+			}
+		},
+		"webpack-subresource-integrity": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/webpack-subresource-integrity/-/webpack-subresource-integrity-1.4.0.tgz",
+			"integrity": "sha512-GB1kB/LwAWC3CxwcedGhMkxGpNZxSheCe1q+KJP1bakuieAdX/rGHEcf5zsEzhKXpqsGqokgsDoD9dIkr61VDQ==",
+			"dev": true,
+			"requires": {
+				"webpack-sources": "^1.3.0"
 			}
 		},
 		"whatwg-encoding": {

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -35,7 +35,7 @@
     "precommit": "lint-staged",
     "prebuild": "rimraf dist",
     "build": "tsc --project ./tsconfig.prod.json --module commonjs && rollup -c rollup.config.ts && npm run build:web",
-    "build:web": "webpack",
+    "build:web": "webpack && node update-readme.js",
     "start": "rollup -c rollup.config.ts -w",
     "postinstall": "node patch.js"
   },
@@ -109,6 +109,8 @@
     "tslint-config-standard": "^8.0.1",
     "typescript": "~3.6.0",
     "webpack": "^4.41.4",
-    "webpack-cli": "^3.3.10"
+    "webpack-assets-manifest": "^3.1.1",
+    "webpack-cli": "^3.3.10",
+    "webpack-subresource-integrity": "^1.4.0"
   }
 }

--- a/packages/taquito/update-readme.js
+++ b/packages/taquito/update-readme.js
@@ -1,0 +1,18 @@
+const fs = require('fs');
+
+const readmePath = './README.md';
+
+const manifest = require('./manifest.json')
+const package = require('./package.json')
+
+const integrityRegex = /integrity=\"(.*)\"/;
+const versionRegex = /@taquito\/taquito@(.+)\/dist/
+
+if (fs.existsSync(readmePath)) {
+  let readme = fs.readFileSync(readmePath).toString('utf8');
+
+  readme = readme.replace(integrityRegex, `integrity="${manifest['main.js'].integrity}"`)
+  readme = readme.replace(versionRegex, `@taquito/taquito@${package.version}/dist`)
+
+  fs.writeFileSync(readmePath, readme);
+}

--- a/packages/taquito/webpack.config.js
+++ b/packages/taquito/webpack.config.js
@@ -1,5 +1,7 @@
 const TerserPlugin = require('terser-webpack-plugin');
 const pkg = require('./package.json');
+var SriPlugin = require('webpack-subresource-integrity');
+var WebpackAssetsManifest = require('webpack-assets-manifest');
 
 module.exports = {
   mode: 'production',
@@ -8,7 +10,8 @@ module.exports = {
     library: 'taquito',
     libraryTarget: 'umd',
     path: __dirname,
-    filename: pkg.unpkg
+    filename: pkg.unpkg,
+    crossOriginLoading: 'anonymous'
   },
   node: {
     fs: 'empty'
@@ -17,4 +20,11 @@ module.exports = {
     minimize: true,
     minimizer: [new TerserPlugin()],
   },
+  plugins: [
+    new SriPlugin({
+      hashFuncNames: ['sha384'],
+      enabled: true
+    }),
+    new WebpackAssetsManifest({ integrity: true })
+  ]
 }


### PR DESCRIPTION
Add the following step to the cdn bundle build task:
- Compute integrity checksum from minified cdn bundle
- Update the script example in the readme using the new integrity checksum and version of the package