### PR TITLE
refactor(taquito): Refactor operation content types to use enum

### DIFF
--- a/integration-tests/batch-api.spec.ts
+++ b/integration-tests/batch-api.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from "./config";
 import { ligoSample } from "./data/ligo-simple-contract";
 import { managerCode } from "./data/manager_code";
-import { MANAGER_LAMBDA } from "@taquito/taquito";
+import { MANAGER_LAMBDA, OpKind } from "@taquito/taquito";
 
 CONFIGS.forEach(({ lib, rpc, setup, knownBaker, createAddress }) => {
   const Tezos = lib;
@@ -31,12 +31,12 @@ CONFIGS.forEach(({ lib, rpc, setup, knownBaker, createAddress }) => {
     it('Simple transfers with origination using with', async (done) => {
       const op = await Tezos.batch([
         {
-          kind: 'transaction',
+          kind: OpKind.TRANSACTION,
           to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
           amount: 2
         },
         {
-          kind: 'origination',
+          kind: OpKind.ORIGINATION,
           balance: "1",
           code: ligoSample,
           storage: 0,
@@ -74,12 +74,12 @@ CONFIGS.forEach(({ lib, rpc, setup, knownBaker, createAddress }) => {
 
       const batchOp = await LocalTez.batch([
         {
-          kind: 'transaction',
+          kind: OpKind.TRANSACTION,
           to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
           amount: 1
         },
         {
-          kind: 'origination',
+          kind: OpKind.ORIGINATION,
           balance: "0",
           code: ligoSample,
           storage: 0,

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "@taquito/local-forging": "^6.0.3-beta.1",
     "@taquito/signer": "^6.0.3-beta.1",
-    "@taquito/taquito": "^6.0.3-beta.1"
+    "@taquito/taquito": "^6.0.3-beta.1",
+    "@taquito/utils": "^6.0.3-beta.1"
   },
   "private": true,
   "jest": {

--- a/packages/taquito-rpc/src/opkind.ts
+++ b/packages/taquito-rpc/src/opkind.ts
@@ -1,0 +1,13 @@
+export enum OpKind {
+  ORIGINATION = 'origination',
+  DELEGATION = 'delegation',
+  REVEAL = 'reveal',
+  TRANSACTION = 'transaction',
+  ACTIVATION = 'activate_account',
+  ENDORSEMENT = 'endorsement',
+  SEED_NONCE_REVELATION = 'seed_nonce_revelation',
+  DOUBLE_ENDORSEMENT_EVIDENCE = 'double_endorsement_evidence',
+  DOUBLE_BAKING_EVIDENCE = 'double_baking_evidence',
+  PROPOSALS = 'proposals',
+  BALLOT = 'ballot',
+}

--- a/packages/taquito-rpc/src/taquito-rpc.ts
+++ b/packages/taquito-rpc/src/taquito-rpc.ts
@@ -40,6 +40,8 @@ import { castToBigNumber } from './utils/utils';
 
 export * from './types';
 
+export { OpKind } from './opkind';
+
 const defaultRPC = 'https://mainnet.tezrpc.me';
 const defaultChain = 'main';
 

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -28,6 +28,20 @@ interface Frozenbalancebycycle {
   rewards: BigNumber;
 }
 
+export enum OpKind {
+  ORIGINATION = 'origination',
+  DELEGATION = 'delegation',
+  REVEAL = 'reveal',
+  TRANSACTION = 'transaction',
+  ACTIVATION = 'activate_account',
+  ENDORSEMENT = 'endorsement',
+  SEED_NONCE_REVELATION = 'seed_nonce_revelation',
+  DOUBLE_ENDORSEMENT_EVIDENCE = 'double_endorsement_evidence',
+  DOUBLE_BAKING_EVIDENCE = 'double_baking_evidence',
+  PROPOSALS = 'proposals',
+  BALLOT = 'ballot',
+}
+
 export type BigMapKey = { key: { [key: string]: string }; type: { prim: string } };
 
 // BlockResponse interface
@@ -47,7 +61,7 @@ export interface BlockFullHeader {
   signature: string;
 }
 
-export type InlinedEndorsementKindEnum = 'endorsement';
+export type InlinedEndorsementKindEnum = OpKind.ENDORSEMENT;
 
 export interface InlinedEndorsementContents {
   kind: InlinedEndorsementKindEnum;
@@ -63,43 +77,43 @@ export interface InlinedEndorsement {
 export type OperationContentsBallotEnum = 'nay' | 'yay' | 'pass';
 
 export interface OperationContentsEndorsement {
-  kind: 'endorsement';
+  kind: OpKind.ENDORSEMENT;
   level: number;
 }
 
 export interface OperationContentsRevelation {
-  kind: 'seed_nonce_revelation';
+  kind: OpKind.SEED_NONCE_REVELATION;
   level: number;
   nonce: string;
 }
 
 export interface OperationContentsDoubleEndorsement {
-  kind: 'double_endorsement_evidence';
+  kind: OpKind.DOUBLE_ENDORSEMENT_EVIDENCE;
   op1: InlinedEndorsement;
   op2: InlinedEndorsement;
 }
 
 export interface OperationContentsDoubleBaking {
-  kind: 'double_baking_evidence';
+  kind: OpKind.DOUBLE_BAKING_EVIDENCE;
   bh1: BlockFullHeader;
   bh2: BlockFullHeader;
 }
 
 export interface OperationContentsActivateAccount {
-  kind: 'activate_account';
+  kind: OpKind.ACTIVATION;
   pkh: string;
   secret: string;
 }
 
 export interface OperationContentsProposals {
-  kind: 'proposals';
+  kind: OpKind.PROPOSALS;
   source: string;
   period: number;
   proposals: string[];
 }
 
 export interface OperationContentsBallot {
-  kind: 'ballot';
+  kind: OpKind.BALLOT;
   source: string;
   period: number;
   proposal: string;
@@ -107,7 +121,7 @@ export interface OperationContentsBallot {
 }
 
 export interface OperationContentsReveal {
-  kind: 'reveal';
+  kind: OpKind.REVEAL;
   source: string;
   fee: string;
   counter: string;
@@ -117,7 +131,7 @@ export interface OperationContentsReveal {
 }
 
 export interface OperationContentsTransaction {
-  kind: 'transaction';
+  kind: OpKind.TRANSACTION;
   source: string;
   fee: string;
   counter: string;
@@ -129,7 +143,7 @@ export interface OperationContentsTransaction {
 }
 
 export interface OperationContentsOrigination {
-  kind: 'origination';
+  kind: OpKind.ORIGINATION;
   source: string;
   fee: string;
   counter: string;
@@ -141,7 +155,7 @@ export interface OperationContentsOrigination {
 }
 
 export interface OperationContentsDelegation {
-  kind: 'delegation';
+  kind: OpKind.DELEGATION;
   source: string;
   fee: string;
   counter: string;
@@ -192,41 +206,41 @@ export interface OperationContentsAndResultMetadata {
 }
 
 export interface OperationContentsAndResultEndorsement {
-  kind: 'endorsement';
+  kind: OpKind.ENDORSEMENT;
   level: number;
   metadata: OperationContentsAndResultMetadataExtended;
 }
 
 export interface OperationContentsAndResultRevelation {
-  kind: 'seed_nonce_revelation';
+  kind: OpKind.SEED_NONCE_REVELATION;
   level: number;
   nonce: string;
   metadata: OperationContentsAndResultMetadata;
 }
 
 export interface OperationContentsAndResultDoubleEndorsement {
-  kind: 'double_endorsement_evidence';
+  kind: OpKind.DOUBLE_ENDORSEMENT_EVIDENCE;
   op1: InlinedEndorsement;
   op2: InlinedEndorsement;
   metadata: OperationContentsAndResultMetadata;
 }
 
 export interface OperationContentsAndResultDoubleBaking {
-  kind: 'double_baking_evidence';
+  kind: OpKind.DOUBLE_BAKING_EVIDENCE;
   bh1: BlockFullHeader;
   bh2: BlockFullHeader;
   metadata: OperationContentsAndResultMetadata;
 }
 
 export interface OperationContentsAndResultActivateAccount {
-  kind: 'activate_account';
+  kind: OpKind.ACTIVATION;
   pkh: string;
   secret: string;
   metadata: OperationContentsAndResultMetadata;
 }
 
 export interface OperationContentsAndResultProposals {
-  kind: 'proposals';
+  kind: OpKind.PROPOSALS;
   source: string;
   period: number;
   proposals: string[];
@@ -234,7 +248,7 @@ export interface OperationContentsAndResultProposals {
 }
 
 export interface OperationContentsAndResultBallot {
-  kind: 'ballot';
+  kind: OpKind.BALLOT;
   source: string;
   period: number;
   proposal: string;
@@ -243,7 +257,7 @@ export interface OperationContentsAndResultBallot {
 }
 
 export interface OperationContentsAndResultReveal {
-  kind: 'reveal';
+  kind: OpKind.REVEAL;
   source: string;
   fee: string;
   counter: string;
@@ -254,7 +268,7 @@ export interface OperationContentsAndResultReveal {
 }
 
 export interface OperationContentsAndResultTransaction {
-  kind: 'transaction';
+  kind: OpKind.TRANSACTION;
   source: string;
   fee: string;
   counter: string;
@@ -267,7 +281,7 @@ export interface OperationContentsAndResultTransaction {
 }
 
 export interface OperationContentsAndResultDelegation {
-  kind: 'delegation';
+  kind: OpKind.DELEGATION;
   source: string;
   fee: string;
   counter: string;
@@ -477,42 +491,18 @@ export interface OperationBalanceUpdatesItem {
 
 export type OperationBalanceUpdates = OperationBalanceUpdatesItem[];
 
-export interface ConstructedOperation {
-  kind: string;
-  level: number;
-  nonce: string;
-  pkh: string;
-  hash: string;
-  secret: string;
-  source: string;
-  period: number;
-  proposal: string;
-  ballot: string;
-  fee: string;
-  counter: string;
-  gas_limit: string;
-  storage_limit: string;
-  parameters: string;
-  balance: string;
-  delegate: string;
-  amount: string;
-  destination: string;
-  public_key: string;
-  script: { code: string; storage: string };
-}
-
 export interface OperationObject {
   branch?: string;
-  contents?: ConstructedOperation[];
+  contents?: OperationContents[];
   protocol?: string;
   signature?: string;
 }
 
 export type InternalOperationResultKindEnum =
-  | 'reveal'
-  | 'transaction'
-  | 'origination'
-  | 'delegation';
+  | OpKind.REVEAL
+  | OpKind.TRANSACTION
+  | OpKind.ORIGINATION
+  | OpKind.DELEGATION;
 
 export type InternalOperationResultEnum =
   | OperationResultReveal
@@ -687,7 +677,7 @@ export type EntrypointsResponse = {
 };
 
 export interface OperationContentsAndResultOrigination {
-  kind: 'origination';
+  kind: OpKind.ORIGINATION;
   source: string;
   fee: string;
   counter: string;

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -1,4 +1,5 @@
 import BigNumber from 'bignumber.js';
+import { OpKind } from './opkind';
 
 export type BalanceResponse = BigNumber;
 export type StorageResponse = ScriptedContracts['storage'];
@@ -26,20 +27,6 @@ interface Frozenbalancebycycle {
   deposit: BigNumber;
   fees: BigNumber;
   rewards: BigNumber;
-}
-
-export enum OpKind {
-  ORIGINATION = 'origination',
-  DELEGATION = 'delegation',
-  REVEAL = 'reveal',
-  TRANSACTION = 'transaction',
-  ACTIVATION = 'activate_account',
-  ENDORSEMENT = 'endorsement',
-  SEED_NONCE_REVELATION = 'seed_nonce_revelation',
-  DOUBLE_ENDORSEMENT_EVIDENCE = 'double_endorsement_evidence',
-  DOUBLE_BAKING_EVIDENCE = 'double_baking_evidence',
-  PROPOSALS = 'proposals',
-  BALLOT = 'ballot',
 }
 
 export type BigMapKey = { key: { [key: string]: string }; type: { prim: string } };

--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -11,6 +11,7 @@ import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT } from '../consta
 import { ml2mic, sexp2mic } from '@taquito/utils';
 import { Schema } from '@taquito/michelson-encoder';
 import { format } from '../format';
+import { OpKind } from '@taquito/rpc';
 
 export const createOriginationOperation = async ({
   code,
@@ -45,7 +46,7 @@ export const createOriginationOperation = async ({
   };
 
   const operation: RPCOriginationOperation = {
-    kind: 'origination',
+    kind: OpKind.ORIGINATION,
     fee,
     gas_limit: gasLimit,
     storage_limit: storageLimit,
@@ -70,7 +71,7 @@ export const createTransferOperation = async ({
   rawParam = false,
 }: TransferParams) => {
   const operation: RPCTransferOperation = {
-    kind: 'transaction',
+    kind: OpKind.TRANSACTION,
     fee,
     gas_limit: gasLimit,
     storage_limit: storageLimit,
@@ -96,7 +97,7 @@ export const createSetDelegateOperation = async ({
   storageLimit = DEFAULT_STORAGE_LIMIT.DELEGATION,
 }: DelegateParams) => {
   const operation: RPCDelegateOperation = {
-    kind: 'delegation',
+    kind: OpKind.DELEGATION,
     source,
     fee,
     gas_limit: gasLimit,
@@ -115,7 +116,7 @@ export const createRegisterDelegateOperation = async (
   source: string
 ) => {
   return {
-    kind: 'delegation',
+    kind: OpKind.DELEGATION,
     fee,
     gas_limit: gasLimit,
     storage_limit: storageLimit,

--- a/packages/taquito/src/forger/interface.ts
+++ b/packages/taquito/src/forger/interface.ts
@@ -1,8 +1,8 @@
-import { ConstructedOperation } from '@taquito/rpc';
+import { OperationContents } from '@taquito/rpc';
 
 export interface ForgeParams {
   branch: string;
-  contents: ConstructedOperation[];
+  contents: OperationContents[];
 }
 
 export type ForgeResponse = string; // hex string

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -1,29 +1,30 @@
 import {
   BlockHeaderResponse,
-  ConstructedOperation,
   ManagerKeyResponse,
+  OperationContents,
   OperationContentsAndResult,
+  OpKind,
   RpcClient,
   RPCRunOperationParam,
 } from '@taquito/rpc';
 import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT, Protocols } from '../constants';
 import { Context } from '../context';
+import { Estimate } from '../contract/estimate';
 import { flattenErrors, TezosOperationError, TezosPreapplyFailureError } from './operation-errors';
 import {
   ForgedBytes,
+  isOpRequireReveal,
   PrepareOperationParams,
-  RPCDelegateOperation,
   RPCOperation,
-  RPCOriginationOperation,
+  RPCOpWithFee,
+  RPCOpWithSource,
   RPCRevealOperation,
-  RPCTransferOperation,
 } from './types';
-import { Estimate } from '../contract/estimate';
 
 export interface PreparedOperation {
   opOb: {
     branch: string;
-    contents: ConstructedOperation[];
+    contents: OperationContents[];
     protocol: string;
   };
   counter: number;
@@ -39,25 +40,6 @@ export abstract class OperationEmitter {
   }
 
   constructor(protected context: Context) {}
-
-  private isSourceOp(
-    op: RPCOperation
-  ): op is (RPCTransferOperation | RPCOriginationOperation | RPCDelegateOperation) & {
-    source?: string;
-  } {
-    return ['transaction', 'origination', 'delegation'].includes(op.kind);
-  }
-
-  private isFeeOp(
-    op: RPCOperation
-  ): op is (
-    | RPCTransferOperation
-    | RPCOriginationOperation
-    | RPCDelegateOperation
-    | RPCRevealOperation
-  ) & { source?: string } {
-    return ['reveal', 'transaction', 'origination', 'delegation'].includes(op.kind);
-  }
 
   // Originally from sotez (Copyright (c) 2018 Andrew Kishino)
   protected async prepareOperation({
@@ -85,7 +67,7 @@ export abstract class OperationEmitter {
     let counterPromise: Promise<string | undefined> = Promise.resolve(undefined);
     let managerPromise: Promise<ManagerKeyResponse | undefined> = Promise.resolve(undefined);
     for (let i = 0; i < ops.length; i++) {
-      if (['transaction', 'origination', 'delegation'].includes(ops[i].kind)) {
+      if (isOpRequireReveal(ops[i])) {
         requiresReveal = true;
         const { counter } = await this.rpc.getContract(publicKeyHash);
         counterPromise = Promise.resolve(counter);
@@ -115,7 +97,7 @@ export abstract class OperationEmitter {
       const haveManager = manager && typeof manager === 'object' ? !!manager.key : !!manager;
       if (!haveManager) {
         const reveal: RPCRevealOperation = {
-          kind: 'reveal',
+          kind: OpKind.REVEAL,
           fee: DEFAULT_FEE.REVEAL,
           public_key: await this.signer.publicKey(),
           source: publicKeyHash,
@@ -132,50 +114,68 @@ export abstract class OperationEmitter {
       counters[publicKeyHash] = counter;
     }
 
-    const constructOps = (cOps: RPCOperation[]): ConstructedOperation[] =>
+    const getFee = (op: RPCOpWithFee) => {
+      const opCounter = ++counters[publicKeyHash];
+      return {
+        counter: `${opCounter}`,
+        // tslint:disable-next-line: strict-type-predicates
+        fee: typeof op.fee === 'undefined' ? '0' : `${op.fee}`,
+        // tslint:disable-next-line: strict-type-predicates
+        gas_limit: typeof op.gas_limit === 'undefined' ? '0' : `${op.gas_limit}`,
+        // tslint:disable-next-line: strict-type-predicates
+        storage_limit: typeof op.storage_limit === 'undefined' ? '0' : `${op.storage_limit}`,
+      };
+    };
+
+    const getSource = (op: RPCOpWithSource) => {
+      return {
+        source: typeof op.source === 'undefined' ? source || publicKeyHash : op.source,
+      };
+    };
+
+    const constructOps = (cOps: RPCOperation[]): OperationContents[] =>
       // tslint:disable strict-type-predicates
       cOps.map((op: RPCOperation) => {
-        const constructedOp = { ...op } as ConstructedOperation;
-        if (this.isSourceOp(op)) {
-          if (typeof op.source === 'undefined') {
-            constructedOp.source = source || publicKeyHash;
-          }
+        switch (op.kind) {
+          case OpKind.ACTIVATION:
+            return {
+              ...op,
+            };
+          case OpKind.REVEAL:
+            return {
+              ...op,
+              ...getSource(op),
+              ...getFee(op),
+            };
+          case OpKind.ORIGINATION:
+            return {
+              ...op,
+              balance: typeof op.balance !== 'undefined' ? `${op.balance}` : '0',
+              ...getSource(op),
+              ...getFee(op),
+            };
+          case OpKind.TRANSACTION:
+            const cops = {
+              ...op,
+              amount: typeof op.amount !== 'undefined' ? `${op.amount}` : '0',
+              ...getSource(op),
+              ...getFee(op),
+            };
+            if (cops.source.toLowerCase().startsWith('kt1')) {
+              throw new Error(
+                `KT1 addresses are not supported as source since ${Protocols.PsBabyM1}`
+              );
+            }
+            return cops;
+          case OpKind.DELEGATION:
+            return {
+              ...op,
+              ...getSource(op),
+              ...getFee(op),
+            };
+          default:
+            throw new Error('Unsupported operation');
         }
-        if (this.isFeeOp(op)) {
-          if (typeof op.fee === 'undefined') {
-            constructedOp.fee = '0';
-          } else {
-            constructedOp.fee = `${op.fee}`;
-          }
-          if (typeof op.gas_limit === 'undefined') {
-            constructedOp.gas_limit = '0';
-          } else {
-            constructedOp.gas_limit = `${op.gas_limit}`;
-          }
-          if (typeof op.storage_limit === 'undefined') {
-            constructedOp.storage_limit = '0';
-          } else {
-            constructedOp.storage_limit = `${op.storage_limit}`;
-          }
-          const opCounter = ++counters[publicKeyHash];
-          constructedOp.counter = `${opCounter}`;
-        }
-        if (op.kind === 'origination') {
-          if (typeof op.balance !== 'undefined') constructedOp.balance = `${constructedOp.balance}`;
-        }
-
-        if (op.kind === 'transaction') {
-          if (constructedOp.source.toLowerCase().startsWith('kt1')) {
-            throw new Error(
-              `KT1 addresses are not supported as source since ${Protocols.PsBabyM1}`
-            );
-          }
-
-          if (typeof op.amount !== 'undefined') constructedOp.amount = `${constructedOp.amount}`;
-        }
-        // tslint:enable strict-type-predicates
-
-        return constructedOp;
       });
 
     const branch = head.hash;

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -1,4 +1,8 @@
-import { OperationContentsAndResult, OperationContentsAndResultOrigination } from '@taquito/rpc';
+import {
+  OperationContentsAndResult,
+  OperationContentsAndResultOrigination,
+  OpKind,
+} from '@taquito/rpc';
 import { Context } from '../context';
 import { RpcContractProvider } from '../contract/rpc-contract-provider';
 import { Operation } from './operations';
@@ -8,6 +12,7 @@ import {
   StorageConsumingOperation,
   RPCOriginationOperation,
   FeeConsumingOperation,
+  withKind,
 } from './types';
 
 /**
@@ -40,8 +45,8 @@ export class OriginationOperation extends Operation
 
   get operationResults() {
     const originationOp =
-      Array.isArray(this.results) &&
-      (this.results.find(op => op.kind === 'origination') as OperationContentsAndResultOrigination);
+      Array.isArray(this.results) && this.results.find(op => op.kind === 'origination');
+
     const result =
       originationOp && originationOp.metadata && originationOp.metadata.operation_result;
     return result ? result : undefined;

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -1,5 +1,7 @@
 import { OperationObject, InternalOperationResultKindEnum, OpKind } from '@taquito/rpc';
 
+export { OpKind } from '@taquito/rpc';
+
 export type withKind<T, K extends OpKind> = T & { kind: K };
 
 export type ParamsWithKind =

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -28,6 +28,8 @@ export * from './contract';
 export * from './contract/big-map';
 export * from './constants';
 
+export { OpKind } from './operations/types';
+
 export { TaquitoProvider } from './context';
 export { PollingSubscribeProvider } from './subscribe/polling-provider';
 export { RpcForger } from './forger/rpc-forger';

--- a/packages/taquito/src/tz/rpc-tz-provider.ts
+++ b/packages/taquito/src/tz/rpc-tz-provider.ts
@@ -4,6 +4,7 @@ import { OperationEmitter } from '../operations/operation-emitter';
 import { Operation } from '../operations/operations';
 import { RPCActivateOperation } from '../operations/types';
 import { TzProvider } from './interface';
+import { OpKind } from '@taquito/rpc';
 
 export class RpcTzProvider extends OperationEmitter implements TzProvider {
   constructor(context: Context) {
@@ -20,7 +21,7 @@ export class RpcTzProvider extends OperationEmitter implements TzProvider {
 
   async activate(pkh: string, secret: string) {
     const operation: RPCActivateOperation = {
-      kind: 'activate_account',
+      kind: OpKind.ACTIVATION,
       pkh,
       secret,
     };


### PR DESCRIPTION
Removed constructed operation type and leverage type inference when mapping operation from user
parameter to RPC compliant object