### PR TITLE
300 - Update docs to support Carthagenet

### DIFF
--- a/docs/making_transfers.md
+++ b/docs/making_transfers.md
@@ -41,7 +41,7 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
   })
   .then(op => {
     render(`Waiting for ${op.hash} to be confirmed...`);
-    return op.confirmation(3).then(() => op.hash);
+    return op.confirmation(1).then(() => op.hash);
   })
   .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${JSON.stringify(error, null, 2)}`));

--- a/docs/making_transfers.md
+++ b/docs/making_transfers.md
@@ -40,10 +40,10 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
     return Tezos.contract.transfer({ to: address, amount: amount });
   })
   .then(op => {
-    render(`Waiting for a confirmation...`);
-    return op.confirmation();
+    render(`Waiting for ${op.hash} to be confirmed...`);
+    return op.confirmation(3).then(() => op.hash);
   })
-  .then(block => render(`Block height: ${block}`))
+  .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
 

--- a/docs/making_transfers.md
+++ b/docs/making_transfers.md
@@ -20,10 +20,10 @@ await Tezos.contract.transfer({ to: contract.address, amount: 1 })
 
 In the following example we will transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNjY29asdBfZ` address that will sign the operation to `tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY`.
 ```js live noInline
-Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/babylonnet' });
+Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
 render(`Fetching a private key...`);
-fetch('https://api.tez.ie/keys/babylonnet/', {
+fetch('https://api.tez.ie/keys/carthagenet/', {
     method: 'POST',
     headers: { 'Authorization': 'Bearer taquito-example' }
   })
@@ -61,7 +61,7 @@ In order to transfer tokens from a KT1 addresses with the new `manager.tz` contr
 
 Sending 50 mutez from `kt1...` to `tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh`.
 
-### Example transfer from a KT1 to a tz1 address on Babylon/Proto005
+### Example transfer from a KT1 to a tz1 address on Carthage/Proto006
 
 ```js
 const contract = await Tezos.contract.at("kt1...")

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -137,7 +137,7 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
   })
   .then(op => {
     render(`Waiting for ${op.hash} to be confirmed...`);
-    return op.confirmation(3).then(() => op.hash);
+    return op.confirmation(1).then(() => op.hash);
   })
   .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${error} ${JSON.stringify(error, null, 2)}`));
@@ -169,7 +169,7 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
   })
   .then(op => {
     render(`Waiting for ${op.hash} to be confirmed...`);
-    return op.confirmation(3).then(() => op.hash);
+    return op.confirmation(1).then(() => op.hash);
   })
   .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${JSON.stringify(error, null, 2)}`));

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -116,10 +116,10 @@ Tezos.importKey(
 The transfer operation requires a configured signer. In this example we will use a private key that we will get from a service that was implemented for demonstration purposes and should only be used for testing and development.
 
 ```js live noInline
-Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/babylonnet' });
+Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
 render(`Fetching a private key...`);
-fetch('https://api.tez.ie/keys/babylonnet/', {
+fetch('https://api.tez.ie/keys/carthagenet/', {
     method: 'POST',
     headers: { 'Authorization': 'Bearer taquito-example' }
   })
@@ -148,10 +148,10 @@ fetch('https://api.tez.ie/keys/babylonnet/', {
 Calling smart contract operations require a configured signer, in this example we will use a faucet key. The source for the smart contract [KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
 
 ```js live noInline
-Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/babylonnet' });
+Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
 render(`Fetching a private key...`);
-fetch('https://api.tez.ie/keys/babylonnet/', {
+fetch('https://api.tez.ie/keys/carthagenet/', {
     method: 'POST',
     headers: { 'Authorization': 'Bearer taquito-example' }
   })
@@ -174,4 +174,4 @@ fetch('https://api.tez.ie/keys/babylonnet/', {
 
 [boilerplate]: https://github.com/ecadlabs/taquito-boilerplate
 [smart_contract_source]: https://ide.ligolang.org/p/CelcoaDRK5mLFDmr5rSWug
-[smart_contract_on_better_call_dev]: https://better-call.dev/babylon/KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8/operations
+[smart_contract_on_better_call_dev]: https://better-call.dev/carthage/KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8/operations

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -145,7 +145,7 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
 
 ### Interact with a smart contract
 
-Calling smart contract operations require a configured signer, in this example we will use a faucet key. The source for the smart contract [KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
+Calling smart contract operations require a configured signer, in this example we will use a faucet key. The source for the smart contract [KT1JVErLYTgtY8uGGZ4mso2npTSxqVLDRVbC][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
 
 ```js live noInline
 Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
@@ -160,7 +160,7 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
     render(`Importing the private key...`);
     return Tezos.importKey(privateKey);
   })
-  .then(() => Tezos.contract.at('KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8'))
+  .then(() => Tezos.contract.at('KT1JVErLYTgtY8uGGZ4mso2npTSxqVLDRVbC'))
   .then(contract => {
     const i = 7;
 
@@ -174,4 +174,4 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
 
 [boilerplate]: https://github.com/ecadlabs/taquito-boilerplate
 [smart_contract_source]: https://ide.ligolang.org/p/CelcoaDRK5mLFDmr5rSWug
-[smart_contract_on_better_call_dev]: https://better-call.dev/carthage/KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8/operations
+[smart_contract_on_better_call_dev]: https://better-call.dev/carthage/KT1JVErLYTgtY8uGGZ4mso2npTSxqVLDRVbC/operations

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -136,10 +136,10 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
     return Tezos.contract.transfer({ to: address, amount: amount });
   })
   .then(op => {
-    render(`Waiting for a confirmation...`);
-    return op.confirmation();
+    render(`Waiting for ${op.hash} to be confirmed...`);
+    return op.confirmation(3).then(() => op.hash);
   })
-  .then(block => render(`Block height: ${block}`))
+  .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${error} ${JSON.stringify(error, null, 2)}`));
 ```
 
@@ -167,8 +167,11 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
     render(`Incrementing storage value by ${i}...`);
     return contract.methods.increment(i).send();
   })
-  .then(op => op.confirmation())
-  .then(block => render(`Block height: ${block}`))
+  .then(op => {
+    render(`Waiting for ${op.hash} to be confirmed...`);
+    return op.confirmation(3).then(() => op.hash);
+  })
+  .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
 

--- a/docs/set_delegate.md
+++ b/docs/set_delegate.md
@@ -36,7 +36,7 @@ In order to delegate for a KT1 addresses with the new `manager.tz` contract, a c
 > 
 > For the time being, we regard KT1 manager accounts as a regular smart contract. In fact, it is possible to have a smart contract that is not following the manager.tz conventions and that also delegates to a baker. The correct lambda to pass to a contract in order to delegate is application/wallet specific. Therefore Taquito does not make any assumption on the KT1.
 
-### Example of delegation for a KT1 on Babylon/Proto005
+### Example of delegation for a KT1 on Carthage/Proto006
 
 ```js
 const contract = await Tezos.contract.at("kt1...")

--- a/docs/set_delegate.md
+++ b/docs/set_delegate.md
@@ -60,9 +60,3 @@ const setDelegate = (key: string) => {
   ];
 };
 ```
-
-### Example for Athens/Proto004
-
-```js
-await Tezos.contract.setDelegate({ delegate: 'tz1_baker', source: 'KT1...' })
-```

--- a/docs/smartcontracts.md
+++ b/docs/smartcontracts.md
@@ -13,7 +13,7 @@ Michelson is a somewhat specialized language that isn't typical in Javascript or
 
 ## Taquito's Smart Contract Abstraction
 
-Taquito assists developers by reading the Michelson code for a given contract from the blockchain. Based on the retrieved Michelson code, Taquito generates a `contract` javascript object with methods and storage that correspond to the contacts Michelson entrypoints, storage definitions and values.
+Taquito assists developers by reading the Michelson code for a given contract from the blockchain. Based on the retrieved Michelson code, Taquito generates a `contract` javascript object with methods and storage that correspond to the contract's Michelson entrypoints, storage definitions and values.
 
 ## The Counter Contract
 
@@ -89,12 +89,12 @@ You can view this contract and deploy it to a testnet using the [Ligo WebIDE][2]
 To load the contract from the Tezos Blockchain, we use the `Tezos.contract.at` method.
 We can inspect the contract methods and data types using the `c.parameterSchema.ExtractSignatures()` method.
 
-The following example shows how to load the contact, and view the methods on that contract.
+The following example shows how to load the contract, and view the methods on that contract.
 
 ```js live noInline
 Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
-Tezos.contract.at('KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8')
+Tezos.contract.at('KT1JVErLYTgtY8uGGZ4mso2npTSxqVLDRVbC')
 .then(c => {
     let methods = c.parameterSchema.ExtractSignatures()
     render(JSON.stringify(methods, null, 2))
@@ -116,7 +116,7 @@ We can inspect the transfer params produced by Taquito using the `toTransferPara
 ```js live noInline
 Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
-Tezos.contract.at('KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8')
+Tezos.contract.at('KT1JVErLYTgtY8uGGZ4mso2npTSxqVLDRVbC')
 .then(c => {
     let incrementParams = c.methods.increment(2).toTransferParams()
     render(JSON.stringify(incrementParams, null, 2))
@@ -145,7 +145,7 @@ fetch('https://api.tez.ie/keys/carthagenet/', {
     render(`Importing the private key...`);
     return Tezos.importKey(privateKey);
   })
-  .then(() => Tezos.contract.at('KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8'))
+  .then(() => Tezos.contract.at('KT1JVErLYTgtY8uGGZ4mso2npTSxqVLDRVbC'))
   .then(contract => {
     const i = 7;
 

--- a/docs/smartcontracts.md
+++ b/docs/smartcontracts.md
@@ -92,7 +92,7 @@ We can inspect the contract methods and data types using the `c.parameterSchema.
 The following example shows how to load the contact, and view the methods on that contract.
 
 ```js live noInline
-Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/babylonnet' });
+Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
 Tezos.contract.at('KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8')
 .then(c => {
@@ -114,7 +114,7 @@ In Tezos, to call an entrypoint on a contract, one must send a transfer operatio
 We can inspect the transfer params produced by Taquito using the `toTransferParams()` method as follows.
 
 ```js live noInline
-Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/babylonnet' });
+Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
 Tezos.contract.at('KT1LjpCPTqGajeaXfLM3WV7csatSgyZcTDQ8')
 .then(c => {
@@ -133,10 +133,10 @@ We call the `send()` method on the `increment()` method. Taquito then forges thi
 Then we wait for the `confirmation(3)` to complete. The `3` number tells Taquito how many confirmations to wait for before resolving the promise. `3` is a good value for this type of demonstration, but we recommend a higher value if you are dealing with mainnet transactions.
 
 ```js live noInline
-Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/babylonnet' });
+Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
 render(`Fetching temporary private key for testing...`);
-fetch('https://api.tez.ie/keys/babylonnet/', {
+fetch('https://api.tez.ie/keys/carthagenet/', {
     method: 'POST',
     headers: { 'Authorization': 'Bearer taquito-example' }
   })
@@ -156,7 +156,7 @@ fetch('https://api.tez.ie/keys/babylonnet/', {
     render(`Awaiting for ${op.hash} to be confirmed...`)
     return op.confirmation(3).then(() => op.hash)
   })
-  .then(hash => render(`Operation injected: https://babylonnet.tzstats.com/${hash}`))
+  .then(hash => render(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
   .catch(error => render(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
 

--- a/packages/taquito/README.md
+++ b/packages/taquito/README.md
@@ -8,7 +8,7 @@ The `@taquito/taquito` package contains higher level functionality that builds u
 
 ```html
 <script src="https://unpkg.com/@taquito/taquito@6.1.0-beta.0/dist/taquito.min.js"
-crossorigin="anonymous" integrity="sha384-KXhl9yW7Y71XNNxJBbfVO6JGL23UZ8sF5tZMFCujrhk56QcGe56CkcqcmW+ybshG"></script>
+crossorigin="anonymous" integrity="sha384-sk4V+57zLUCfkna8z4p1u6CioucJqmeo+QnaiXoFiuE8vdkm7/ae2TNFLbL+Ys02"></script>
 ```
 
 ## API Documentation

--- a/packages/taquito/README.md
+++ b/packages/taquito/README.md
@@ -8,7 +8,7 @@ The `@taquito/taquito` package contains higher level functionality that builds u
 
 ```html
 <script src="https://unpkg.com/@taquito/taquito@6.1.0-beta.0/dist/taquito.min.js"
-crossorigin="anonymous" integrity="sha384-sk4V+57zLUCfkna8z4p1u6CioucJqmeo+QnaiXoFiuE8vdkm7/ae2TNFLbL+Ys02"></script>
+crossorigin="anonymous" integrity="sha384-KXhl9yW7Y71XNNxJBbfVO6JGL23UZ8sF5tZMFCujrhk56QcGe56CkcqcmW+ybshG"></script>
 ```
 
 ## API Documentation


### PR DESCRIPTION
This updates all docs examples to use Carthagenet and renders the injection operation link upon success. 

@jevonearth do you want me to wait for 3 confirmations on all examples? Takes a decent amount longer than just waiting for `op.confirmation()`