### PR TITLE
fix(rpc): Apply correct type to parameters, remove rawParam option

### DIFF
--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -31,8 +31,6 @@ interface Frozenbalancebycycle {
 
 export type BigMapKey = { key: { [key: string]: string }; type: { prim: string } };
 
-// BlockResponse interface
-// header:
 export interface BlockFullHeader {
   level: number;
   proto: number;
@@ -126,7 +124,7 @@ export interface OperationContentsTransaction {
   storage_limit: string;
   amount: string;
   destination: string;
-  parameters?: MichelsonV1Expression;
+  parameters?: TransactionOperationParameter;
 }
 
 export interface OperationContentsOrigination {
@@ -263,7 +261,7 @@ export interface OperationContentsAndResultTransaction {
   storage_limit: string;
   amount: string;
   destination: string;
-  parameters?: MichelsonV1Expression;
+  parameters?: TransactionOperationParameter;
   metadata: OperationContentsAndResultMetadataTransaction;
 }
 
@@ -291,8 +289,6 @@ export type OperationContentsAndResult =
   | OperationContentsAndResultOrigination
   | OperationContentsAndResultDelegation;
 
-// BlockResponse interface
-// operations:
 export interface OperationEntry {
   protocol: string;
   chain_id: string;
@@ -463,10 +459,6 @@ export interface ScriptedContracts {
   storage: MichelsonV1Expression;
 }
 
-// BlockResponse interface
-// metadata: {
-//   balanceUpdates:
-// }
 export interface OperationBalanceUpdatesItem {
   kind: BalanceUpdateKindEnum;
   category?: BalanceUpdateCategoryEnum;
@@ -535,13 +527,18 @@ export interface OperationResultReveal {
   errors?: TezosGenericOperationError[];
 }
 
+export interface TransactionOperationParameter {
+  entrypoint: string;
+  value: MichelsonV1Expression;
+}
+
 export interface InternalOperationResult {
   kind: InternalOperationResultKindEnum;
   source: string;
   nonce: number;
   amount?: string;
   destination?: string;
-  parameters?: MichelsonV1Expression;
+  parameters?: TransactionOperationParameter;
   public_key?: string;
   balance?: string;
   delegate?: string;

--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -79,7 +79,6 @@ export class ContractMethod {
           ? this.parameterSchema.Encode(this.name, ...this.args)
           : this.parameterSchema.Encode(...this.args),
       },
-      rawParam: true,
     };
     return fullTransferParams;
   }

--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -68,7 +68,6 @@ export const createTransferOperation = async ({
   gasLimit = DEFAULT_GAS_LIMIT.TRANSFER,
   storageLimit = DEFAULT_STORAGE_LIMIT.TRANSFER,
   mutez = false,
-  rawParam = false,
 }: TransferParams) => {
   const operation: RPCTransferOperation = {
     kind: OpKind.TRANSACTION,
@@ -77,15 +76,8 @@ export const createTransferOperation = async ({
     storage_limit: storageLimit,
     amount: mutez ? amount.toString() : format('tz', 'mutez', amount).toString(),
     destination: to,
+    parameters: parameter,
   };
-
-  if (parameter) {
-    operation.parameters = rawParam
-      ? parameter
-      : typeof parameter === 'string'
-      ? sexp2mic(parameter)
-      : parameter;
-  }
   return operation;
 };
 

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -1,4 +1,9 @@
-import { OperationObject, InternalOperationResultKindEnum, OpKind } from '@taquito/rpc';
+import {
+  OperationObject,
+  InternalOperationResultKindEnum,
+  OpKind,
+  TransactionOperationParameter,
+} from '@taquito/rpc';
 
 export { OpKind } from '@taquito/rpc';
 
@@ -168,11 +173,10 @@ export interface TransferParams {
   source?: string;
   amount: number;
   fee?: number;
-  parameter?: string | object | { entrypoint: string; value: object };
+  parameter?: TransactionOperationParameter;
   gasLimit?: number;
   storageLimit?: number;
   mutez?: boolean;
-  rawParam?: boolean;
 }
 
 /**
@@ -186,7 +190,7 @@ export interface RPCTransferOperation {
   amount: string;
   source?: string;
   destination: string;
-  parameters?: any;
+  parameters?: TransactionOperationParameter;
 }
 
 /**


### PR DESCRIPTION
- `parameters?` was incorrectly typed as `MichelsonV1Expression`.  New type is now `TransactionOperationHeader`.
- Removed the `rawParam` option, as this was not working anyway, and does not appear to be needed anyway.
- Removed some stray comments

Fix #312