### PR TITLE
fix(signer): Fix merge issues from previous commit

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/example",
-	"version": "5.2.0-beta.0",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "integration-tests",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5545,9 +5545,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-			"integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+			"version": "3.6.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
+			"integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
 			"dev": true
 		},
 		"uglify-js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18220,9 +18220,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
-      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "uglify-js": {

--- a/packages/taquito-http-utils/package-lock.json
+++ b/packages/taquito-http-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/http-utils",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-local-forging/package-lock.json
+++ b/packages/taquito-local-forging/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/local-forging",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-michelson-encoder/package-lock.json
+++ b/packages/taquito-michelson-encoder/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/michelson-encoder",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-react-components/package-lock.json
+++ b/packages/taquito-react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/react-components",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-remote-signer/package-lock.json
+++ b/packages/taquito-remote-signer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/remote-signer",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-rpc/package-lock.json
+++ b/packages/taquito-rpc/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/rpc",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-signer/package-lock.json
+++ b/packages/taquito-signer/package-lock.json
@@ -403,80 +403,6 @@
 				"any-observable": "^0.3.0"
 			}
 		},
-		"@taquito/http-utils": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-6.0.1-beta.0.tgz",
-			"integrity": "sha512-kAFHj8Q59fSELY+Mb2bX332HmmtDkChT76pcyJ/hPwudHZfNNkVwSufFqI/dehXUtFaykJOuHHu0VlH3GMI70g==",
-			"requires": {
-				"xhr2-cookies": "^1.1.0"
-			}
-		},
-		"@taquito/indexer": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/indexer/-/indexer-6.0.1-beta.0.tgz",
-			"integrity": "sha512-FAPFkIi8PnmrNpXqCr1b/MQGUG3dsw6cKZ6VHcCUTRM0uVOnMtqLoTzxM7mawuqRm10l/6cLJUvURy01ZdNzow==",
-			"requires": {
-				"@taquito/http-utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0"
-			}
-		},
-		"@taquito/michelson-encoder": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-6.0.1-beta.0.tgz",
-			"integrity": "sha512-kdR6taE7UFP7UkE8X3KAN0pYENnPRaj8D7R3fiGMAd7EWav7fRVjAz1SCq4E4q+BqnpyDuvt8X1c0FOOl7Km1g==",
-			"requires": {
-				"@taquito/utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0"
-			}
-		},
-		"@taquito/rpc": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-6.0.1-beta.0.tgz",
-			"integrity": "sha512-N+vc7VJz135pMhtCUNVgO0eWrF71c1v3sHxQZWoG/8jBRiXi4t4Sb/5JO9+S0QRzV2NWGBwVXQLfyx4R5UDI3Q==",
-			"requires": {
-				"@taquito/http-utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0",
-				"lodash": "^4.17.15"
-			}
-		},
-		"@taquito/signer": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-6.0.1-beta.0.tgz",
-			"integrity": "sha512-hGSGS/PvTXBV7HKrxFjUr1CY6BO8kQju0ZKH9RSJ2Gy9li7BqbOtf6CNoGrvdoxMd+Fv9SKicPt6PX+0Hjr68w==",
-			"requires": {
-				"@taquito/utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0",
-				"bip39": "^3.0.2",
-				"elliptic": "^6.5.1",
-				"libsodium-wrappers": "^0.7.5",
-				"pbkdf2": "^3.0.17",
-				"typedarray-to-buffer": "^3.1.5"
-			}
-		},
-		"@taquito/taquito": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-6.0.1-beta.0.tgz",
-			"integrity": "sha512-sbuDdiLBlowYWIsyU305fWIBjnHVgMd/XIUSSOVvGMYnOyebvwHc42T9Ql2avAuqwam1vBVUXHtbHAhKCkC84w==",
-			"requires": {
-				"@taquito/indexer": "^6.0.1-beta.0",
-				"@taquito/michelson-encoder": "^6.0.1-beta.0",
-				"@taquito/rpc": "^6.0.1-beta.0",
-				"@taquito/signer": "^6.0.1-beta.0",
-				"@taquito/utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0",
-				"rxjs": "^6.5.3"
-			}
-		},
-		"@taquito/utils": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-6.0.1-beta.0.tgz",
-			"integrity": "sha512-he63WaG/qGQuAB6savK89epPMCbdaRbnsl16kHVUf/ey2ncBrb3Y5wkj/GV2U2QrfH8KVxJKqH2/VPQlAMl/Kg==",
-			"requires": {
-				"blakejs": "^1.1.0",
-				"bs58check": "^2.1.2",
-				"buffer": "^5.2.1"
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -945,19 +871,6 @@
 				}
 			}
 		},
-		"base-x": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
-		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -999,11 +912,6 @@
 					"integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
 				}
 			}
-		},
-		"blakejs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bn.js": {
 			"version": "4.11.8",
@@ -1086,24 +994,6 @@
 				"fast-json-stable-stringify": "2.x"
 			}
 		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
-			}
-		},
 		"bser": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -1111,15 +1001,6 @@
 			"dev": true,
 			"requires": {
 				"node-int64": "^0.4.0"
-			}
-		},
-		"buffer": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-			"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
 			}
 		},
 		"buffer-from": {
@@ -1406,11 +1287,6 @@
 					"dev": true
 				}
 			}
-		},
-		"cookiejar": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
 		},
 		"copy-descriptor": {
 			"version": "0.1.1",
@@ -3003,11 +2879,6 @@
 				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
-		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-		},
 		"import-fresh": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -4232,7 +4103,8 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -5418,6 +5290,7 @@
 			"version": "6.5.4",
 			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.4.tgz",
 			"integrity": "sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==",
+			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -6127,7 +6000,8 @@
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+			"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==",
+			"dev": true
 		},
 		"tslint": {
 			"version": "5.20.1",
@@ -6583,14 +6457,6 @@
 			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0"
-			}
-		},
-		"xhr2-cookies": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-			"integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-			"requires": {
-				"cookiejar": "^2.1.1"
 			}
 		},
 		"xml-name-validator": {

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -66,8 +66,7 @@
     ]
   },
   "dependencies": {
-    "@taquito/utils": "^6.0.1-beta.0",
-    "@taquito/taquito": "^6.0.1-beta.0",
+    "@taquito/utils": "^6.1.0-beta.0",
     "bignumber.js": "^9.0.0",
     "bip39": "^3.0.2",
     "elliptic": "^6.5.1",

--- a/packages/taquito-signer/src/import-key.ts
+++ b/packages/taquito-signer/src/import-key.ts
@@ -1,5 +1,4 @@
 import { InMemorySigner } from './taquito-signer';
-import { TezosToolkit } from '@taquito/taquito';
 
 /**
  *
@@ -12,7 +11,7 @@ import { TezosToolkit } from '@taquito/taquito';
  * @param secret Faucet secret
  */
 export async function importKey(
-  toolkit: TezosToolkit,
+  toolkit: any,
   privateKeyOrEmail: string,
   passphrase?: string,
   mnemonic?: string,
@@ -20,7 +19,7 @@ export async function importKey(
 ) {
   if (privateKeyOrEmail && passphrase && mnemonic && secret) {
     const signer = InMemorySigner.fromFundraiser(privateKeyOrEmail, passphrase, mnemonic);
-    toolkit.setSignerProvider(signer);
+    toolkit.setProvider({ signer });
     const pkh = await signer.publicKeyHash();
     let op;
     try {
@@ -37,6 +36,6 @@ export async function importKey(
   } else {
     // Fallback to regular import
     const signer = await InMemorySigner.fromSecretKey(privateKeyOrEmail, passphrase);
-    toolkit.setSignerProvider(signer);
+    toolkit.setProvider({ signer });
   }
 }

--- a/packages/taquito-signer/src/taquito-signer.ts
+++ b/packages/taquito-signer/src/taquito-signer.ts
@@ -5,7 +5,6 @@ import { Tz1 } from './ed-key';
 import { Tz2, ECKey, Tz3 } from './ec-key';
 import pbkdf2 from 'pbkdf2';
 import { mnemonicToSeedSync } from 'bip39';
-import { Signer } from '@taquito/taquito';
 
 export * from './import-key';
 
@@ -22,7 +21,7 @@ export * from './import-key';
  *
  * The recommended usage is to use InMemorySigner.fromSecretKey('edsk', 'passphrase')
  */
-export class InMemorySigner implements Signer {
+export class InMemorySigner {
   private _key!: Tz1 | ECKey;
 
   static fromFundraiser(email: string, password: string, mnemonic: string) {

--- a/packages/taquito-signer/test/import-key.spec.ts
+++ b/packages/taquito-signer/test/import-key.spec.ts
@@ -35,6 +35,7 @@ describe('ImportKey', () => {
 
     mockRpcClient.getManagerKey.mockResolvedValue('test');
     toolkit = new TezosToolkit();
+    toolkit['_rpcClient'] = mockRpcClient;
     toolkit['_context'].rpc = mockRpcClient;
     toolkit['_options'].rpc = mockRpcClient;
   });

--- a/packages/taquito-tezbridge-signer/package-lock.json
+++ b/packages/taquito-tezbridge-signer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/tezbridge-signer",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito-utils/package-lock.json
+++ b/packages/taquito-utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@taquito/utils",
-	"version": "6.0.3-beta.1",
+	"version": "6.1.0-beta.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/taquito/package-lock.json
+++ b/packages/taquito/package-lock.json
@@ -501,63 +501,6 @@
 				"any-observable": "^0.3.0"
 			}
 		},
-		"@taquito/http-utils": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-6.0.1-beta.0.tgz",
-			"integrity": "sha512-kAFHj8Q59fSELY+Mb2bX332HmmtDkChT76pcyJ/hPwudHZfNNkVwSufFqI/dehXUtFaykJOuHHu0VlH3GMI70g==",
-			"requires": {
-				"xhr2-cookies": "^1.1.0"
-			}
-		},
-		"@taquito/indexer": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/indexer/-/indexer-6.0.1-beta.0.tgz",
-			"integrity": "sha512-FAPFkIi8PnmrNpXqCr1b/MQGUG3dsw6cKZ6VHcCUTRM0uVOnMtqLoTzxM7mawuqRm10l/6cLJUvURy01ZdNzow==",
-			"requires": {
-				"@taquito/http-utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0"
-			}
-		},
-		"@taquito/michelson-encoder": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-6.0.1-beta.0.tgz",
-			"integrity": "sha512-kdR6taE7UFP7UkE8X3KAN0pYENnPRaj8D7R3fiGMAd7EWav7fRVjAz1SCq4E4q+BqnpyDuvt8X1c0FOOl7Km1g==",
-			"requires": {
-				"@taquito/utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0"
-			}
-		},
-		"@taquito/rpc": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-6.0.1-beta.0.tgz",
-			"integrity": "sha512-N+vc7VJz135pMhtCUNVgO0eWrF71c1v3sHxQZWoG/8jBRiXi4t4Sb/5JO9+S0QRzV2NWGBwVXQLfyx4R5UDI3Q==",
-			"requires": {
-				"@taquito/http-utils": "^6.0.1-beta.0",
-				"bignumber.js": "^9.0.0",
-				"lodash": "^4.17.15"
-			}
-		},
-		"@taquito/utils": {
-			"version": "6.0.1-beta.0",
-			"resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-6.0.1-beta.0.tgz",
-			"integrity": "sha512-he63WaG/qGQuAB6savK89epPMCbdaRbnsl16kHVUf/ey2ncBrb3Y5wkj/GV2U2QrfH8KVxJKqH2/VPQlAMl/Kg==",
-			"requires": {
-				"blakejs": "^1.1.0",
-				"bs58check": "^2.1.2",
-				"buffer": "^5.2.1"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "5.5.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
-					"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
-			}
-		},
 		"@types/babel__core": {
 			"version": "7.1.6",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.6.tgz",
@@ -1246,18 +1189,11 @@
 				}
 			}
 		},
-		"base-x": {
-			"version": "3.0.8",
-			"resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
-			"integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
-			"requires": {
-				"safe-buffer": "^5.0.1"
-			}
-		},
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
 		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.2",
@@ -1294,11 +1230,6 @@
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
-		},
-		"blakejs": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.1.0.tgz",
-			"integrity": "sha1-ad+S75U6qIylGjLfarHFShVfx6U="
 		},
 		"bluebird": {
 			"version": "3.7.2",
@@ -1458,24 +1389,6 @@
 			"dev": true,
 			"requires": {
 				"fast-json-stable-stringify": "2.x"
-			}
-		},
-		"bs58": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
-			"integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
-			"requires": {
-				"base-x": "^3.0.2"
-			}
-		},
-		"bs58check": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-			"integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-			"requires": {
-				"bs58": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"safe-buffer": "^5.1.2"
 			}
 		},
 		"bser": {
@@ -1693,6 +1606,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
 			"integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -1911,11 +1825,6 @@
 				}
 			}
 		},
-		"cookiejar": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-			"integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
-		},
 		"copy-concurrently": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/copy-concurrently/-/copy-concurrently-1.0.5.tgz",
@@ -1981,6 +1890,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
 			"integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+			"dev": true,
 			"requires": {
 				"cipher-base": "^1.0.1",
 				"inherits": "^2.0.1",
@@ -3782,6 +3692,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
 			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -3873,7 +3784,8 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+			"dev": true
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -3932,7 +3844,8 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -5151,7 +5064,8 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
 		},
 		"lodash.camelcase": {
 			"version": "4.3.0",
@@ -5342,6 +5256,7 @@
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
 			"integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
@@ -6613,6 +6528,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
 			"integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+			"dev": true,
 			"requires": {
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1"
@@ -6729,7 +6645,8 @@
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"dev": true
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -6836,6 +6753,7 @@
 			"version": "2.4.11",
 			"resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
 			"integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.0.1"
@@ -8349,14 +8267,6 @@
 			"dev": true,
 			"requires": {
 				"async-limiter": "~1.0.0"
-			}
-		},
-		"xhr2-cookies": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-			"integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-			"requires": {
-				"cookiejar": "^2.1.1"
 			}
 		},
 		"xml-name-validator": {

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -75,10 +75,10 @@
     ]
   },
   "dependencies": {
-    "@taquito/indexer": "^6.0.1-beta.0",
-    "@taquito/michelson-encoder": "^6.0.1-beta.0",
-    "@taquito/rpc": "^6.0.1-beta.0",
-    "@taquito/utils": "^6.0.1-beta.0",
+    "@taquito/michelson-encoder": "^6.1.0-beta.0",
+    "@taquito/rpc": "^6.1.0-beta.0",
+    "@taquito/signer": "^6.1.0-beta.0",
+    "@taquito/utils": "^6.1.0-beta.0",
     "bignumber.js": "^9.0.0",
     "rxjs": "^6.5.3"
   },

--- a/packages/taquito/src/signer/interface.ts
+++ b/packages/taquito/src/signer/interface.ts
@@ -1,5 +1,5 @@
 /**
- * @description Signer interface which is used accross taquito in order to sign and inject operation
+ * @description Signer interface which is used across taquito in order to sign and inject operation
  */
 export interface Signer {
   /**


### PR DESCRIPTION
Resolve cyclical dependency in @taquito/signer and fix dependencies from previous rebase in order to fix build issues.

The previous commit introduced a cyclical dependency. This commit should resolve that and reset the dependencies that were outdated from a rebase of master. The only issue is that in `import-key.ts` toolkit does not explicitly set a type.
```
export async function importKey(
  toolkit: any,
  privateKeyOrEmail: string,
  passphrase?: string,
  mnemonic?: string,
  secret?: string
) {
```

Any ideas on how we can add a type to toolkit instead of `any`?