### PR TITLE
fix(taquito): Replace instanceof with static method to allow cross module type checks

### DIFF
--- a/packages/taquito-michelson-encoder/src/michelson-map.ts
+++ b/packages/taquito-michelson-encoder/src/michelson-map.ts
@@ -2,6 +2,10 @@ import { MichelsonV1Expression } from '@taquito/rpc';
 import { Schema } from './schema/storage';
 import stringify from 'fast-json-stable-stringify';
 
+// Retrieve a unique symbol associated with the key from the environment
+// Used in order to identify all object that are of type MichelsonMap even if they come from different module
+const michelsonMapTypeSymbol = Symbol.for('taquito-michelson-map-type-symbol');
+
 export type MichelsonMapKey = Array<any> | Object | string | boolean | number;
 
 const isMapType = (
@@ -25,6 +29,15 @@ export class MapTypecheckError implements Error {
 export class MichelsonMap<K extends MichelsonMapKey, T extends any> {
   private valueMap = new Map<string, T>();
   private keyMap = new Map<string, K>();
+
+  public [michelsonMapTypeSymbol] = true;
+
+  // Used to check if an object is a michelson map.
+  // Using instanceof was not working for project that had multiple instance of taquito dependencies
+  // as the class constructor is different
+  static isMichelsonMap(obj: any): obj is MichelsonMap<any, any> {
+    return obj && obj[michelsonMapTypeSymbol] === true;
+  }
 
   private keySchema?: Schema;
   private valueSchema?: Schema;

--- a/packages/taquito-michelson-encoder/src/schema/storage.ts
+++ b/packages/taquito-michelson-encoder/src/schema/storage.ts
@@ -7,11 +7,19 @@ import { Semantic, Token, TokenValidationError } from '../tokens/token';
 import { RpcTransaction } from './model';
 import { Falsy } from './types';
 
+const schemaTypeSymbol = Symbol.for('taquito-schema-type-symbol');
+
 /**
  * @warn Our current smart contract abstraction feature is currently in preview. It's API is not final, and it may not cover every use case (yet). We will greatly appreciate any feedback on this feature.
  */
 export class Schema {
   private root: Token;
+
+  public [schemaTypeSymbol] = true;
+
+  public static isSchema(obj: any): obj is Schema {
+    return obj && obj[schemaTypeSymbol] === true;
+  }
 
   // TODO: Should we deprecate this?
   private bigMap?: BigMapToken;

--- a/packages/taquito-michelson-encoder/src/tokens/bigmap.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bigmap.ts
@@ -1,5 +1,5 @@
-import { Token, TokenFactory, ComparableToken, Semantic, TokenValidationError } from './token';
 import { MichelsonMap } from '../michelson-map';
+import { ComparableToken, Semantic, Token, TokenFactory, TokenValidationError } from './token';
 
 export class BigMapValidationError extends TokenValidationError {
   name: string = 'BigMapValidationError';
@@ -33,7 +33,7 @@ export class BigMapToken extends Token {
   }
 
   private isValid(value: any): BigMapValidationError | null {
-    if (value instanceof MichelsonMap) {
+    if (MichelsonMap.isMichelsonMap(value)) {
       return null;
     }
 

--- a/packages/taquito-michelson-encoder/src/tokens/map.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/map.ts
@@ -1,5 +1,5 @@
-import { Token, TokenFactory, Semantic, TokenValidationError, ComparableToken } from './token';
 import { MichelsonMap } from '../michelson-map';
+import { ComparableToken, Semantic, Token, TokenFactory, TokenValidationError } from './token';
 
 export class MapValidationError extends TokenValidationError {
   name: string = 'MapValidationError';
@@ -28,7 +28,7 @@ export class MapToken extends Token {
   }
 
   private isValid(value: any): MapValidationError | null {
-    if (value instanceof MichelsonMap) {
+    if (MichelsonMap.isMichelsonMap(value)) {
       return null;
     }
 

--- a/packages/taquito-rpc/src/utils/utils.ts
+++ b/packages/taquito-rpc/src/utils/utils.ts
@@ -63,7 +63,7 @@ export function castToString(data: any, keys?: any): object {
       return;
     }
 
-    if (!(item instanceof BigNumber)) {
+    if (!BigNumber.isBigNumber(item)) {
       response[key] = item;
       return;
     }

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -43,7 +43,7 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
     }
 
     let contractSchema: Schema;
-    if (schema instanceof Schema) {
+    if (Schema.isSchema(schema)) {
       contractSchema = schema;
     } else {
       contractSchema = Schema.fromRPCResponse({ script: schema as ScriptResponse });
@@ -72,7 +72,7 @@ export class RpcContractProvider extends OperationEmitter implements ContractPro
     }
 
     let contractSchema: Schema;
-    if (schema instanceof Schema) {
+    if (Schema.isSchema(schema)) {
       contractSchema = schema;
     } else {
       contractSchema = Schema.fromRPCResponse({ script: schema as ScriptResponse });


### PR DESCRIPTION
User inputs that were instantiated from a different module instance of Taquito was not valid.

were rejected by the `instanceof` operator.

Implementing the solution described here: https://jakearchibald.com/2017/arrays-symbols-realms/#multiple-realms.