### PR TITLE
Integration tests use RemoteSigner/ephemeral keys, allow custom http headers

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -27,7 +27,7 @@ interface Config {
 /**
  * SignerType specifies the different signer options used in the integration test suite. EPHEMERAL_KEY relies on a the [tezos-key-get-api](https://github.com/ecadlabs/tezos-key-gen-api)
  */
-enum signerType {
+enum SignerType {
   FAUCET,
   EPHEMERAL_KEY
 }
@@ -42,7 +42,7 @@ interface ConfigWithSetup extends Config {
  * EphemeralConfig contains configuration for interacting with the [tezos-key-gen-api](https://github.com/ecadlabs/tezos-key-gen-api)
  */
 interface EphemeralConfig {
-  type: signerType.EPHEMERAL_KEY,
+  type: SignerType.EPHEMERAL_KEY,
   keyUrl: string,
   requestHeaders: {[key: string]: string}
 }
@@ -51,8 +51,8 @@ interface EphemeralConfig {
  * FaucetConfig contains a JSON faucet key that can be used on Tezos test-nets or sandboxes. Faucet keys for public testnets are available from [https://faucet.tzalpha.net/](https://faucet.tzalpha.net/)
  */
 interface FaucetConfig {
-  type: signerType.FAUCET,
-  faucetKey?: {}
+  type: SignerType.FAUCET,
+  faucetKey: {}
 }
 
   const carthagenetEphemeral = {
@@ -61,7 +61,7 @@ interface FaucetConfig {
     knownContract: 'KT1XYa1JPKYVJYVJge89r4w2tShS8JYb1NQh',
     protocol: Protocols.PsCARTHA,
     signerConfig: {
-      type: signerType.EPHEMERAL_KEY,
+      type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
       keyUrl: 'https://api.tez.ie/keys/carthagenet/ephemeral',
       requestHeaders: {'Authorization': 'Bearer taquito-example'},
      }
@@ -72,7 +72,7 @@ interface FaucetConfig {
     knownContract: 'KT1EM2LvxxFGB3Svh9p9HCP2jEEYyHjABMbK',
     protocol: Protocols.PsBabyM1,
     signerConfig: {
-      type: signerType.EPHEMERAL_KEY,
+      type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
       keyUrl: 'https://api.tez.ie/keys/babylonnet/ephemeral',
       requestHeaders: {'Authorization': 'Bearer taquito-example'},
      }
@@ -107,9 +107,9 @@ interface FaucetConfig {
     knownContract: 'KT1EM2LvxxFGB3Svh9p9HCP2jEEYyHjABMbK',
     protocol: Protocols.PsCARTHA,
     signerConfig: {
-      type: signerType.FAUCET,
+      type: SignerType.FAUCET as SignerType.FAUCET,
       faucetKey: key,
-     } as FaucetConfig
+     }
   }
 
  const babylonnetFaucet = {
@@ -118,9 +118,9 @@ interface FaucetConfig {
     knownContract: 'KT1EM2LvxxFGB3Svh9p9HCP2jEEYyHjABMbK',
     protocol: Protocols.PsBabyM1,
     signerConfig: {
-      type: signerType.FAUCET,
+      type: SignerType.FAUCET as SignerType.FAUCET,
       faucetKey: key,
-     } as FaucetConfig
+     }
   }
 const providers: Config[] = [];
 
@@ -160,12 +160,12 @@ export const CONFIGS: ConfigWithSetup[] =
         lib: Tezos,
         signerConfig,
         setup: async () => {
-          if (signerConfig.type === signerType.FAUCET) {
+          if (signerConfig.type === SignerType.FAUCET) {
 
             const faucetKey: any = faucetKeyFile || signerConfig.faucetKey
             await importKey(Tezos, faucetKey.email, faucetKey.password, faucetKey.mnemonic.join(" "), faucetKey.secret)
 
-          } else if(signerConfig.type === signerType.EPHEMERAL_KEY) {
+          } else if(signerConfig.type === SignerType.EPHEMERAL_KEY) {
 
             const httpClient = new HttpBackend()
             const { id, pkh } = await httpClient.createRequest(

--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -94,7 +94,7 @@ export const CONFIGS: ConfigWithSetup[] =
           const tezos = new TezosToolkit()
           tezos.setProvider({ rpc: rpc })
 
-          const keyBytes = new Buffer(32);
+          const keyBytes = Buffer.alloc(32);
           nodeCrypto.randomFillSync(keyBytes)
 
           const key = b58cencode(new Uint8Array(keyBytes), prefix[Prefix.P2SK]);

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -1,12 +1,15 @@
 {
   "name": "integration-tests",
   "scripts": {
-    "test": "jest --runInBand"
+    "test:faucet": "RUN_WITH_FAUCET=true jest --runInBand",
+    "test": "jest"
   },
   "version": "6.1.1-beta.0",
   "dependencies": {
     "@taquito/local-forging": "^6.1.1-beta.0",
     "@taquito/signer": "^6.1.1-beta.0",
+    "@taquito/remote-signer": "^6.1.1-beta.0",
+    "@taquito/http-utils": "^6.1.1-beta.0",
     "@taquito/taquito": "^6.1.1-beta.0",
     "@taquito/utils": "^6.1.1-beta.0"
   },

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -16,6 +16,7 @@ interface HttpRequestOptions {
   method?: 'GET' | 'POST';
   timeout?: number;
   query?: { [key: string]: any };
+  headers?: { [key: string]: string };
 }
 
 export class HttpResponseError implements Error {
@@ -82,11 +83,14 @@ export class HttpBackend {
    *
    * @param options contains options to be passed for the HTTP request (url, method and timeout)
    */
-  createRequest<T>({ url, method, timeout, query }: HttpRequestOptions, data?: {}) {
+  createRequest<T>({ url, method, timeout, query, headers = {} }: HttpRequestOptions, data?: {}) {
     return new Promise<T>((resolve, reject) => {
       const request = this.createXHR();
       request.open(method || 'GET', `${url}${this.serialize(query)}`);
       request.setRequestHeader('Content-Type', 'application/json');
+      for (const k in headers) {
+        request.setRequestHeader(k, headers[k]);
+      }
       request.timeout = timeout || defaultTimeout;
       request.onload = function() {
         if (this.status >= 200 && this.status < 300) {

--- a/packages/taquito-signer/src/import-key.ts
+++ b/packages/taquito-signer/src/import-key.ts
@@ -2,7 +2,7 @@ import { InMemorySigner } from './taquito-signer';
 
 /**
  *
- * @description Import a key to sign operation
+ * @description Import a key to sign operation with the side-effect of setting the Tezos instance to use the InMemorySigner provider
  *
  * @param toolkit The toolkit instance to attach a signer
  * @param privateKeyOrEmail Key to load in memory


### PR DESCRIPTION
- Add configuration options to run integration tests using InMemorySigner/faucet keys or RemoteSigner/ephemeral keys
- Allow users to specify custom HTTP headers via HttpRequestOptions
- Allow users to specify RemoteSignerConfig options