### PR TITLE
fix(estimator) Fix a bug where explicit limits were ignored by the estimator

### DIFF
--- a/integration-tests/batch-api.spec.ts
+++ b/integration-tests/batch-api.spec.ts
@@ -51,19 +51,24 @@ CONFIGS.forEach(({ lib, rpc, setup, knownBaker, createAddress }) => {
     })
 
     it('Simple transfers with bad origination', async (done) => {
-      const op = await Tezos.batch()
-        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
-        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
-        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
-        .withOrigination({
-          balance: "1",
-          code: ligoSample,
-          storage: 0,
-          storageLimit: 0,
-        })
-        .send();
-      await op.confirmation();
-      expect(op.status).toEqual('backtracked')
+      expect.assertions(1);
+      try {
+        await Tezos.batch()
+          .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+          .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+          .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+          .withOrigination({
+            balance: "1",
+            code: ligoSample,
+            storage: 0,
+            storageLimit: 0,
+          })
+          .send();
+      } catch (ex) {
+        expect(ex).toEqual(expect.objectContaining({
+          message: expect.stringContaining('storage_exhausted.operation')
+        }))
+      }
       done();
     })
 


### PR DESCRIPTION
Description of the issue:

Setting the storageLimit to 0 on an origination did not threw an error and did a dry run with the maximum storageLimit (60000). Also the actual operation sent by taquito
contained the explicit storageLimit instead of the that the user specified which lead to a failure on chain. So in this example the origination would have been reported as valid to the user but rejected by the chain.

- Ensure that we respect the explicit limit set by the user while estimating
- Add unit test coverage and integration test coverage for this issue