### PR TITLE
refactor(remote-signer): verify signature from remote-signer

### DIFF
--- a/packages/taquito-remote-signer/package-lock.json
+++ b/packages/taquito-remote-signer/package-lock.json
@@ -894,11 +894,29 @@
 				"@babel/types": "^7.3.0"
 			}
 		},
+		"@types/bn.js": {
+			"version": "4.11.6",
+			"resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+			"integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
 			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
 			"dev": true
+		},
+		"@types/elliptic": {
+			"version": "6.4.12",
+			"resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.12.tgz",
+			"integrity": "sha512-gP1KsqoouLJGH6IJa28x7PXb3cRqh83X8HCLezd2dF+XcAIMKYv53KV+9Zn6QA561E120uOqZBQ+Jy/cl+fviw==",
+			"dev": true,
+			"requires": {
+				"@types/bn.js": "*"
+			}
 		},
 		"@types/estree": {
 			"version": "0.0.39",
@@ -949,6 +967,12 @@
 				"jest-diff": "^25.2.1",
 				"pretty-format": "^25.2.1"
 			}
+		},
+		"@types/libsodium-wrappers": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.7.tgz",
+			"integrity": "sha512-Li91pVKcLvQJK3ZolwCPo85oxf2gKBCApgnesRxYg4OVYchLXcJB2eivX8S87vfQVv6ZRnyCO1lLDosZGJfpRg==",
+			"dev": true
 		},
 		"@types/node": {
 			"version": "14.0.1",
@@ -1367,6 +1391,11 @@
 				"tweetnacl": "^0.14.3"
 			}
 		},
+		"bn.js": {
+			"version": "4.11.9",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+			"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+		},
 		"brace-expansion": {
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1385,6 +1414,11 @@
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
+		},
+		"brorand": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+			"integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
 		},
 		"browser-process-hrtime": {
 			"version": "1.0.0",
@@ -1934,6 +1968,20 @@
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-2.0.0.tgz",
 			"integrity": "sha512-5YRYHhvhYzV/FC4AiMdeSIg3jAYGq9xFvbhZMpPlJoBsfYgrw2DSCYeXfat6tYBu45PWiyRr3+flaCPPmviPaA==",
 			"dev": true
+		},
+		"elliptic": {
+			"version": "6.5.2",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+			"integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+			"requires": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
 		},
 		"emoji-regex": {
 			"version": "8.0.0",
@@ -2558,6 +2606,25 @@
 				}
 			}
 		},
+		"hash.js": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+			"integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+			"requires": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"hmac-drbg": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+			"integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+			"requires": {
+				"hash.js": "^1.0.3",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.1"
+			}
+		},
 		"hosted-git-info": {
 			"version": "2.8.8",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
@@ -2664,8 +2731,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"interpret": {
 			"version": "1.2.0",
@@ -4182,6 +4248,19 @@
 				"type-check": "~0.3.2"
 			}
 		},
+		"libsodium": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.6.tgz",
+			"integrity": "sha512-hPb/04sEuLcTRdWDtd+xH3RXBihpmbPCsKW/Jtf4PsvdyKh+D6z2D2gvp/5BfoxseP+0FCOg66kE+0oGUE/loQ=="
+		},
+		"libsodium-wrappers": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.6.tgz",
+			"integrity": "sha512-OUO2CWW5bHdLr6hkKLHIKI4raEkZrf3QHkhXsJ1yCh6MZ3JDA7jFD3kCATNquuGSG6MjjPHQIQms0y0gBDzjQg==",
+			"requires": {
+				"libsodium": "0.7.6"
+			}
+		},
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -4492,6 +4571,16 @@
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
 			"integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
 			"dev": true
+		},
+		"minimalistic-assert": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+			"integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+		},
+		"minimalistic-crypto-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+			"integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
 		},
 		"minimatch": {
 			"version": "3.0.4",

--- a/packages/taquito-remote-signer/package.json
+++ b/packages/taquito-remote-signer/package.json
@@ -61,11 +61,15 @@
   "dependencies": {
     "@taquito/http-utils": "^6.2.0-beta.1",
     "@taquito/utils": "^6.2.0-beta.1",
+    "elliptic": "^6.5.2",
+    "libsodium-wrappers": "^0.7.6",
     "typedarray-to-buffer": "^3.1.5"
   },
   "devDependencies": {
     "@taquito/taquito": "^6.2.0-beta.1",
+    "@types/elliptic": "^6.4.12",
     "@types/jest": "^25.2.2",
+    "@types/libsodium-wrappers": "^0.7.7",
     "@types/node": "^14.0.1",
     "@types/ws": "^7.2.4",
     "colors": "^1.4.0",

--- a/packages/taquito-remote-signer/src/errors.ts
+++ b/packages/taquito-remote-signer/src/errors.ts
@@ -12,3 +12,13 @@ export class BadSigningDataError implements Error {
   public name: string = 'BadSigningData';
   constructor(public message: string, public innerException: any, public readonly data: any) {}
 }
+
+export class SignatureVerificationError implements Error {
+  public name: string = 'SignatureVerification';
+  constructor(public message: string, public readonly data: any) {}
+}
+
+export class PublicKeyMismatchError implements Error {
+  public name: string = 'PublicKeyMismatch';
+  constructor(public message: string, public readonly data: any) {}
+}


### PR DESCRIPTION
On receipt of signature from remote signer, validate the signature against the public key. Also
validate that the public key returned from the remote signer corresponds to the public key hash used to initialize the remote signer.

- Added a new `verify` method which takes the bytes and signature from the remote signer and validates it against the public key to ensure that the signature is indeed valid. This method also verifies that the public key being returned from the server matches the public key hash used to initialize the remote signer.