### PR TITLE
Fix to encode schema properly when optional value is null

### DIFF
--- a/docs/complex_parameters.md
+++ b/docs/complex_parameters.md
@@ -1,0 +1,194 @@
+---
+title: Working with contracts having complexe storage/parameters
+author: Roxane Letourneau
+---
+
+This section shows how Taquito can be used to :
+- Originate a contract with complex storage
+- Call a contract function with a complex object as a parameter
+- Pass null value to some optional arguments
+
+The source code of the contract used in the following examples is available [here](https://better-call.dev/carthagenet/KT1TRHzT3HdLe3whe35q6rNxavGx8WVFHSpH/code).
+
+## Origination of a contract with complex storage
+
+Here we have the storage of the contract defined in Michelson.
+
+This storage uses a pair which is itself composed of a pair and a `map` (annotated as %validators). The nested pair consists of an address (annotated as %owner) and a `bigMap` (annotated as %records). The `map %validators` uses a natural number (`nat`) as its key and an address as its value. The `bigMap %records` uses a value in `bytes` as its key and a pair consisting of nested pairs as its value. In these nested pairs, we find addresses and natural numbers, where some are optional, and a `map` (annotated %data). The `map %data` uses a `string` as its key and the user needs to choose the value of the `map` between different proposed types (`int`, `bytes`, `bool`, ...). We can notice in this example that all the arguments are identified by an annotation.
+
+```
+storage (pair
+          (pair (address %owner)
+                (big_map %records bytes
+                          (pair
+                            (pair
+                              (pair (option %address address)
+                                    (map %data string
+                                               (or
+                                                 (or
+                                                   (or
+                                                     (or (address %address)
+                                                         (bool %bool))
+                                                     (or (bytes %bytes)
+                                                         (int %int)))
+                                                   (or
+                                                     (or (key %key)
+                                                         (key_hash %key_hash))
+                                                     (or (nat %nat)
+                                                         (signature %signature))))
+                                                 (or
+                                                   (or (string %string)
+                                                       (mutez %tez))
+                                                   (timestamp %timestamp)))))
+                              (pair (address %owner) (option %ttl nat)))
+                            (option %validator nat))))
+          (map %validators nat address));
+```
+
+In this example, we originate the contract with initial values in the storage. We use the `MichelsonMap` class' of Taquito to initialize [the maps and the bigMap](https://tezostaquito.io/docs/maps_bigmaps). 
+
+As described above, the `map %data` uses a value that we chose between different types. When using Taquito, we need to surround the chosen argument with curly braces. In the current example, we initialize value in the `map %data` to the boolean true : `{ bool : true }`.
+
+Since every argument is identified by an annotation, we can ignore optional values if they are not needed. In the first entry of the `bigMap %records` of this example, we do not specify a value for the `address %address`, the `nat %ttl` and the `nat %validator`, but we define one for the `nat %validator` of the second entry of the bigMap.
+
+```js
+import { Tezos, MichelsonMap } from '@taquito/taquito';
+
+//%data
+const dataMap = new MichelsonMap();
+//key is a string, we choose a boolean for the value
+dataMap.set('Hello', { bool : true })
+
+//%records 
+const recordsBigMap = new MichelsonMap();
+recordsBigMap.set(
+    'FFFF', //key of the bigMap %records is in bytes
+    { //address %address is optional,
+      data : dataMap,
+      owner : 'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr',
+      //nat %ttl is optional
+      //nat %validator is optional
+    })
+recordsBigMap.set(
+    'AAAA', //key of the bigMap %records is in bytes
+    { //address %address is optional
+      data : dataMap,
+      owner : 'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr',
+      //nat %ttl is optional
+      validator : '1' //nat %validator is optional
+    })
+
+//%validators
+const validatorsMap = new MichelsonMap();
+//key is a nat, value is an address
+validatorsMap.set('1', 'tz1btkXVkVFWLgXa66sbRJa8eeUSwvQFX4kP')
+
+const originationOp = await Tezos.contract.originate({
+    code : contractJSON,
+    storage : {
+      owner : 'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', //address
+      records: recordsBigMap, 
+      validators : validatorsMap
+    }})
+
+const contract = await originationOp.contract()
+console.log(contract.address)
+```
+
+## Calling the function of a contract having a complex object as a parameter
+
+The contract contains a function named `set_child_record`. The parameter of the function is composed of nested pairs regrouping different datatypes (address, `map`, `bytes` and `nat`). Two of its arguments, the `address %address` and the `nat %ttl`, are optional. The `map %data` uses a `string` as its key and the user needs to choose the value of the `map` between different proposed types. 
+
+Here is the parameter of the function defined in Michelson :
+
+```
+(pair %set_child_record
+        (pair
+          (pair (option %address address)
+                (map %data string
+                           (or
+                             (or
+                               (or (or (address %address) (bool %bool))
+                                   (or (bytes %bytes) (int %int)))
+                               (or (or (key %key) (key_hash %key_hash))
+                                   (or (nat %nat) (signature %signature))))
+                             (or (or (string %string) (mutez %tez))
+                                 (timestamp %timestamp)))))
+          (pair (bytes %label) (address %owner)))
+        (pair (bytes %parent) (option %ttl nat)))
+```
+
+The way to write the parameter when calling the function of a contract with Taquito differs from the way of writing its storage during the origination step. When calling the contract function, we do not write the annotations of the arguments (nor the indexes). So the order of the arguments is important. Before calling the contract function, it may be useful to use Taquito's `toTransferParams` method to inspect the parameter.
+
+#### Inspect parameter
+
+```js live noInline
+import { Tezos, MichelsonMap } from '@taquito/taquito';
+
+Tezos.importKey(emailExample, passwordExample, mnemonicExample, secretExample)
+.then(signer => {
+    return Tezos.contract.at('KT1JjYmy6q4xxZGL4qXQGkSra7xNtrEpQ85K')
+}).then(myContract => {
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", { bool : true })
+    let inspect = myContract.methods.set_child_record('tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', dataMap, 'EEEE', 'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', 'FFFF', '10').toTransferParams(); 
+    println(JSON.stringify(inspect, null, 2))
+}).catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
+```
+
+#### Call the set_child_record function when all the arguments are defined
+
+```js live noInline
+import { Tezos, MichelsonMap } from '@taquito/taquito';
+
+Tezos.importKey(emailExample, passwordExample, mnemonicExample, secretExample)
+.then(signer => {
+    return Tezos.contract.at('KT1JjYmy6q4xxZGL4qXQGkSra7xNtrEpQ85K')
+}).then(myContract => {
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", { bool : true })
+  
+    return myContract.methods.set_child_record(
+      'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', //address(optional)
+      dataMap, //data
+      'EEEE', //label
+      'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', //owner
+      'FFFF', //parent
+      '10' //ttl(optional)
+    ).send(); 
+}).then(op => {
+    println(`Waiting for ${op.hash} to be confirmed...`);
+    return op.confirmation(1).then(() => op.hash);
+}).then(hash => {
+    println(`Operation injected: https://better-call.dev/carthagenet/KT1JjYmy6q4xxZGL4qXQGkSra7xNtrEpQ85K/operations`);
+}).catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
+```
+#### Call the set_child_record function when optional arguments are null
+
+The `address %address` and the `nat %ttl` of the `set_child_record` function are optional. If we want one or both to be null, we must specify the value of the argument as `null` or `undefined`.
+
+```js live noInline
+import { Tezos, MichelsonMap } from '@taquito/taquito';
+
+Tezos.importKey(emailExample, passwordExample, mnemonicExample, secretExample)
+.then(signer => {
+    return Tezos.contract.at('KT1JjYmy6q4xxZGL4qXQGkSra7xNtrEpQ85K')
+}).then(myContract => {
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", { nat : '3' })
+  
+    return myContract.methods.set_child_record(
+      null, //address(optional)
+      dataMap, //data
+      'EEEE', //label
+      'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', //owner
+      'FFFF', //parent
+      undefined //ttl(optional)
+    ).send(); 
+}).then(op => {
+    println(`Waiting for ${op.hash} to be confirmed...`);
+    return op.confirmation(1).then(() => op.hash);
+}).then(hash => {
+    println(`Operation injected: https://better-call.dev/carthagenet/KT1JjYmy6q4xxZGL4qXQGkSra7xNtrEpQ85K/operations`);
+}).catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
+```

--- a/docs/complex_parameters.md
+++ b/docs/complex_parameters.md
@@ -1,5 +1,5 @@
 ---
-title: Working with contracts having complexe storage/parameters
+title: Working with contracts having complex storage/parameters
 author: Roxane Letourneau
 ---
 

--- a/docs/maps_bigmaps.md
+++ b/docs/maps_bigmaps.md
@@ -24,7 +24,7 @@ Michelson offers two variants of `Maps` that are semantically the same but have 
 
 This example builds on the Ligo Lang Taco Shop learning resources.
 
-The storage of the contract used in the following example is a map where a key is a natural number (a `nat`), and a value is a pair composed of two values representing the quantity of stock and `tez` tokens respectively. The source code of the contract can is available [here](https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-smart-contract#making-sure-we-get-paid-for-our-tacos). In the example, the contract is originated with initial values using the `MichelsonMap` class' `set` method.
+The storage of the contract used in the following example is a map where a key is a natural number (a `nat`), and a value is a pair composed of two values representing the quantity of stock and `tez` tokens respectively. The source code of the contract is available [here](https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-smart-contract#making-sure-we-get-paid-for-our-tacos). In the example, the contract is originated with initial values using the `MichelsonMap` class' `set` method.
 
 ```js live noInline
 import { MichelsonMap } from "@taquito/taquito";

--- a/docs/originate.md
+++ b/docs/originate.md
@@ -39,7 +39,7 @@ Is equivilent to this Michelson expression
 Pair 0 (Pair 1 {"edpkuLxx9PQD8fZ45eUzrK3BhfDZJHhBuK4Zi49DcEGANwd2rpX82t"})
 ```
 
-As you cal see, the property names are discarded. The order of your properties is crucial!
+As you can see, the property names are discarded. The order of your properties is crucial!
 
 ### a. Initializing storage using a JavaScript object
 

--- a/packages/taquito-michelson-encoder/data/sample15.ts
+++ b/packages/taquito-michelson-encoder/data/sample15.ts
@@ -1,0 +1,197 @@
+export const setChildRecordParam = {
+  "prim": "pair",
+  "args": [
+    {
+      "prim": "pair",
+      "args": [
+        {
+          "prim": "pair",
+          "args": [
+            {
+              "prim": "option",
+              "args": [
+                {
+                  "prim": "address"
+                }
+              ],
+              "annots": [
+                "%address"
+              ]
+            },
+            {
+              "prim": "map",
+              "args": [
+                {
+                  "prim": "string"
+                },
+                {
+                  "prim": "or",
+                  "args": [
+                    {
+                      "prim": "or",
+                      "args": [
+                        {
+                          "prim": "or",
+                          "args": [
+                            {
+                              "prim": "or",
+                              "args": [
+                                {
+                                  "prim": "address",
+                                  "annots": [
+                                    "%address"
+                                  ]
+                                },
+                                {
+                                  "prim": "bool",
+                                  "annots": [
+                                    "%bool"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "prim": "or",
+                              "args": [
+                                {
+                                  "prim": "bytes",
+                                  "annots": [
+                                    "%bytes"
+                                  ]
+                                },
+                                {
+                                  "prim": "int",
+                                  "annots": [
+                                    "%int"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "or",
+                          "args": [
+                            {
+                              "prim": "or",
+                              "args": [
+                                {
+                                  "prim": "key",
+                                  "annots": [
+                                    "%key"
+                                  ]
+                                },
+                                {
+                                  "prim": "key_hash",
+                                  "annots": [
+                                    "%key_hash"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "prim": "or",
+                              "args": [
+                                {
+                                  "prim": "nat",
+                                  "annots": [
+                                    "%nat"
+                                  ]
+                                },
+                                {
+                                  "prim": "signature",
+                                  "annots": [
+                                    "%signature"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "prim": "or",
+                      "args": [
+                        {
+                          "prim": "or",
+                          "args": [
+                            {
+                              "prim": "string",
+                              "annots": [
+                                "%string"
+                              ]
+                            },
+                            {
+                              "prim": "mutez",
+                              "annots": [
+                                "%tez"
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "prim": "timestamp",
+                          "annots": [
+                            "%timestamp"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "annots": [
+                "%data"
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "pair",
+          "args": [
+            {
+              "prim": "bytes",
+              "annots": [
+                "%label"
+              ]
+            },
+            {
+              "prim": "address",
+              "annots": [
+                "%owner"
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "prim": "pair",
+      "args": [
+        {
+          "prim": "bytes",
+          "annots": [
+            "%parent"
+          ]
+        },
+        {
+          "prim": "option",
+          "args": [
+            {
+              "prim": "nat"
+            }
+          ],
+          "annots": [
+            "%ttl"
+          ]
+        }
+      ]
+    }
+  ],
+  "annots": [
+    "%set_child_record"
+  ]
+}
+
+export const updateDetailsParam =  { "prim": "pair","args":[ { "prim": "pair","args":[ { "prim": "int", "annots": [ "%id" ] },{ "prim": "option","args": [ { "prim": "address" } ],"annots": [ "%new_controller" ] } ] },{ "prim": "option","args": [ { "prim": "bytes" } ],"annots": [ "%new_profile" ] } ],"annots": [ "%update_details" ] }

--- a/packages/taquito-michelson-encoder/src/tokens/option.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/option.ts
@@ -25,9 +25,12 @@ export class OptionToken extends Token {
     const value = args;
     if (
       value === undefined ||
-      value === null ||
-      (Array.isArray(value) && (value[0] === undefined || value[0] === null))
+      value === null
     ) {
+      return { prim: 'None' };
+    }
+    else if ((Array.isArray(value) && (value[value.length-1] === undefined || value[value.length-1] === null))) {
+      value.pop();
       return { prim: 'None' };
     }
 

--- a/packages/taquito-michelson-encoder/test/sample15.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample15.spec.ts
@@ -1,0 +1,523 @@
+import { setChildRecordParam, updateDetailsParam } from '../data/sample15';
+import { ParameterSchema } from '../src/schema/parameter';
+import { MichelsonMap } from '../src/michelson-map';
+
+describe('Schema test when calling contract with complex object as param and null value', () => {
+
+  it('Should encode parameter schema properly', () => {
+    const schema = new ParameterSchema(setChildRecordParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      'tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5', //address(optional)
+      dataMap,//data
+      'AAAA', //label
+      'tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5', //owner
+      'FFFF', //parent
+      '1' //ttl(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "prim": "Some",
+                  "args": [
+                    {
+                      "string": "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
+                    }
+                  ]
+                },
+                [
+                  {
+                    "prim": "Elt",
+                    "args": [
+                      {
+                        "string": "Hello World"
+                      },
+                      {
+                        "prim": "Left",
+                        "args": [
+                          {
+                            "prim": "Left",
+                            "args": [
+                              {
+                                "prim": "Left",
+                                "args": [
+                                  {
+                                    "prim": "Right",
+                                    "args": [
+                                      {
+                                        "prim": "True"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "bytes": "AAAA"
+                },
+                {
+                  "string": "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "bytes": "FFFF"
+            },
+            {
+              "prim": "Some",
+              "args": [
+                {
+                  "int": "1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly when first element which is optional is null', () => {
+    const schema = new ParameterSchema(setChildRecordParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      null, //address(optional)
+      dataMap,//data
+      'AAAA', //label
+      'tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5', //owner
+      'FFFF', //parent
+      '1' //ttl(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "prim": "None"
+                },
+                [
+                  {
+                    "prim": "Elt",
+                    "args": [
+                      {
+                        "string": "Hello World"
+                      },
+                      {
+                        "prim": "Left",
+                        "args": [
+                          {
+                            "prim": "Left",
+                            "args": [
+                              {
+                                "prim": "Left",
+                                "args": [
+                                  {
+                                    "prim": "Right",
+                                    "args": [
+                                      {
+                                        "prim": "True"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "bytes": "AAAA"
+                },
+                {
+                  "string": "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "bytes": "FFFF"
+            },
+            {
+              "prim": "Some",
+              "args": [
+                {
+                  "int": "1"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly when last element which is optional is null', () => {
+    const schema = new ParameterSchema(setChildRecordParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      'tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5', //address(optional)
+      dataMap,//data
+      'AAAA', //label
+      'tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5', //owner
+      'FFFF', //parent
+      null //ttl(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "prim": "Some",
+                  "args": [
+                    {
+                      "string": "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
+                    }
+                  ]
+                },
+                [
+                  {
+                    "prim": "Elt",
+                    "args": [
+                      {
+                        "string": "Hello World"
+                      },
+                      {
+                        "prim": "Left",
+                        "args": [
+                          {
+                            "prim": "Left",
+                            "args": [
+                              {
+                                "prim": "Left",
+                                "args": [
+                                  {
+                                    "prim": "Right",
+                                    "args": [
+                                      {
+                                        "prim": "True"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "bytes": "AAAA"
+                },
+                {
+                  "string": "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "bytes": "FFFF"
+            },
+            {
+              "prim": "None"
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly when first and last element which are optional are null', () => {
+    const schema = new ParameterSchema(setChildRecordParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      null, //address(optional)
+      dataMap,//data
+      'AAAA', //label
+      'tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5', //owner
+      'FFFF', //parent
+      null //ttl(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "prim": "None"
+                },
+                [
+                  {
+                    "prim": "Elt",
+                    "args": [
+                      {
+                        "string": "Hello World"
+                      },
+                      {
+                        "prim": "Left",
+                        "args": [
+                          {
+                            "prim": "Left",
+                            "args": [
+                              {
+                                "prim": "Left",
+                                "args": [
+                                  {
+                                    "prim": "Right",
+                                    "args": [
+                                      {
+                                        "prim": "True"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              ]
+            },
+            {
+              "prim": "Pair",
+              "args": [
+                {
+                  "bytes": "AAAA"
+                },
+                {
+                  "string": "tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "bytes": "FFFF"
+            },
+            {
+              "prim": "None"
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly', () => {
+    const schema = new ParameterSchema(updateDetailsParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      '5',//id
+      'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', //new_controller(optional)
+      'AAAA', //new_profile(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "int": "5"
+            },
+            {
+              "prim": "Some",
+              "args": [
+                {
+                  "string": "tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "Some",
+          "args": [
+            {
+              "bytes": "AAAA"
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly if last element which is optinal is null', () => {
+    const schema = new ParameterSchema(updateDetailsParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      '5',//id
+      'tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr', //new_controller(optional)
+      null, //new_profile(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "int": "5"
+            },
+            {
+              "prim": "Some",
+              "args": [
+                {
+                  "string": "tz1PgQt52JMirBUhhkq1eanX8hVd1Fsg71Lr"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "prim": "None"
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly if second and last elements which are optional are null', () => {
+    const schema = new ParameterSchema(updateDetailsParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      '5',//id
+      null, //new_controller(optional)
+      null, //new_profile(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "int": "5"
+            },
+            {
+              "prim": "None"
+            }
+          ]
+        },
+        {
+          "prim": "None"
+        }
+      ]
+    });
+  });
+
+  it('Should encode parameter schema properly if second element which is optional is null', () => {
+    const schema = new ParameterSchema(updateDetailsParam);
+    const dataMap = new MichelsonMap();
+    dataMap.set("Hello World", {bool:true})
+    const result = schema.Encode(
+      '5',//id
+      null, //new_controller(optional)
+      'AAAA', //new_profile(optional)
+    );
+    expect(schema).toBeTruthy();
+    expect(result).toEqual({
+      "prim": "Pair",
+      "args": [
+        {
+          "prim": "Pair",
+          "args": [
+            {
+              "int": "5"
+            },
+            {
+              "prim": "None"
+            }
+          ]
+        },
+        {
+          "prim": "Some",
+          "args": [
+            {
+              "bytes": "AAAA"
+            }
+          ]
+        }
+      ]
+    });
+  });
+
+});

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -24,6 +24,13 @@
             ]
         },
         {
+            "type": "category",
+            "label": "Advanced",
+            "items": [
+                "complex_parameters"
+            ]
+        },
+        {
             "type": "link",
             "label": "TypeDoc Reference",
             "href": "https://tezostaquito.io/typedoc"

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -98,6 +98,13 @@ const contractMap8pairs =
 //contract for map and bigmap combined example
 const contractMapBigMap = 
 [ { "prim": "parameter", "args": [ { "prim": "unit" } ] },{ "prim": "storage","args":[ { "prim": "pair","args":[ { "prim": "big_map","args":[ { "prim": "pair","args": [ { "prim": "nat" }, { "prim": "address" } ] },{ "prim": "int" } ], "annots": [ "%thebigmap" ] },{ "prim": "map","args":[ { "prim": "pair","args": [ { "prim": "nat" }, { "prim": "address" } ] },{ "prim": "int" } ], "annots": [ "%themap" ] } ] } ] },{ "prim": "code","args":[ [ { "prim": "DUP" }, { "prim": "CDR" },{ "prim": "NIL", "args": [ { "prim": "operation" } ] },{ "prim": "PAIR" },{ "prim": "DIP", "args": [ [ { "prim": "DROP" } ] ] } ] ] } ]
+
+//signer for example with complex storage/parameters
+const emailExample = "zsjpcmui.oysiavbv@tezos.example.org"
+const passwordExample = "4rW0D22yXt"
+const mnemonicExample = "arrange ceiling whisper churn congress double step carpet empty rice prevent swallow silk casual champion"
+const secretExample = "af552679c4943509bd77643b8ef3f8dcf42e61b3"
+
 `;
 
     this.transpile({ code, scope, transformCode, noInline });


### PR DESCRIPTION
Fixed the Encode function of option.ts to remove optional value from the array of args when its value is null or undefined.
Added tests