### PR TITLE
fix(dep) Add dep to RPC for MichelsonV1Expression type

### DIFF
--- a/packages/taquito-michelson-encoder/package.json
+++ b/packages/taquito-michelson-encoder/package.json
@@ -68,6 +68,7 @@
   },
   "dependencies": {
     "@taquito/utils": "^6.3.5-beta.0",
+    "@taquito/rpc": "^6.3.5-beta.0",
     "bignumber.js": "^9.0.0",
     "fast-json-stable-stringify": "^2.1.0"
   },


### PR DESCRIPTION
Closes #409 

## Release Note Draft Snippet

Update dependencies for `@taquito/michelson-encoder` to include the RPC package, as the encoder depends on `MichelsonV1Expression` which is defined in the RPC pacakge.