### PR TITLE
fix(subscribe): subscription should not die on rpc error

### DIFF
--- a/example/example-streamer.ts
+++ b/example/example-streamer.ts
@@ -3,7 +3,7 @@ import { Tezos } from '@taquito/taquito';
 
 async function example() {
   const provider = 'https://api.tez.ie/rpc/mainnet';
-  Tezos.setProvider({ rpc: provider });
+  Tezos.setProvider({ rpc: provider, config: {shouldObservableSubscriptionRetry: true} });
   try {
 
     const bakerEndorsementFilter = {

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -18,16 +18,21 @@ export interface TaquitoProvider<T, K extends Array<any>> {
   new (context: Context, ...rest: K): T;
 }
 
+// The shouldObservableSubscriptionRetrythe parameter is related to the observable in ObservableSubsription class. 
+// When set to true, the observable won't die when getBlock rpc call fails; the error will be reported via the error callback, 
+// and it will continue to poll for new blocks.
 export interface Config {
   confirmationPollingIntervalSecond?: number;
   confirmationPollingTimeoutSecond?: number;
   defaultConfirmationCount?: number;
+  shouldObservableSubscriptionRetry?: boolean;
 }
 
 export const defaultConfig: Required<Config> = {
   confirmationPollingIntervalSecond: 10,
   defaultConfirmationCount: 1,
   confirmationPollingTimeoutSecond: 180,
+  shouldObservableSubscriptionRetry: false
 };
 
 /**

--- a/packages/taquito/src/subscribe/observable-subscription.ts
+++ b/packages/taquito/src/subscribe/observable-subscription.ts
@@ -8,7 +8,7 @@ export class ObservableSubscription<T> implements Subscription<T> {
   private closeListeners: Array<() => void> = [];
   private completed$ = new Subject();
 
-  constructor(obs: Observable<T>) {
+  constructor(obs: Observable<T>, private shouldRetry: boolean = false) {
     obs
       .pipe(
         takeUntil(this.completed$),
@@ -23,7 +23,7 @@ export class ObservableSubscription<T> implements Subscription<T> {
             this.call(this.closeListeners);
           }
         ),
-        retry()
+        this.shouldRetry ? retry() : tap(),
       )
       .subscribe();
   }

--- a/packages/taquito/src/subscribe/polling-provider.ts
+++ b/packages/taquito/src/subscribe/polling-provider.ts
@@ -47,10 +47,10 @@ export class PollingSubscribeProvider implements SubscribeProvider {
   constructor(private context: Context, public readonly POLL_INTERVAL = 20000) {}
 
   subscribe(_filter: 'head'): Subscription<string> {
-    return new ObservableSubscription(this.newBlock$.pipe(pluck('hash')));
+    return new ObservableSubscription(this.newBlock$.pipe(pluck('hash')), this.context.config.shouldObservableSubscriptionRetry);
   }
 
   subscribeOperation(filter: Filter): Subscription<OperationContent> {
-    return new ObservableSubscription(this.newBlock$.pipe(applyFilter(filter)));
+    return new ObservableSubscription(this.newBlock$.pipe(applyFilter(filter)), this.context.config.shouldObservableSubscriptionRetry);
   }
 }

--- a/packages/taquito/test/subscribe/observable-subscription.spec.ts
+++ b/packages/taquito/test/subscribe/observable-subscription.spec.ts
@@ -1,0 +1,65 @@
+import { defer } from 'rxjs';
+import { rxSandbox } from 'rx-sandbox';
+import { ObservableSubscription } from '../../src/subscribe/observable-subscription';
+
+describe('Observable subscription test', () => {
+    it('the observable emits 3 data', async (done) => {
+        const { cold, flush } = rxSandbox.create();
+        let stub = jest.fn();
+        let observable$ = cold('a-b-c');
+        const subscriber = new ObservableSubscription(observable$, true);
+        subscriber.on('data', stub);
+
+        flush();
+
+        expect(stub).toBeCalledTimes(3);                
+        done();
+    })
+
+    it('the observable retries on error when the property "shouldRetry" is set to true', async (done) => {
+        const { cold, flush } = rxSandbox.create();
+        let stub = jest.fn();
+        let errStub = jest.fn();
+        let value = ['a-#', 'b-#', 'c'];
+        let i = 0;
+        let observable$ = defer(() => {
+            return cold(value[i++])
+        });
+        const subscriber = new ObservableSubscription(observable$, true);
+        subscriber.on('data', stub);
+        subscriber.on('error', errStub);
+
+        flush();
+
+        expect(stub).toBeCalledTimes(3);
+        expect(errStub).toBeCalledTimes(2);
+            
+        done();
+    })
+
+    it('the observable does not retry on error when the property "shouldRetry" is set to false', async (done) => {
+        const { cold, flush } = rxSandbox.create();
+        let stub = jest.fn();
+        let errStub = jest.fn();
+        let value = ['a-#', 'b-#', 'c'];
+        let i = 0;
+        let observable$ = defer(() => {
+            return cold(value[i++])
+        });
+        const subscriber = new ObservableSubscription(observable$, false);
+        subscriber.on('data', stub);
+        subscriber.on('error', errStub);
+
+        flush();
+
+        expect(stub).toBeCalledTimes(1);
+        expect(errStub).toBeCalledTimes(1);
+            
+        done();
+})
+
+});
+
+
+
+


### PR DESCRIPTION
currently, the observable in ObservableSubsription dies when getBlock rpc call fails. This change
makes it report the error via the error callback, but it continues to poll for new blocks

fix #430

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [X] Your code builds cleanly without any errors or warnings
- [NA] You have added unit tests
- [NA] You have added integration tests (if relevant/appropriate)
- [NA] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [NA] You have added or updated corresponding documentation
- [NA] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
