### PR TITLE
re #432 provide better transfer api - implement estimate utility

### DIFF
--- a/docs/alternative_transfer_api.md
+++ b/docs/alternative_transfer_api.md
@@ -1,0 +1,25 @@
+---
+title: Alternative Implementation of the Transfer utilities
+---
+Taquito's transfer api can be used alternatively, demostrated in the following documentation.
+
+##  Current Implementation - 
+Current implementation implements Taquito's estimate method, which can be used to estimate fees, gas and storage associated with an operation.
+
+### Estimate utility - Estimate a transfer operation
+
+The following example shows an estimate of the fees associated with transferring 2.1ꜩ to `tz1VtHKUzDac9oGUmt2ReLrPj3kh3zyzF6GR` address. For demonstration purpose, the signer is configured using a throw-away private key.
+
+```js live noInline
+const amount = 2.1;
+const address = 'tz1VtHKUzDac9oGUmt2ReLrPj3kh3zyzF6GR';
+
+println(`Estimating the transfer of ${amount} ꜩ to ${address} : `);
+Tezos.transfer({ to: address, amount: amount })._estimate()
+  .then(est => {
+    println(gasLimit : ${est._gasLimit},  
+    storageLimit : ${est._storageLimit},
+    usingBaseFeeMutez : ${est.baseFeeMutez}`);
+  })
+  .catch(error => console.table(`Error: ${JSON.stringify(error, null, 2)}`));
+```

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -6,6 +6,7 @@ import { Injector } from './injector/interface';
 import { RpcInjector } from './injector/rpc-injector';
 import { Signer } from './signer/interface';
 import { NoopSigner } from './signer/noop';
+import { TransferProvider } from './contract/rpc-transfer-provider';
 import { OperationFactory } from './wallet/opreation-factory';
 import { RpcTzProvider } from './tz/rpc-tz-provider';
 import { RPCEstimateProvider } from './contract/rpc-estimate-provider';
@@ -42,6 +43,7 @@ export class Context {
   public readonly tz = new RpcTzProvider(this);
   public readonly estimate = new RPCEstimateProvider(this);
   public readonly contract = new RpcContractProvider(this, this.estimate);
+  public readonly transfer = new TransferProvider(this);
   public readonly batch = new RPCBatchProvider(this, this.estimate);
   public readonly wallet = new Wallet(this);
 

--- a/packages/taquito/src/contract/rpc-transfer-provider.ts
+++ b/packages/taquito/src/contract/rpc-transfer-provider.ts
@@ -1,0 +1,147 @@
+import { Context } from "../context";
+import BigNumber from 'bignumber.js';
+import { TransferParams, PrepareOperationParams, isOpWithFee } from "../operations/types";
+import { OperationEmitter } from "../operations/operation-emitter";
+import { Estimate } from "./estimate";
+import { createTransferOperation } from "./prepare";
+import { RPCRunOperationParam, PreapplyResponse } from "@taquito/rpc";
+import { flattenErrors, TezosOperationError, flattenOperationResult } from "../operations/operation-errors";
+
+// RPC requires a signature but does not verify it
+const SIGNATURE_STUB =
+    'edsigtkpiSSschcaCt9pUVrpNPf7TTcgvgDEDD6NCEHMy8NNQJCGnMfLZzYoQj74yLjo9wx6MPVV29CvVzgi7qEcEUok3k7AuMg';
+
+interface Limits {
+    fee?: number;
+    storageLimit?: number;
+    gasLimit?: number;
+}
+
+const mergeLimits = (
+    userDefinedLimit: Limits,
+    defaultLimits: Required<Limits>
+): Required<Limits> => {
+    return {
+        fee: typeof userDefinedLimit.fee === 'undefined' ? defaultLimits.fee : userDefinedLimit.fee,
+        gasLimit:
+            typeof userDefinedLimit.gasLimit === 'undefined'
+                ? defaultLimits.gasLimit
+                : userDefinedLimit.gasLimit,
+        storageLimit:
+            typeof userDefinedLimit.storageLimit === 'undefined'
+                ? defaultLimits.storageLimit
+                : userDefinedLimit.storageLimit,
+    };
+};
+
+export class TransferProvider extends OperationEmitter {
+    private _context: Context;
+    private _transferParams!: TransferParams;
+    private readonly ALLOCATION_STORAGE = 257;
+    private readonly ORIGINATION_STORAGE = 257;
+
+    constructor(context: Context) {
+        super(context);
+        // currently we are not using context, but has been added for future usage
+        this._context = context;
+        // this._transferParams = null;
+    }
+
+    // Maximum values defined by the protocol
+    private async getAccountLimits(pkh: string) {
+        const balance = await this.rpc.getBalance(pkh);
+        const {
+            hard_gas_limit_per_operation,
+            hard_storage_limit_per_operation,
+            cost_per_byte,
+        } = await this.rpc.getConstants();
+        return {
+            fee: 0,
+            gasLimit: hard_gas_limit_per_operation.toNumber(),
+            storageLimit: Math.floor(
+                BigNumber.min(balance.dividedBy(cost_per_byte), hard_storage_limit_per_operation).toNumber()
+            ),
+        };
+    }
+
+    transfer = (transferParams: TransferParams) => {
+        // do the magic
+        this._transferParams = transferParams;
+        return this;
+    }
+
+    private createEstimateFromOperationContent(
+        content: PreapplyResponse['contents'][0],
+        size: number
+    ) {
+        const operationResults = flattenOperationResult({ contents: [content] });
+        let totalGas = 0;
+        let totalStorage = 0;
+        operationResults.forEach(result => {
+            totalStorage +=
+                'originated_contracts' in result && typeof result.originated_contracts !== 'undefined'
+                    ? result.originated_contracts.length * this.ORIGINATION_STORAGE
+                    : 0;
+            totalStorage += 'allocated_destination_contract' in result ? this.ALLOCATION_STORAGE : 0;
+            totalGas += Number(result.consumed_gas) || 0;
+            totalStorage +=
+                'paid_storage_size_diff' in result ? Number(result.paid_storage_size_diff) || 0 : 0;
+        });
+
+        if (isOpWithFee(content)) {
+            return new Estimate(totalGas || 0, Number(totalStorage || 0), size);
+        } else {
+            return new Estimate(0, 0, size, 0);
+        }
+    }
+
+    private async createEstimate(params: PrepareOperationParams) {
+        const {
+            opbytes,
+            opOb: { branch, contents },
+        } = await this.prepareAndForge(params);
+
+        let operation: RPCRunOperationParam = {
+            operation: { branch, contents, signature: SIGNATURE_STUB },
+            chain_id: await this.rpc.getChainId(),
+        };
+
+        const { opResponse } = await this.simulate(operation);
+
+        const errors = [...flattenErrors(opResponse, 'backtracked'), ...flattenErrors(opResponse)];
+
+        // Fail early in case of errors
+        if (errors.length) {
+            throw new TezosOperationError(errors);
+        }
+
+        while (
+            opResponse.contents.length !== (Array.isArray(params.operation) ? params.operation.length : 1)
+        ) {
+            opResponse.contents.shift();
+        }
+
+        return opResponse.contents.map(x => {
+            return this.createEstimateFromOperationContent(
+                x,
+                opbytes.length / 2 / opResponse.contents.length
+            );
+        });
+    }
+
+
+    async _estimate() {
+        const { fee, storageLimit, gasLimit, ...rest } = this._transferParams;
+        const pkh = await this.signer.publicKeyHash();
+        const DEFAULT_PARAMS = await this.getAccountLimits(pkh);
+        const op = await createTransferOperation({
+            ...rest,
+            ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
+        });
+        return (await this.createEstimate({ operation: op, source: pkh }))[0];
+    }
+
+    send() {
+        return 'send';
+    }
+}

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -206,6 +206,13 @@ export class TezosToolkit {
   }
 
   /**
+   * @description Provide access to transfer utilities
+   */
+  get transfer() {
+    return this._context.transfer.transfer;
+  }
+
+  /**
    * @description Provide access to streaming utilities backed by an streamer implementation
    */
   get stream(): SubscribeProvider {

--- a/packages/taquito/src/transfer/interface.ts
+++ b/packages/taquito/src/transfer/interface.ts
@@ -1,0 +1,12 @@
+import { Estimate } from "../contract/estimate";
+
+/**
+ * @description Transfer interface for providing transfer utilities
+ */
+export interface Transfer {
+    /**
+     * @description Return transfer estimate
+     */
+    estimate(): Promise<Estimate>;
+  }
+  

--- a/packages/taquito/src/transfer/no-op.ts
+++ b/packages/taquito/src/transfer/no-op.ts
@@ -1,0 +1,22 @@
+import { Estimate } from '../contract/estimate';
+import { TransferParams } from '../operations/types';
+import { Transfer } from './interface';
+
+export class UnconfiguredTransferParamsError implements Error {
+    name = 'UnconfiguredTransferParamsError';
+    message =
+        'No transfer parameters. Please configure by passing values to transfer(params).';
+}
+
+/**
+ * @description Default signer implementation which does nothing and produce invalid signature
+ */
+export class NoOpTransfer implements Transfer {
+    transferParams: TransferParams;
+    constructor() {
+        this.transferParams = { to: '', amount: 0 };
+    }
+    async estimate(): Promise<Estimate> {
+        throw new UnconfiguredTransferParamsError();
+    }
+}

--- a/packages/taquito/test/contract/transfer.spec.ts
+++ b/packages/taquito/test/contract/transfer.spec.ts
@@ -1,7 +1,7 @@
 import { importKey } from "@taquito/signer";
 import { TezosToolkit } from "../../src/taquito";
 
-describe('Tranfer tests', () => {
+describe('Transfer tests', () => {
     let mockRpcClient: any;
     let toolkit: TezosToolkit;
 
@@ -14,7 +14,7 @@ describe('Tranfer tests', () => {
         importKey(toolkit, FAUCET_KEY.email, FAUCET_KEY.password, FAUCET_KEY.mnemonic.join(' '), FAUCET_KEY.secret);
     });
 
-    it('Verify transfer estimate', async done => {
+    it('should provide transfer estimate', async done => {
         jest.setTimeout(60000 * 10);
         const estimate = await toolkit.transfer({ to: 'tz1VtHKUzDac9oGUmt2ReLrPj3kh3zyzF6GR', amount: 2.1 })._estimate();
         expect(estimate).toMatchObject({

--- a/packages/taquito/test/contract/transfer.spec.ts
+++ b/packages/taquito/test/contract/transfer.spec.ts
@@ -1,0 +1,28 @@
+import { importKey } from "@taquito/signer";
+import { TezosToolkit } from "../../src/taquito";
+
+describe('Tranfer tests', () => {
+    let mockRpcClient: any;
+    let toolkit: TezosToolkit;
+
+    beforeEach(() => {
+
+        toolkit = new TezosToolkit();
+        toolkit.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
+
+        const FAUCET_KEY = { "mnemonic": ["unknown", "hub", "eye", "sport", "walk", "oil", "outdoor", "donkey", "poet", "expire", "just", "indicate", "response", "lawsuit", "thank"], "secret": "71c2c58c6b1fadef14fd5ac8f380ee595b804938", "amount": "40032467721", "pkh": "tz1VtHKUzDac9oGUmt2ReLrPj3kh3zyzF6GR", "password": "1knvgG5AQJ", "email": "lrsfvdev.aomudkjy@tezos.example.org" };
+        importKey(toolkit, FAUCET_KEY.email, FAUCET_KEY.password, FAUCET_KEY.mnemonic.join(' '), FAUCET_KEY.secret);
+    });
+
+    it('Verify transfer estimate', async done => {
+        jest.setTimeout(60000 * 10);
+        const estimate = await toolkit.transfer({ to: 'tz1VtHKUzDac9oGUmt2ReLrPj3kh3zyzF6GR', amount: 2.1 })._estimate();
+        expect(estimate).toMatchObject({
+            _gasLimit: 10207,
+            _storageLimit: 0,
+            opSize: 92,
+            baseFeeMutez: 100
+        });
+        done();
+    });
+});


### PR DESCRIPTION
`Tezos.estimate.transfer({})` is also available as `Tezos.transfer({})._estimate()` as a partial fix re #432 .
Does not break the current code.

==========================================

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:
- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [x] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

### Transfer API
A new API for making estimate for transfer requests has been added.
