### PR TITLE
Removed the Tezos function

### DIFF
--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -18,7 +18,7 @@ When creating an instance of the TezosToolkit, it is now required to specify the
 
 **Change required:**
 
-Before version 7:
+Before version 7:  
 ``` js
 import { TezosToolkit } from '@taquito/taquito';
 const tezos = new TezosToolkit();
@@ -26,15 +26,15 @@ const tezos = new TezosToolkit();
 // or
 
 import { Tezos } from '@taquito/taquito';
-// ready to use Tezos singleton
+// ready-to-use Tezos singleton
 ```
 
-With version 7:
+Since version 7:
 ``` js
 import { TezosToolkit } from '@taquito/taquito';
 const tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL_NOW_REQUIRED');
 
-// or the ones that were using the Tezos singleton can considered naming the variable as the singleton to avoid having the rename it everywhere in their code:
+// Those who were using the Tezos singleton may consider naming the variable like the singleton to avoid renaming it everywhere in their code:
 const Tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL_NOW_REQUIRED');
 ```
 

--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -14,20 +14,28 @@ Before version 7, Taquito was configured to use our default RPC node; the defaul
 
 However, in version 7 of Taquito, we decided to remove the default RPC node. The reason behind this choice is to avoid that a lot of applications rely on our default node and thus centralize a part of the ecosystem on one node.
 
-When creating an instance of the TezosToolkit, it is now required to specify the RPC node. The Tezos singleton has been replaced by a function taking an RPC node as a parameter. Both ways are equivalent, and the second one has been kept for users familiar with the Tezos singleton.
+When creating an instance of the TezosToolkit, it is now required to specify the RPC node. The Tezos singleton is no longer supported.
 
 **Change required:**
 
-~~const tezos = new TezosToolkit()~~
-
+Before version 7:
 ``` js
 import { TezosToolkit } from '@taquito/taquito';
-const tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL');
+const tezos = new TezosToolkit();
 
 // or
 
-import { Tezos } '@taquito/taquito';
-const tezos = Tezos('https://YOUR_PREFERRED_RPC_URL');
+import { Tezos } from '@taquito/taquito';
+// ready to use Tezos singleton
+```
+
+With version 7:
+``` js
+import { TezosToolkit } from '@taquito/taquito';
+const tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL_NOW_REQUIRED');
+
+// or the ones that were using the Tezos singleton can considered naming the variable as the singleton to avoid having the rename it everywhere in their code:
+const Tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL_NOW_REQUIRED');
 ```
 
 Here is an example of the compilation error you would get when updating Taquito to version 7, if the RPC URL is not specified: 

--- a/example/contract-origination.ts
+++ b/example/contract-origination.ts
@@ -1,10 +1,10 @@
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import { importKey } from '@taquito/signer';
 
 const provider = 'https://api.tez.ie/rpc/carthagenet';
 
 async function example() {
-  const tezos = Tezos(provider);
+  const tezos = new TezosToolkit(provider);
   await importKey(
     tezos,
     'peqjckge.qkrrajzs@tezos.example.org',

--- a/example/contract-origination2.ts
+++ b/example/contract-origination2.ts
@@ -1,11 +1,11 @@
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import { ligoSample } from '../integration-tests/data/ligo-simple-contract';
 
 import { importKey } from '@taquito/signer';
 const provider = 'https://api.tez.ie/rpc/carthagenet';
 
 async function example() {
-  const tezos = Tezos(provider)
+  const tezos = new TezosToolkit(provider)
   await importKey(
     tezos,
     'peqjckge.qkrrajzs@tezos.example.org',

--- a/example/contract-origination3.ts
+++ b/example/contract-origination3.ts
@@ -1,10 +1,10 @@
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import { voteInitSample, voteSample } from '../integration-tests/data/vote-contract';
 const provider = 'https://api.tez.ie/rpc/carthagenet';
 import { importKey } from '@taquito/signer';
 
 async function example() {
-  const tezos = Tezos(provider)
+  const tezos = new TezosToolkit(provider)
   await importKey(
     tezos,
     'peqjckge.qkrrajzs@tezos.example.org',

--- a/example/contract-schema.ts
+++ b/example/contract-schema.ts
@@ -1,11 +1,11 @@
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 
 
 async function example() {
     const provider = 'https://api.tez.ie/rpc/carthagenet';
     const signer: any = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
-    const tezos = Tezos(provider);
+    const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider( signer );
     try {
         const contract = await tezos.contract.at('KT1Q3t3gb8RANMfZozAfSDUXW2UWVqmSR3rr');

--- a/example/example-activate.ts
+++ b/example/example-activate.ts
@@ -1,10 +1,10 @@
-import { Tezos } from '@taquito/taquito'
+import { TezosToolkit } from '@taquito/taquito'
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
     const provider = 'https://api.tez.ie/rpc/carthagenet';
     const signer: any = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
-    const tezos = Tezos(provider);
+    const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider( signer );
     try {
         const op = await tezos.tz.activate("tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu", "161d907951bf5594bedb1d70bb03c938d63c22be")

--- a/example/example-node.ts
+++ b/example/example-node.ts
@@ -1,4 +1,4 @@
-import { Tezos } from '../packages/taquito/src/taquito';
+import { TezosToolkit } from '../packages/taquito/src/taquito';
 import { RpcClient } from '../packages/taquito-rpc/src/taquito-rpc';
 import { castToString } from '../packages/taquito-rpc/src/utils/utils';
 
@@ -7,7 +7,7 @@ const client = new RpcClient(provider);
 
 async function example() {
   try {
-    const tezos = Tezos(provider);
+    const tezos = new TezosToolkit(provider);
 
     console.log('Getting storage...');
     await tezos.contract.at('KT1HqWsXrGbHWc9muqkApqWu64WsxCU3FoRf').then(async contract => {

--- a/example/example-streamer.ts
+++ b/example/example-streamer.ts
@@ -1,9 +1,8 @@
-import { Tezos } from '@taquito/taquito';
-
+import { TezosToolkit } from '@taquito/taquito';
 
 async function example() {
   const provider = 'https://api.tez.ie/rpc/mainnet';
-  const tezos = Tezos(provider)
+  const tezos = new TezosToolkit(provider)
   tezos.setProvider({ config: { shouldObservableSubscriptionRetry: true } });
   try {
 

--- a/example/pretty-print-contract.ts
+++ b/example/pretty-print-contract.ts
@@ -1,11 +1,11 @@
 import { Parser, emitMicheline } from '@taquito/michel-codec'
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 
 const provider = 'https://api.tez.ie/rpc/mainnet';
 
 const example = async () => {
 
-  const tezos = Tezos(provider)
+  const tezos = new TezosToolkit(provider)
 
   try {
     const contract = await tezos.contract.at('KT1EctCuorV2NfVb1XTQgvzJ88MQtWP8cMMv') //StakerDAO

--- a/example/scan-path-ledger.ts
+++ b/example/scan-path-ledger.ts
@@ -1,13 +1,13 @@
 
 import { LedgerSigner, DerivationType } from '@taquito/ledger-signer';
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
 
 async function example() {
 
     const transport = await TransportNodeHid.create();
     let index = 0;
-    const tezos = Tezos('https://api.tez.ie/rpc/carthagenet')
+    const tezos = new TezosToolkit('https://api.tez.ie/rpc/carthagenet')
     while (index < 10) {
         const ledgerSigner = new LedgerSigner(transport, `44'/1729'/${index}'/0'`, false, DerivationType.tz1);
         tezos.setProvider({ signer: ledgerSigner });

--- a/integration-tests/ledger-signer-falling-tests.spec.ts
+++ b/integration-tests/ledger-signer-falling-tests.spec.ts
@@ -1,6 +1,6 @@
 import { LedgerSigner, LedgerTransport, DerivationType } from '../packages/taquito-ledger-signer/src/taquito-ledger-signer';
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import { ligoSample } from "./data/ligo-simple-contract";
 
 /**
@@ -58,7 +58,7 @@ describe('LedgerSigner falling test', () => {
                     false, 
                     DerivationType.tz1
                 );
-                const tezos = Tezos('https://api.tez.ie/rpc/carthagenet');
+                const tezos = new TezosToolkit('https://api.tez.ie/rpc/carthagenet');
                 tezos.setSignerProvider( signer );
                 try {
                     const op = await tezos.wallet.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.1 }).send()
@@ -80,7 +80,7 @@ describe('LedgerSigner falling test', () => {
                     false, 
                     DerivationType.tz1
                 );
-                const tezos = Tezos('https://api.tez.ie/rpc/carthagenet');
+                const tezos = new TezosToolkit('https://api.tez.ie/rpc/carthagenet');
                 tezos.setSignerProvider( signer );
                 try {
                     const op = await tezos.contract.originate({

--- a/integration-tests/ledger-signer.spec.ts
+++ b/integration-tests/ledger-signer.spec.ts
@@ -1,6 +1,6 @@
 import { LedgerSigner, LedgerTransport, DerivationType } from '../packages/taquito-ledger-signer/src/taquito-ledger-signer';
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
-import { Tezos } from '@taquito/taquito';
+import { TezosToolkit } from '@taquito/taquito';
 import { ligoSample } from "./data/ligo-simple-contract";
 
 /**
@@ -136,7 +136,7 @@ describe('LedgerSigner test', () => {
         false, 
         DerivationType.tz1
       );
-      const tezos = Tezos('https://api.tez.ie/rpc/carthagenet');
+      const tezos = new TezosToolkit('https://api.tez.ie/rpc/carthagenet');
       tezos.setSignerProvider( signer );
       const op = await tezos.contract.originate({
         balance: "1",
@@ -160,7 +160,7 @@ describe('Should be abble to used Ledger with wallet API', () => {
           false, 
           DerivationType.tz1
         );
-        const tezos = Tezos('https://api.tez.ie/rpc/carthagenet');
+        const tezos = new TezosToolkit('https://api.tez.ie/rpc/carthagenet');
         tezos.setSignerProvider( signer );
         const op = await tezos.wallet.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.1 }).send()
       await op.confirmation()

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -241,8 +241,3 @@ export class TezosToolkit {
     };
   }
 }
-
-/**
- * @description Default Tezos toolkit instance
- */
-export const Tezos = (rpcClient: RpcClient | string) => new TezosToolkit(rpcClient);


### PR DESCRIPTION
For simplicity, the Tezos function added in the TezosToolkit (to replace the Tezos singleton after removing the default RPC URL) has been removed. So the only way to create a new instance will be :
`const tezos = new TezosToolkit('your_rpc');`

Fixed examples that were using this function.