### PR TITLE
Replace SECP256R1 by P256 in the ledger-signer

### DIFF
--- a/docs/ledger_signer.md
+++ b/docs/ledger_signer.md
@@ -53,7 +53,7 @@ The constructor of the `LedgerSigner` class can take three other parameters. If 
  - prompt: **default is true**  
  If true, you will be asked, on your Ledger device, for validation to send your public key. ***Note that confirmation is required when using `@ledgerhq/hw-transport-u2f`, so you should not set this parameter to false if you are using this transport.***
  - derivationType: **default is DerivationType.ED25519**  
- It can be DerivationType.ED25519 (tz1), DerivationType.SECP256K1 (tz2) or DerivationType.SECP256R1 (tz3).
+ It can be DerivationType.ED25519 (tz1), DerivationType.SECP256K1 (tz2) or DerivationType.P256 (tz3).
 
 ```js
 import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';

--- a/docs/v7_breaking_changes.md
+++ b/docs/v7_breaking_changes.md
@@ -175,7 +175,7 @@ Ledger support was pre-released in September. Taquito never officially released 
 
 This breaking change can impact the users of the pre-released `ledger-signer` package. 
 
-We have renamed the enum `DerivationType` members to use the curve name. Now `tz1`, `tz2`, and `tz3` become `ED25519`, `SECP256K1`, and `SECP256R1`. This enum is used in the optional `derivationType` parameter of the constructor of the `LedgerSigner` class.
+We have renamed the enum `DerivationType` members to use the curve name. Now `tz1`, `tz2`, and `tz3` become `ED25519`, `SECP256K1`, and `P256`. This enum is used in the optional `derivationType` parameter of the constructor of the `LedgerSigner` class.
 
 There is another derivation type (`BIPS32_ED25519`), which also uses the tz1 prefix. It is used by the `tezos-client` CLI when paired with a ledger device but is not implemented so far in the `ledger-signer` package. The derivation types being named `tz1`, `tz2` and `tz3` were potentially an area of confusion in the future, whereas different derivation types use the same signature scheme. 
 

--- a/integration-tests/ledger-signer.spec.ts
+++ b/integration-tests/ledger-signer.spec.ts
@@ -87,7 +87,7 @@ describe('LedgerSigner test', () => {
           transport,
           "44'/1729'/1'/0'", 
           false, 
-          DerivationType.SECP256R1
+          DerivationType.P256
         );
         const pk = await signer.publicKey();
         const pkh = await signer.publicKeyHash();

--- a/packages/taquito-ledger-signer/src/taquito-ledger-signer.ts
+++ b/packages/taquito-ledger-signer/src/taquito-ledger-signer.ts
@@ -16,7 +16,7 @@ export type LedgerTransport = Pick<Transport<string>, 'send' | 'decorateAppAPIMe
 export enum DerivationType {
   ED25519 = 0x00, // tz1
   SECP256K1 = 0x01, // tz2
-  SECP256R1 = 0x02 // tz3
+  P256 = 0x02 // tz3
 };
 
 export const HDPathTemplate = (account: number) => {
@@ -30,7 +30,7 @@ export const HDPathTemplate = (account: number) => {
  * @param transport A transport instance from LedgerJS libraries depending on the platform used (e.g. Web, Node)
  * @param path The ledger derivation path (default is "44'/1729'/0'/0'")
  * @param prompt Whether to prompt the ledger for public key (default is true)
- * @param derivationType The value which defines the curve to use (DerivationType.ED25519(default), DerivationType.SECP256K1, DerivationType.SECP256R1)
+ * @param derivationType The value which defines the curve to use (DerivationType.ED25519(default), DerivationType.SECP256K1, DerivationType.P256)
  * 
  * @example
  * ```
@@ -70,7 +70,7 @@ export class LedgerSigner implements Signer {
         throw new Error("The derivation path must start with 44'/1729'");
       }
       if(!Object.values(DerivationType).includes(derivationType)) {
-        throw new Error("The derivation type must be DerivationType.ED25519, DerivationType.SECP256K1 or DerivationType.SECP256R1")
+        throw new Error("The derivation type must be DerivationType.ED25519, DerivationType.SECP256K1 or DerivationType.P256")
       }
     }    
 
@@ -99,7 +99,7 @@ export class LedgerSigner implements Signer {
             prefPk = prefix[Prefix.SPPK];
             prefPkh = prefix[Prefix.TZ2]
         }
-        else if (this.derivationType === DerivationType.SECP256R1){
+        else if (this.derivationType === DerivationType.P256){
             prefPk = prefix[Prefix.P2PK];
             prefPkh = prefix[Prefix.TZ3]
         }

--- a/packages/taquito-ledger-signer/test/taquito-ledger-signer.spec.ts
+++ b/packages/taquito-ledger-signer/test/taquito-ledger-signer.spec.ts
@@ -70,7 +70,7 @@ it('Should get public key and public key hash for default path and tz1 curve', a
   })
 
   it('Should get public key and public key hash for path which accounnt is 1 and tz3 curve', async () => {
-    const signer = new LedgerSigner(mockTransport, "44'/1729'/1'/0'", false, DerivationType.SECP256R1);
+    const signer = new LedgerSigner(mockTransport, "44'/1729'/1'/0'", false, DerivationType.P256);
     const mockpk = Buffer.from('4104eac3db090c124a2d57623d8e743f4a2beef9e6f96e80b49a4755c525c6c80ee391d9d93595479ae1d0099ecc8f4d56ca0542516407ff9f386c48678de965b8809000', 'hex');
     mockTransport.send.mockResolvedValue(mockpk); 
     const pk = await signer.publicKey();
@@ -140,7 +140,7 @@ it('Should get public key and public key hash for default path and tz1 curve', a
   })
 
   it('Should sign operation for tz3', async () => {
-    const signer = new LedgerSigner(mockTransport, "44'/1729'/0'/0'", false, DerivationType.SECP256R1);
+    const signer = new LedgerSigner(mockTransport, "44'/1729'/0'/0'", false, DerivationType.P256);
     const mocksig = Buffer.from('3144022005ccc37c4c434b39054a68d15f9f4d4d279699dd3a406cb235e0b3bf62a6ec1702204f72794ad3f06dd3ebb21b36b63eb44b98f5607e8751513741d73660b7952c399000', 'hex');
     mockTransport.send.mockResolvedValue(mocksig); 
     const signature = await signer.sign('038e1824a75961255a36e47d354733d6923c5849579d6abb4bd8c2a929ab5d393a6b02bd2cbb50fb2bfd7237b474a25b1b4ae447c577208c0babbc8d01e8520002022937a7444d7a00cb29f353058444d26d19382f0079e34b5aaf0eda4cec6665f16d02bd2cbb50fb2bfd7237b474a25b1b4ae447c577209310acbc8d01bb78c2030000000000b702000000b205000764045b0000000a2564656372656d656e74045b0000000a25696e6372656d656e740501035b0502020000008303210317057000010321057100020316072e020000002b032105700002032105710003034203210317057000010321057100020316034b051f020000000405200002020000002b0321057000020321057100030342032103170570000103210571000203160312051f020000000405200002053d036d0342051f020000000405200002000000020000');


### PR DESCRIPTION
Replaced SECP256R1 with P256 to keep it more consistent with the ecosystem.
