### PR TITLE
Fixed live code examples in the wallet documentation

### DIFF
--- a/docs/wallet_API.md
+++ b/docs/wallet_API.md
@@ -244,7 +244,7 @@ Although it is possible and perfectly fine to transfer tokens directly from the 
 
 ### - Transfer between implicit accounts
 
-```js live noInline
+```js live noInline wallet
 Tezos.wallet
   .transfer({ to: 'tz1NhNv9g7rtcjyNsH8Zqu79giY5aTqDDrzB', amount: 0.2 })
   .send()
@@ -268,16 +268,17 @@ The `transfer` method takes an object with only two required properties: the `to
 
 ### - Transfer to smart contracts
 
-```js live noInline
+```js live noInline wallet
 Tezos.wallet
   .transfer({ to: 'KT1TMZhfoYtpjbGG1nLjs7SZioFM1njsRwkP', amount: 0.2 })
   .send()
-  .then((op) =>
-    op
-      .confirmation()
-      .then((result) => println(result))
+  .then((op) => {
+    println(`Waiting for ${op.opHash} to be confirmed...`);
+    return op.confirmation(1).then(() => op.opHash);
+  })
+  .then(hash => println(`Operation injected: https://carthagenet.tzstats.com/${hash}`))
       .catch((err) => println(err))
-  );
+
 ```
 
 Transactions to smart contracts operate in the same fashion as transactions to an implicit account, the only difference being the `KT1...` address. You will also receive a transaction hash and have to wait for the transaction to be confirmed. Once confirmed, it can be the right time to update the user's/contract's balance, for example.
@@ -300,7 +301,7 @@ In this example, we are working with a simple smart contract with two methods: `
 Most of the possible arguments of the entrypoint method are pretty straightforward and intuitive and do not require any explanation. However, a couple of them need more attention.
 Most of the time, the process is simple: you take the contract abstraction you created for the contract you target, you call the `methods` property on it which exposes all the entrypoints of the contract as methods. You pass the argument you want to send to the contract as a function argument before calling the `send()` method to send the transaction:
 
-```js live noInline
+```js live noInline wallet
 Tezos.wallet
   .at('KT1PCLg8Da8T5h5SWibMopPVsxiKg27tSRxx')
   .then((contract) => contract.methods.areYouThere(true).send())
@@ -323,7 +324,7 @@ Tezos.wallet
 
 In the case of multiple arguments (for example if the entrypoint expects a pair), you can just pass the arguments one by one. Be careful of the order of the arguments, they must be in the exact order expected by the contract entrypoint:
 
-```js live noInline
+```js live noInline wallet
 Tezos.wallet
   .at('KT1PCLg8Da8T5h5SWibMopPVsxiKg27tSRxx')
   .then((contract) =>

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -10,6 +10,10 @@ module.exports = {
     src:
       'https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js',
     async: true,
+  }, {
+    src:
+      'https://www.tezbridge.com/plugin.js',
+    async: true,
   }],
   stylesheets: [
     'https://fonts.googleapis.com/css?family=Baloo+Tammudu|Open+Sans:400,600,800&display=swap',

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2498,6 +2498,14 @@
         }
       }
     },
+    "@taquito/tezbridge-wallet": {
+      "version": "7.0.0-beta-RC.0",
+      "resolved": "https://registry.npmjs.org/@taquito/tezbridge-wallet/-/tezbridge-wallet-7.0.0-beta-RC.0.tgz",
+      "integrity": "sha512-bDTo3RZOpR25S4RvyG269jInXCyNgY85jpcKFptEt1fy+hgjwi8+STB/EegGEqRDTNdJRKwFCh/zSXDIwuuoYA==",
+      "requires": {
+        "@taquito/taquito": "^7.0.0-beta-RC.0"
+      }
+    },
     "@taquito/utils": {
       "version": "7.0.0-beta-RC.0",
       "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-7.0.0-beta-RC.0.tgz",
@@ -2517,6 +2525,14 @@
             "ieee754": "^1.1.13"
           }
         }
+      }
+    },
+    "@thanos-wallet/dapp": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@thanos-wallet/dapp/-/dapp-0.7.0.tgz",
+      "integrity": "sha512-eXa8NwHYmlXo1ZWbLfW0tVRAjame92NKJo1I+EsS0ZQyoz9dJTIQSsqwA1cfzIoXV/wFSXmfhTnHniraCtc2fQ==",
+      "requires": {
+        "nanoid": "^3.1.10"
       }
     },
     "@types/anymatch": {
@@ -9293,6 +9309,11 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
+    "nanoid": {
+      "version": "3.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.16.tgz",
+      "integrity": "sha512-+AK8MN0WHji40lj8AEuwLOvLSbWYApQpre/aFJZD71r43wVRLrOYS4FmJOPQYon1TqB462RzrrxlfA74XRES8w=="
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/website/package.json
+++ b/website/package.json
@@ -19,7 +19,9 @@
     "@taquito/ledger-signer": "^7.0.0-beta-RC.0",
     "@taquito/signer": "^7.0.0-beta-RC.0",
     "@taquito/taquito": "^7.0.0-beta-RC.0",
+    "@taquito/tezbridge-wallet": "^7.0.0-beta-RC.0",
     "@taquito/utils": "^7.0.0-beta-RC.0",
+    "@thanos-wallet/dapp": "^0.7.0",
     "classnames": "^2.2.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"

--- a/website/src/theme/CodeBlock/index.js
+++ b/website/src/theme/CodeBlock/index.js
@@ -21,6 +21,8 @@ import {
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { InMemorySigner } from '@taquito/signer';
 import { LedgerSigner, DerivationType } from '@taquito/ledger-signer';
+import { TezBridgeWallet } from '@taquito/tezbridge-wallet';
+import { ThanosWallet } from '@thanos-wallet/dapp';
 import TransportU2F from "@ledgerhq/hw-transport-u2f";
 import Playground from '@theme/Playground';
 import classnames from 'classnames';
@@ -93,7 +95,9 @@ export default ({
           MichelsonMap, 
           BeaconWallet, 
           InMemorySigner, 
-          LedgerSigner, 
+          LedgerSigner,
+          TezBridgeWallet,
+          ThanosWallet, 
           DerivationType, 
           TransportU2F }}
         code={children.trim()}

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -48,28 +48,33 @@ function println(value) {
 
 Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
-${this.props.wallet ? 
-`const option = {name:"exampleWallet"};
-const wallet = new BeaconWallet(option);
-const network = {type:"carthagenet"};
-wallet.requestPermissions({network})
-.then(permission => {
-  return Tezos.setWalletProvider(wallet);
-})
-.then(() => {
-  ${this.code}
-});`:
-`fetch('https://api.tez.ie/keys/carthagenet/', {
-  method: 'POST',
-  headers: { Authorization: 'Bearer taquito-example' },
-})
-.then(response => response.text())
-.then(privateKey => {
-  return importKey(Tezos, privateKey);
- })
-.then(() => {
-  ${this.code}
- });`}
+if(${this.props.wallet}){
+  console.log("Using BeaconWallet")
+  const option = {name:"exampleWallet"};
+  const wallet = new BeaconWallet(option);
+  const network = {type:"carthagenet"};
+  wallet.requestPermissions({network})
+  .then(permission => {
+    return Tezos.setWalletProvider(wallet);
+  })
+  .then(() => {
+    ${this.code}
+  });
+} else if (${this.props.thanosWallet}) {
+
+} else {
+    fetch('https://api.tez.ie/keys/carthagenet/', {
+    method: 'POST',
+    headers: { Authorization: 'Bearer taquito-example' },
+  })
+  .then(response => response.text())
+  .then(privateKey => {
+    return importKey(Tezos, privateKey);
+  })
+  .then(() => {
+    ${this.code}
+  });
+}
 
 //contract used in example "estimate a contract origination"
 const genericMultisigJSONfile = 

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -48,9 +48,8 @@ function println(value) {
 
 Tezos.setProvider({ rpc: 'https://api.tez.ie/rpc/carthagenet' });
 
-if(${this.props.wallet}){
-  console.log("Using BeaconWallet")
-  const option = {name:"exampleWallet"};
+${this.props.wallet ? 
+  `const option = {name:"exampleWallet"};
   const wallet = new BeaconWallet(option);
   const network = {type:"carthagenet"};
   wallet.requestPermissions({network})
@@ -59,29 +58,18 @@ if(${this.props.wallet}){
   })
   .then(() => {
     ${this.code}
-  });
-} else if (${this.props.thanosWallet}) {
-  console.log("using Thanos wallet")
-  ThanosWallet.isAvailable()
-  .then(() => {
-    const wallet = new ThanosWallet('MyAwesomeDapp');
-    wallet.connect('carthagenet').then(() => {
-      Tezos.setWalletProvider(wallet);
-    });
-  })
-} else {
-    fetch('https://api.tez.ie/keys/carthagenet/', {
+  });`:
+  `fetch('https://api.tez.ie/keys/carthagenet/', {
     method: 'POST',
     headers: { Authorization: 'Bearer taquito-example' },
   })
   .then(response => response.text())
   .then(privateKey => {
     return importKey(Tezos, privateKey);
-  })
+   })
   .then(() => {
     ${this.code}
-  });
-}
+   });`}
 
 //contract used in example "estimate a contract origination"
 const genericMultisigJSONfile = 

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -61,7 +61,14 @@ if(${this.props.wallet}){
     ${this.code}
   });
 } else if (${this.props.thanosWallet}) {
-
+  console.log("using Thanos wallet")
+  ThanosWallet.isAvailable()
+  .then(() => {
+    const wallet = new ThanosWallet('MyAwesomeDapp');
+    wallet.connect('carthagenet').then(() => {
+      Tezos.setWalletProvider(wallet);
+    });
+  })
 } else {
     fetch('https://api.tez.ie/keys/carthagenet/', {
     method: 'POST',


### PR DESCRIPTION
Added tezbridge plugin to docusaurus config to fix the Tezbridge wallet example.
Added the import for ThanosWallet.
Made the other examples use the taquito-beacon-wallet package otherwise it was using an ephemeral key to sign.