### PR TITLE
Removed context from TezosToolkit constructor

### DIFF
--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -1,4 +1,5 @@
 import { RpcClient } from '@taquito/rpc';
+import { RPCBatchProvider } from './batch/rpc-batch-provider';
 import { Protocols } from './constants';
 import { Config, Context, TaquitoProvider } from './context';
 import { ContractProvider, EstimationProvider } from './contract/interface';
@@ -55,21 +56,24 @@ export class TezosToolkit {
   private _options: SetProviderOptions = {};
   private _rpcClient: RpcClient
   private _wallet: Wallet;
+  private _context: Context;
+  public batch: RPCBatchProvider['batch'];
 
   public readonly format = format;
 
   constructor(
-    private _rpc: RpcClient | string,
-    private _context: Context = new Context(_rpc)
+    private _rpc: RpcClient | string
   ) {
     if (typeof this._rpc === 'string') {
       this._rpcClient = new RpcClient(this._rpc);
     } else {
       this._rpcClient = this._rpc;
     }
+    this._context = new Context(_rpc);
     this._wallet = new Wallet(this._context);
     this.setProvider({ rpc: this._rpcClient });
-  }
+    this.batch = this._context.batch.batch.bind(this._context.batch);
+  } 
 
   /**
    * @description Sets configuration on the Tezos Taquito instance. Allows user to choose which signer, rpc client, rpc url, forger and so forth
@@ -204,8 +208,6 @@ export class TezosToolkit {
   get operation(): OperationFactory {
     return this._context.operationFactory;
   }
-
-  public batch = this._context.batch.batch.bind(this._context.batch);
 
   /**
    * @description Provide access to operation estimation utilities


### PR DESCRIPTION
When I removed the RPC URL, I added an optional context in the constructor of the Toolkit but it should not be accessible like that. This is a fix for it.