### PR TITLE
chore: remove carthagenet integration tests from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,30 +4,6 @@ on: [push]
 jobs:
   lint-and-test:
     runs-on: self-hosted
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    - uses: actions/cache@v1
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-    - run: npm ci
-    - run: npm run lerna -- bootstrap
-    - run: npm run build
-    - run: npm run lint
-    - run: npm run test -- --runInBand
-    - uses: codecov/codecov-action@v1
-      with:
-        file: .coverage/*.json
-      env:
-        CI: true
-        RUN_INTEGRATION: true
-  integration-tests-carthagenet:
-    runs-on: self-hosted
     strategy:
       matrix:
         node: [12.x]
@@ -45,9 +21,15 @@ jobs:
     - run: npm ci
     - run: npm run lerna -- bootstrap
     - run: npm run build
-    - run: cd integration-tests && npm run test:carthagenet -- --maxWorkers=10
+    - run: npm run lint
+    - run: npm run test -- --runInBand
+    - uses: codecov/codecov-action@v1
+      with:
+        file: .coverage/*.json
       env:
         CI: true
+        RUN_INTEGRATION: true
+
   integration-tests-delphinet:
     runs-on: self-hosted
     strategy:


### PR DESCRIPTION


## Release Note Draft Snippet

Carthagenet is no longer supported for the sending of operations. Reading data from the carthagenet period will continue to be supported.