### PR TITLE
Change falling tests to failing tests

### DIFF
--- a/docs/ledger_integration_test.md
+++ b/docs/ledger_integration_test.md
@@ -26,13 +26,13 @@ The Ledger Signer's integration tests are disabled by default because they requi
 4. If you only want to run Ledger integration tests, use this command: `npm run test ledger-signer.spec.ts`
 5. As the tests include operation like transfer of token and contract origination, the tests will take some time to complete. You will be prompt on the Ledger to confirm the operations.
 
-## Falling tests
+## Failing tests
 
 There is also a set of integration tests used to verify the behavior when the user declines the Ledger's prompt.
 
 To run these tests, you need to:
 
 1. Open `Tezos Wallet app` on your Ledger device.
-2. Remove `./ledger-signer-falling-tests.spec.ts` from `"testPathIgnorePatterns"` in the package.json.
-3. If you only want to run these tests, use this command: `npm run test ledger-signer-falling-tests.spec.ts`
+2. Remove `./ledger-signer-failing-tests.spec.ts` from `"testPathIgnorePatterns"` in the package.json.
+3. If you only want to run these tests, use this command: `npm run test ledger-signer-failing-tests.spec.ts`
 4. You will need to decline all Ledger prompts.

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -46,5 +46,5 @@ So if you have a test spec with the name `it('does some stuff)` then the command
 
 ## Configuration
 
-See the `taquito/integration-tests/config.ts` file for details of test configurations and target networks. Some configurations have default values that can be overridden using environment variables. For example, you can make the tests run against a custom `delpinet` node by setting the environment variable: ` export TEZOS_RPC_DELPHINET='http://localhost:8732'`. 
+See the `taquito/integration-tests/config.ts` file for details of test configurations and target networks. Some configurations have default values that can be overridden using environment variables. For example, you can make the tests run against a custom `delphinet` node by setting the environment variable: ` export TEZOS_RPC_DELPHINET='http://localhost:8732'`. 
 

--- a/integration-tests/ledger-signer-failing-tests.ts
+++ b/integration-tests/ledger-signer-failing-tests.ts
@@ -4,10 +4,10 @@ import { TezosToolkit } from '@taquito/taquito';
 import { ligoSample } from "./data/ligo-simple-contract";
 
 /**
- * LedgerSigner falling test
+ * LedgerSigner failing test
  * 
  */
-describe('LedgerSigner falling test', () => {
+describe('LedgerSigner failing test', () => {
     let transport: LedgerTransport;
     
     beforeEach(async () => {


### PR DESCRIPTION
__References in code, file names and documentation to "falling tests" have been changed to "failing tests."__

A typo in integration_tests/README.md is fixed.
