### PR TITLE
feat(createoriginationoperation): adds a mutez property (boolean) to createOriginationOperation

### DIFF
--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -22,6 +22,7 @@ export const createOriginationOperation = async ({
   fee = DEFAULT_FEE.ORIGINATION,
   gasLimit = DEFAULT_GAS_LIMIT.ORIGINATION,
   storageLimit = DEFAULT_STORAGE_LIMIT.ORIGINATION,
+  mutez = false
 }: OriginateParams) => {
   // tslint:disable-next-line: strict-type-predicates
   if (storage !== undefined && init !== undefined) {
@@ -77,7 +78,9 @@ export const createOriginationOperation = async ({
     fee,
     gas_limit: gasLimit,
     storage_limit: storageLimit,
-    balance: format("tz", "mutez", balance).toString(),
+    balance: mutez
+      ? balance.toString()
+      : format('tz', 'mutez', balance).toString(),
     script,
   };
 

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -118,6 +118,7 @@ export type OriginateParamsBase = {
   fee?: number;
   gasLimit?: number;
   storageLimit?: number;
+  mutez?: boolean;
 };
 
 /**

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -258,6 +258,48 @@ describe('RpcContractProvider test', () => {
       });
       done();
     });
+
+    it('should not convert balance to mutez when mutez flag is set to true', async done => {
+      const result = await rpcContractProvider.originate({
+        delegate: 'test_delegate',
+        balance: '200',
+        code: miStr,
+        init: miInit,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 257,
+        mutez: true,
+      });
+      const res = JSON.parse(JSON.stringify(result.raw)); // Strip symbols
+      expect(res).toEqual({
+        counter: 0,
+        opOb: {
+          branch: 'test',
+          contents: [
+            revealOp('test_pub_key_hash'),
+            {
+              balance: '200',
+              counter: '2',
+              delegate: 'test_delegate',
+              fee: '10000',
+              gas_limit: '10600',
+              kind: 'origination',
+              script: {
+                code: miSample,
+                storage: miStorage,
+              },
+              source: 'test_pub_key_hash',
+              storage_limit: '257',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
+
     it('estimate when no fees are specified', async done => {
       const estimate = new Estimate(1000, 1000, 180, 1000);
       mockEstimate.originate.mockResolvedValue(estimate);


### PR DESCRIPTION
Adds a mutez property (boolean) to createOriginationOperation as in createTransferOperation to make
things consistent.

## Issue Description

Thanos wallet originates contracts after converting the balance from `ꜩ` to `uꜩ` twice. It is possible that other wallets also have this issue, but I've not tested them.

I could also submit a PR on Thanos repository to fix the issue, but I believe that this change is preferable.

If this PR gets merged, the Thanos team just needs to change their `mapOriginateParamsToWalletParams` method to this:

```js
async mapOriginateParamsToWalletParams(params: WalletOriginateParams) {
    return { ...createOriginationOperation(params as any), mutez: true };
}
```

## Release Note Draft Snippet

Adds a mutez property (boolean) to createOriginationOperation as in createTransferOperation to facilitate abstraction with wallets.
