### PR TITLE
Fix for Michelson view without param to match TZComet

### DIFF
--- a/docs/tzip12.md
+++ b/docs/tzip12.md
@@ -85,7 +85,7 @@ Here is a flowchart that summarizes the logic perform internally when calling th
 
 Tezos.addExtension(new Tzip12Module());
 
-const contractAddress = "KT1Pf8Ltw1Q91mXEtvkcmxyan3rxPDsHx8eZ";
+const contractAddress = "KT1QL1PrjmbEfRGb2dyLdc9eJ6MQpb83LQtb";
 const tokenId = 1;
 
 Tezos.contract.at(contractAddress, compose(tzip12, tzip16))
@@ -108,7 +108,7 @@ The same result can also be obtained by calling the off-chain view `token_metada
 
 Tezos.addExtension(new Tzip16Module());
 
-const contractAddress = "KT1Pf8Ltw1Q91mXEtvkcmxyan3rxPDsHx8eZ";
+const contractAddress = "KT1QL1PrjmbEfRGb2dyLdc9eJ6MQpb83LQtb";
 const tokenId = 1;
 
 Tezos.contract.at(contractAddress, tzip16)

--- a/integration-tests/tzip12-token-metadata.spec.ts
+++ b/integration-tests/tzip12-token-metadata.spec.ts
@@ -12,7 +12,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 	let contractAddress: string;
 	let contractAddress2: string;
 
- 	describe(`Deploy a Fa2 contract and fetch metadata (token metadata are in the big map %token_metadata): ${rpc}`, () => {
+ 	 describe(`Deploy a Fa2 contract and fetch metadata (token metadata are in the big map %token_metadata): ${rpc}`, () => {
 		beforeEach(async (done) => {
 			await setup();
 			done();
@@ -159,7 +159,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			}
 			done();
 		});
-	}); 
+	});  
 
  	describe(`Deploy a Fa2 contract and fetch metadata (token metadata are obtain from a view %token_metadata): ${rpc}`, () => {
 		beforeEach(async (done) => {
@@ -189,7 +189,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 				'20000'
 			);
 
-			const url = 'https://storage.googleapis.com/tzip-16/fa2-token-metadata-view-all-token-view.json';
+			const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
 			const bytesUrl = char2Bytes(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
@@ -244,7 +244,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 		});    
 
 		it('Should test contratAbstraction composition, fetch contract and token metadata of the Fa2 contract', async (done) => {
-			// delphi: KT1Pf8Ltw1Q91mXEtvkcmxyan3rxPDsHx8eZ
+			// delphi: KT1QL1PrjmbEfRGb2dyLdc9eJ6MQpb83LQtb
 
 			Tezos.addExtension(new Tzip16Module());
 
@@ -253,7 +253,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
 			// Fetch contract metadata on HTTPs
 			const metadata = await contract.tzip16().getMetadata();
-			expect(metadata.uri).toEqual('https://storage.googleapis.com/tzip-16/fa2-token-metadata-view-all-token-view.json');
+			expect(metadata.uri).toEqual('https://storage.googleapis.com/tzip-16/fa2-views.json');
 			expect(metadata.integrityCheckResult).toBeUndefined();
 			expect(metadata.sha256Hash).toBeUndefined();
 			expect(metadata.metadata).toBeDefined();

--- a/packages/taquito-tzip16/src/viewKind/michelson-storage-view.ts
+++ b/packages/taquito-tzip16/src/viewKind/michelson-storage-view.ts
@@ -142,6 +142,10 @@ export class MichelsonStorageView implements View {
 
         const code = this.adaptViewCodeToContext(this.code, contractBalance, blockTimestamp, chainId);
 
+        if(!this.viewParameterType) {
+            code.unshift({ prim: 'CDR' })
+        }
+
         const viewScript = {
             script: [
                 { prim: 'parameter', args: [{ prim: 'pair', args: [viewParameterType, storageArgs] }] },


### PR DESCRIPTION
Made a change to the Michelson views without parameter to match the behavior of TzComet.

Based on a discussion with Seb Mondet:

> the off-chain-view without parameter is a piece of code that transforms just the storage

