### PR TITLE
Refactor batch API

### DIFF
--- a/docs/wallet_API.md
+++ b/docs/wallet_API.md
@@ -1086,12 +1086,9 @@ await batchOp.confirmation();
 
 
 
-> Note: you cannot make a contract call with the first method.
-
-
-
 As with other operations, you must call the `confirmation` method on the returned operation to wait for the operation to be confirmed.
 
+*See [the Batch API documentation](batch-api.md) for more examples using the `batch` method.*
 
 
 We already checked the `originate` method earlier, and it takes an object as a parameter with two properties: `code` with the Michelson code of the contract in a JSON format and storage with the initial storage.

--- a/integration-tests/contract-batch.spec.ts
+++ b/integration-tests/contract-batch.spec.ts
@@ -1,0 +1,166 @@
+import { CONFIGS } from './config';
+import { ligoSample, ligoSampleMichelson } from './data/ligo-simple-contract';
+import { managerCode } from './data/manager_code';
+import { MANAGER_LAMBDA, OpKind } from '@taquito/taquito';
+
+CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }) => {
+    const Tezos = lib;
+    describe(`Test contract.batch using: ${rpc}`, () => {
+        beforeEach(async (done) => {
+            await setup();
+            done();
+        });
+        it('Simple transfers with origination (where the code in JSON Michelson format)', async (done) => {
+            const batch = Tezos.contract
+                .batch()
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withOrigination({
+                    balance: '1',
+                    code: ligoSample,
+                    storage: 0
+                });
+
+            const op = await batch.send();
+            await op.confirmation();
+            expect(op.status).toEqual('applied');
+            done();
+        });
+
+        it('Simple transfers with origination (where the code in Michelson format)', async (done) => {
+            const batch = Tezos.contract
+                .batch()
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withOrigination({
+                    balance: '1',
+                    code: ligoSampleMichelson,
+                    storage: 0
+                });
+
+            const op = await batch.send();
+            await op.confirmation();
+            expect(op.status).toEqual('applied');
+            done();
+        });
+
+        it('Simple transfers with origination using with', async (done) => {
+            const op = await Tezos.contract.batch([
+                {
+                    kind: OpKind.TRANSACTION,
+                    to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+                    amount: 2
+                },
+                {
+                    kind: OpKind.ORIGINATION,
+                    balance: "1",
+                    code: ligoSample,
+                    storage: 0,
+                }
+            ])
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .send();
+            await op.confirmation();
+            expect(op.status).toEqual('applied')
+            done();
+        })
+
+        it('Simple transfers with bad origination', async (done) => {
+            expect.assertions(1);
+            try {
+                await Tezos.contract
+                    .batch()
+                    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                    .withOrigination({
+                        balance: '1',
+                        code: ligoSample,
+                        storage: 0,
+                        storageLimit: 0
+                    })
+                    .send();
+            } catch (ex) {
+                expect(ex).toEqual(
+                    expect.objectContaining({
+                        message: expect.stringContaining('storage_exhausted.operation')
+                    })
+                );
+            }
+            done();
+        });
+
+        it('Test batch from account with low balance', async (done) => {
+            const LocalTez = await createAddress();
+            const op = await Tezos.contract.transfer({ to: await LocalTez.signer.publicKeyHash(), amount: 2 });
+            await op.confirmation();
+
+            const contract = await Tezos.contract.at(knownContract);
+
+            const batchOp = await LocalTez.contract
+                .batch([
+                    {
+                        kind: OpKind.TRANSACTION,
+                        to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+                        amount: 1
+                    },
+                    {
+                        kind: OpKind.ORIGINATION,
+                        balance: '0',
+                        code: ligoSample,
+                        storage: 0
+                    }
+                ])
+                .send();
+            await batchOp.confirmation();
+            expect(op.status).toEqual('applied');
+            done();
+        });
+
+        it('Chain contract calls', async (done) => {
+            const op = await Tezos.contract.originate({
+                balance: '1',
+                code: managerCode,
+                init: { string: await Tezos.signer.publicKeyHash() }
+            });
+
+            const contract = await op.contract();
+            expect(op.status).toEqual('applied');
+
+            const batch = Tezos.contract
+                .batch()
+                .withTransfer({ to: contract.address, amount: 1 })
+                .withContractCall(
+                    contract.methods.do(MANAGER_LAMBDA.transferImplicit('tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh', 50))
+                )
+                .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)))
+                .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()));
+
+            const batchOp = await batch.send();
+
+            await batchOp.confirmation();
+
+            expect(batchOp.status).toEqual('applied');
+            done();
+        });
+
+        it('Batch transfers and method call', async (done) => {
+            const contract = await Tezos.contract.at(knownContract);
+            const batchOp = await Tezos.contract
+                .batch([
+                    { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
+                    { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
+                    { kind: OpKind.TRANSACTION, ...contract.methods.default([['Unit']]).toTransferParams() }
+                ])
+                .send();
+
+            await batchOp.confirmation();
+
+            expect(batchOp.status).toEqual('applied');
+            done();
+        });
+    });
+});

--- a/integration-tests/wallet-batch.spec.ts
+++ b/integration-tests/wallet-batch.spec.ts
@@ -1,0 +1,194 @@
+import { CONFIGS } from './config';
+import { ligoSample, ligoSampleMichelson } from './data/ligo-simple-contract';
+import { managerCode } from './data/manager_code';
+import { MANAGER_LAMBDA, OpKind } from '@taquito/taquito';
+
+CONFIGS().forEach(({ lib, rpc, setup, knownContract, knownBaker, createAddress }) => {
+    const Tezos = lib;
+    describe(`Test wallet.batch using: ${rpc}`, () => {
+        beforeEach(async (done) => {
+            await setup();
+            done();
+        });
+
+        it('Simple transfers with origination (with code in JSON Michelson format)', async (done) => {
+            const batch = Tezos.wallet
+                .batch()
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withOrigination({
+                    balance: '1',
+                    code: ligoSample,
+                    storage: 0
+                });
+
+            const op = await batch.send();
+            const conf1 = await op.confirmation();
+            const currentConf1 = await op.getCurrentConfirmation();
+
+            expect(currentConf1).toEqual(1);
+            expect(conf1).toEqual(
+                expect.objectContaining({
+                    expectedConfirmation: 1,
+                    currentConfirmation: 1,
+                    completed: true
+                })
+            );
+            expect(op.opHash).toBeDefined();
+            done();
+        });
+
+        it('Simple transfers with origination (with code in Michelson format)', async (done) => {
+            const batch = Tezos.wallet
+                .batch()
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withOrigination({
+                    balance: '1',
+                    code: ligoSampleMichelson,
+                    storage: 0
+                });
+
+            const op = await batch.send();
+            const conf1 = await op.confirmation();
+            const currentConf1 = await op.getCurrentConfirmation();
+
+            expect(currentConf1).toEqual(1);
+            expect(conf1).toEqual(
+                expect.objectContaining({
+                    expectedConfirmation: 1,
+                    currentConfirmation: 1,
+                    completed: true
+                })
+            );
+            expect(op.opHash).toBeDefined();
+            done();
+        });
+
+        it('Simple transfers with origination using with', async (done) => {
+            const op = await Tezos.wallet
+                .batch([
+                    {
+                        kind: OpKind.TRANSACTION,
+                        to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+                        amount: 2
+                    },
+                    {
+                        kind: OpKind.ORIGINATION,
+                        balance: '1',
+                        code: ligoSample,
+                        storage: 0
+                    }
+                ])
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
+                .send();
+
+            const conf1 = await op.confirmation();
+            const currentConf1 = await op.getCurrentConfirmation();
+
+            expect(currentConf1).toEqual(1);
+            expect(conf1).toEqual(
+                expect.objectContaining({
+                    expectedConfirmation: 1,
+                    currentConfirmation: 1,
+                    completed: true
+                })
+            );
+            expect(op.opHash).toBeDefined();
+            done();
+        });
+
+        it('Test batch from account with low balance', async (done) => {
+            const LocalTez = await createAddress();
+            const op = await Tezos.wallet.transfer({ to: await LocalTez.wallet.pkh(), amount: 2 }).send();
+            await op.confirmation();
+
+            const batchOp = await LocalTez.wallet
+                .batch([
+                    {
+                        kind: OpKind.TRANSACTION,
+                        to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+                        amount: 1
+                    },
+                    {
+                        kind: OpKind.ORIGINATION,
+                        balance: '0',
+                        code: ligoSample,
+                        storage: 0
+                    }
+                ])
+                .send();
+
+            await batchOp.confirmation();
+
+            expect(await op.status()).toEqual('applied');
+            done();
+        });
+
+        it('Chain contract calls', async (done) => {
+            const op = await Tezos.wallet
+                .originate({
+                    balance: '1',
+                    code: managerCode,
+                    init: { string: await Tezos.signer.publicKeyHash() }
+                })
+                .send();
+
+            const contract = await op.contract();
+            expect(await op.status()).toEqual('applied');
+
+            const batch = Tezos.wallet
+                .batch()
+                .withTransfer({ to: contract.address, amount: 1 })
+                .withContractCall(
+                    contract.methods.do(MANAGER_LAMBDA.transferImplicit('tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh', 50))
+                )
+                .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)))
+                .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()));
+
+            const batchOp = await batch.send();
+            await batchOp.confirmation();
+            const conf1 = await batchOp.confirmation();
+            const currentConf1 = await batchOp.getCurrentConfirmation();
+
+            expect(currentConf1).toEqual(1);
+            expect(conf1).toEqual(
+                expect.objectContaining({
+                    expectedConfirmation: 1,
+                    currentConfirmation: 1,
+                    completed: true
+                })
+            );
+            expect(batchOp.opHash).toBeDefined();
+            done();
+        });
+
+        it('Batch transfers and method call', async (done) => {
+            const contract = await Tezos.wallet.at(knownContract);
+            const batch = await Tezos.wallet
+                .batch([
+                    { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
+                    { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
+                    { kind: OpKind.TRANSACTION, ...contract.methods.default([['Unit']]).toTransferParams() }
+                ])
+                .send();
+
+            const conf1 = await batch.confirmation();
+            const currentConf1 = await batch.getCurrentConfirmation();
+            
+            expect(currentConf1).toEqual(1);
+            expect(conf1).toEqual(
+                expect.objectContaining({
+                    expectedConfirmation: 1,
+                    currentConfirmation: 1,
+                    completed: true
+                })
+            );
+            expect(batch.opHash).toBeDefined();
+            done();
+        });
+    });
+});

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -1,4 +1,5 @@
 import { Schema } from '@taquito/michelson-encoder';
+import { OperationBatch } from '../batch/rpc-batch-provider';
 import { Context } from '../context';
 import { DelegateOperation } from '../operations/delegate-operation';
 import { OriginationOperation } from '../operations/origination-operation';
@@ -138,4 +139,12 @@ export interface ContractProvider extends StorageProvider {
 
   transfer(params: TransferParams): Promise<TransactionOperation>;
   at<T extends ContractAbstraction<ContractProvider>>(address: string, contractAbstractionComposer?: (abs: ContractAbstraction<ContractProvider>, context: Context) => T): Promise<T>;
+
+  /**
+   *
+   * @description Batch a group of operation together. Operations will be applied in the order in which they are added to the batch
+   *
+   * @param params List of operation to batch together
+   */
+  batch(params?: ParamsWithKind[]): OperationBatch ;
 }

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -1,6 +1,7 @@
 import { Schema } from '@taquito/michelson-encoder';
 import { ScriptResponse } from '@taquito/rpc';
 import { encodeExpr } from '@taquito/utils';
+import { OperationBatch } from '../batch/rpc-batch-provider';
 import { Context } from '../context';
 import { DelegateOperation } from '../operations/delegate-operation';
 import { OperationEmitter } from '../operations/operation-emitter';
@@ -9,10 +10,10 @@ import { TransactionOperation } from '../operations/transaction-operation';
 import {
   DelegateParams,
   OriginateParams,
+  ParamsWithKind,
   RegisterDelegateParams,
   TransferParams,
 } from '../operations/types';
-import { Wallet } from '../wallet';
 import { ContractAbstraction } from './contract';
 import { InvalidDelegationSource } from './errors';
 import { ContractProvider, ContractSchema, EstimationProvider, StorageProvider } from './interface';
@@ -215,6 +216,25 @@ export class RpcContractProvider extends OperationEmitter
     const abs = new ContractAbstraction(address, script, this, this, entrypoints, chainId);
     return contractAbstractionComposer(abs, this.context);
   }
+
+  /**
+   *
+   * @description Batch a group of operation together. Operations will be applied in the order in which they are added to the batch
+   *
+   * @returns A batch object from which we can add more operation or send a command to execute the batch
+   * 
+   * @param params List of operation to batch together
+   */
+  batch(params?: ParamsWithKind[]) {
+    const batch = new OperationBatch(this.context, this.estimator);
+
+    if (Array.isArray(params)) {
+      batch.with(params);
+    }
+
+    return batch;
+  }
+
 }
 
 type ContractAbstractionComposer<T> = (abs: ContractAbstraction<ContractProvider>, context: Context) => T 

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -67,6 +67,10 @@ export class TezosToolkit {
   private _rpcClient: RpcClient
   private _wallet: Wallet;
   private _context: Context;
+  /**
+   * @deprecated TezosToolkit.batch has been deprecated in favor of TezosToolkit.contract.batch
+   *
+   */
   public batch: RPCBatchProvider['batch'];
 
   public readonly format = format;

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -86,6 +86,7 @@ export class TezosToolkit {
     this._context = new Context(_rpc);
     this._wallet = new Wallet(this._context);
     this.setProvider({ rpc: this._rpcClient });
+    // tslint:disable-next-line: deprecation
     this.batch = this._context.batch.batch.bind(this._context.batch);
   } 
 

--- a/packages/taquito/src/wallet/wallet.ts
+++ b/packages/taquito/src/wallet/wallet.ts
@@ -240,9 +240,13 @@ export class Wallet {
    *
    * @param params List of operation to initialize the batch with
    */
-  batch(params: Parameters<WalletOperationBatch['with']>[0]) {
+  batch(params?: Parameters<WalletOperationBatch['with']>[0]) {
     const batch = new WalletOperationBatch(this.walletProvider, this.context);
-    batch.with(params);
+    
+    if (Array.isArray(params)) {
+      batch.with(params);
+    }
+    
     return batch;
   }
 

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -37,6 +37,7 @@ import { OperationBatch } from '../../src/batch/rpc-batch-provider';
 describe('RpcContractProvider test', () => {
   let rpcContractProvider: RpcContractProvider;
   let mockRpcClient: {
+    // deepcode ignore no-any: any is good enough
     getScript: jest.Mock<any, any>;
     getStorage: jest.Mock<any, any>;
     getBigMapExpr: jest.Mock<any, any>;
@@ -55,12 +56,14 @@ describe('RpcContractProvider test', () => {
   };
 
   let mockSigner: {
+    // deepcode ignore no-any: any is good enough
     publicKeyHash: jest.Mock<any, any>;
     publicKey: jest.Mock<any, any>;
     sign: jest.Mock<any, any>;
   };
 
   let mockEstimate: {
+    // deepcode ignore no-any: any is good enough
     originate: jest.Mock<any, any>;
     transfer: jest.Mock<any, any>;
     setDelegate: jest.Mock<any, any>;
@@ -120,6 +123,7 @@ describe('RpcContractProvider test', () => {
     });
 
     rpcContractProvider = new RpcContractProvider(
+      // deepcode ignore no-any: any is good enough
       new Context(mockRpcClient as any, mockSigner as any),
       mockEstimate as any
     );
@@ -391,6 +395,7 @@ describe('RpcContractProvider test', () => {
         balance: '200',
         code: miSample
           .concat()
+          // deepcode ignore no-any: any is good enough
           .sort((a: any, b: any) => order1.indexOf(a.prim) - order1.indexOf(b.prim)),
         init: { int: '0' },
         fee: 10000,

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -27,8 +27,9 @@ import { InvalidCodeParameter, InvalidDelegationSource, InvalidInitParameter } f
 import { preapplyResultFrom } from './helper';
 import { MichelsonMap, Schema } from '@taquito/michelson-encoder';
 import { BigMapAbstraction } from '../../src/contract/big-map';
-import { OriginateParams } from '../../src/operations/types';
-import { NoopParser, ParserProvider } from '../../src/taquito';
+import { OpKind, ParamsWithKind } from '../../src/operations/types';
+import { NoopParser } from '../../src/taquito';
+import { OperationBatch } from '../../src/batch/rpc-batch-provider';
 
 /**
  * RPCContractProvider test
@@ -64,6 +65,7 @@ describe('RpcContractProvider test', () => {
     transfer: jest.Mock<any, any>;
     setDelegate: jest.Mock<any, any>;
     registerDelegate: jest.Mock<any, any>;
+    batch: jest.Mock<any, any>;
   };
 
   const revealOp = (source: string) => ({
@@ -106,6 +108,7 @@ describe('RpcContractProvider test', () => {
       transfer: jest.fn(),
       registerDelegate: jest.fn(),
       setDelegate: jest.fn(),
+      batch: jest.fn()
     };
 
     // Required for operations confirmation polling
@@ -823,5 +826,32 @@ describe('RpcContractProvider test', () => {
     }
       done();
     });
+
+    describe('batch', () => {
+      it('should produce a batch operation', async done => {
+
+        const opToBatch: ParamsWithKind[] = [
+          {
+            kind: OpKind.TRANSACTION,
+            to: 'test',
+            amount: 2
+          },
+          {
+            kind: OpKind.TRANSACTION,
+            to: 'test',
+            amount: 2
+          }
+        ];
+
+        const opBatch = new OperationBatch(rpcContractProvider['context'], mockEstimate);
+
+        expect(rpcContractProvider.batch()).toBeInstanceOf(OperationBatch);
+        expect(rpcContractProvider.batch()).toEqual(opBatch);
+
+        expect(rpcContractProvider.batch(opToBatch)).toEqual(opBatch.with(opToBatch));
+
+        done();
+      });
+    }); 
   });
 });


### PR DESCRIPTION
#591 

The `batch` method on the `TezosToolkit` class has been deprecated and moved to the contract API.
Examples of use:
```
const batch = Tezos.contract
    .batch()
    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
    .withOrigination({
        balance: '1',
        code: codeContract,
        storage: 0
    });

const op = await batch.send();
```
```
const op = await Tezos.contract.batch([
    {
        kind: OpKind.TRANSACTION,
        to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
        amount: 2
    },
    {
        kind: OpKind.ORIGINATION,
        balance: "1",
        code: codeContract,
        storage: 0,
    }
])
.send();
```


At the same time, `wallet.batch` method has been refactored so it can be used the same way as with the contract API.
Example:
```
const batch = Tezos.wallet
    .batch()
    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
    .withOrigination({
        balance: '1',
        code: codeContract,
        storage: 0
    });

const op = await batch.send();
```
```
const op = await Tezos.wallet.batch([
    {
        kind: OpKind.TRANSACTION,
        to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
        amount: 2
    },
    {
        kind: OpKind.ORIGINATION,
        balance: "1",
        code: codeContract,
        storage: 0,
    }
])
.send();
```

