### PR TITLE
Updated docs to show batch method on Wallet and Contract

### DIFF
--- a/docs/batch-api.md
+++ b/docs/batch-api.md
@@ -50,7 +50,7 @@ After concatenating the different methods to batch operations together, a single
 
 #### - The `withTransfer` method
 
-This method allows you to add a transfer of tez to the batched operations. It takes an object as a parameter with four properties. Two of them are mandatory: `to` indicates the transfer’s recipient, and `amount` means the amount of tez to be transferred. Two other properties are optional: if `mutez` is set to `true`, the value specified in `amount` is considered to be in mutez. The `parameter` property takes an object to indicate an entrypoint and a value for the transfer.
+This method allows you to add a transfer of tez to the batched operations. It takes an object as a parameter with 4 properties. Two of them are mandatory: `to` indicates the recipient of the transfer and `amount` indicates the amount of tez to be transferred. Two other properties are optional: if `mutez` is set to `true`, the value specified in `amount` is considered to be in mutez. The `parameter` property takes an object where you can indicate an entrypoint and a value for the transfer.
 
 ```js
 const batch = await Tezos.wallet.batch()

--- a/docs/batch-api.md
+++ b/docs/batch-api.md
@@ -31,13 +31,13 @@ Tracking the confirmation of transactions and the transaction counter’s update
 
 ## How does it work?
 
-The `TezosToolkit` object exposes a method called `batch.` Subsequently, the returned object exposes six different methods that you can concatenate according to the number of transactions to emit.
+The `contract` or `wallet` property of the `TezosToolkit` object exposes a method called `batch` (the choice between `contract` or `wallet` depends on your use case, whether the transaction will be signed by a wallet or not). Subsequently, the returned object exposes six different methods that you can concatenate according to the number of transactions to emit.
 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
 const Tezos = new TezosToolkit('RPC address here');
-const batch = await Tezos.batch();
+const batch = Tezos.wallet.batch(); // or Tezos.contract.batch()
 
 // Add here the operations to be emitted together
 
@@ -50,10 +50,10 @@ After concatenating the different methods to batch operations together, a single
 
 #### - The `withTransfer` method
 
-This method allows you to add a transfer of tez to the batched operations. It takes an object as a parameter with four properties. Two of them are mandatory: `to` indicates the transfer’s recipient, and `amount` means the amount of tez to be transferred. Two other properties are optional: if `mutez` is set to `true,` the value specified in `amount` is considered to be in mutez. The `parameter` property takes an object to indicate an entrypoint and a value for the transfer.
+This method allows you to add a transfer of tez to the batched operations. It takes an object as a parameter with four properties. Two of them are mandatory: `to` indicates the transfer’s recipient, and `amount` means the amount of tez to be transferred. Two other properties are optional: if `mutez` is set to `true`, the value specified in `amount` is considered to be in mutez. The `parameter` property takes an object to indicate an entrypoint and a value for the transfer.
 
 ```js
-const batch = await Tezos.batch()
+const batch = await Tezos.wallet.batch()
   .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
   .withTransfer({ to: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb', amount: 4000000, mutez: true })
   .withTransfer({ to: 'tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6', amount: 3 });
@@ -64,7 +64,7 @@ const batch = await Tezos.batch()
 This method allows you to add the origination of one or multiple contracts to an existing batch of operations. It takes an object as a parameter with four properties. The `code` property is mandatory and can be a string representing the plain Michelson code or the Michelson contract’s JSON representation. The parameter object must also include an `init` or `storage` property: when `init` is specified, `storage` is optional and vice-versa. `init` is the initial storage object value that can be either Micheline or JSON encoded. `storage` is a JavaScript representation of a storage object. You can also indicate a `balance` for the newly created contract and a `delegate.`
 
 ```js
-const batch = await Tezos.batch()
+const batch = await Tezos.contract.batch()
   .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
   .withOrigination({
     code: validCode,
@@ -79,7 +79,7 @@ const batch = await Tezos.batch()
 This simple method allows batching multiple delegation transactions. The method takes an object as a parameter with a single property: the address of the delegate.
 
 ```js
-const batch = await Tezos.batch().withDelegation({
+const batch = await Tezos.contract.batch().withDelegation({
   delegate: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
 });
 ```
@@ -89,19 +89,19 @@ const batch = await Tezos.batch().withDelegation({
 This method may be one of the most useful ones as it allows you to batch and emit multiple contract calls under one transaction. The parameter is also pretty simple: it takes the function you would call on the contract abstraction object to send a single transaction.
 
 ```js
-const batch = await Tezos.batch()
+const batch = await Tezos.wallet.batch()
   .withContractCall(contract.methods.interact('tezos'))
   .withContractCall(contract.methods.wait([['unit']]));
 ```
 
-#### - The `with` method
+#### - The `array of transactions` method
 
 If you prefer having an array that contains objects with the different transactions you want to emit, you can use the `with` method. It allows you to group transactions as objects instead of concatenating function calls. The object you use expects the same properties as the parameter of the corresponding method with an additional `kind` property that indicates the kind of transaction you want to emit (a handy `opKind` enum is [exported from the Taquito package](https://github.com/ecadlabs/taquito/blob/master/packages/taquito-rpc/src/opkind.ts) with the valid values for the `kind` property).
 
 ```js
 import { OpKind } from '@taquito/taquito';
 
-const batch = await Tezos.batch([
+const batch = await Tezos.wallet.batch([
   {
     kind: OpKind.TRANSACTION,
     to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
@@ -118,17 +118,18 @@ const batch = await Tezos.batch([
     kind: OpKind.DELEGATION,
     delegate: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
   },
+  { kind: OpKind.TRANSACTION, 
+    ...contract.methods.default([['Unit']]).toTransferParams() 
+  }
 ]);
 ```
-
-> Note: you cannot make contract calls with this method.
 
 #### - The `send` method
 
 After batching all the necessary operations together, you must use the `send` method to emit them. This step is very similar to what you would do to emit a single transaction.
 
 ```js
-const batch = await Tezos.batch();
+const batch = Tezos.contract.batch();
 /*
  * Here happens all the operation batching
  */


### PR DESCRIPTION
I updated the docs for the Batch API to reflect recent changes.
However, I haven't been able to test them as using `Tezos.wallet.batch().with...` raises an error with the latest Taquito version available (`Expected 1 arguments, but got 0`). A new version should be made available to download in order to test the changes.