### PR TITLE
update taquito docs quick-start page to remove v7 breaking changes warning

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -3,10 +3,6 @@ title: Quick Start
 author: Simon Boissonneault-Robert
 ---
 
-:::warning v7 Breaking changes
-Taquito version 7, which supports the Tezos "Delphi" protocol, has some breaking changes. If you are upgrading from an earlier version to v7, please read the [v7 upgrade guide](v7_breaking_changes.md)
-:::
-
 ## Installing Taquito using npm
 
 > For quick-start, you may also like to try out our template/boilerplate app [here][boilerplate]


### PR DESCRIPTION
As we are on version 8 now, we no longer need a warning in the documentation about breaking changes introduced in v7.

