### PR TITLE
More integration tests need retries

### DIFF
--- a/integration-tests/contract-batch.spec.ts
+++ b/integration-tests/contract-batch.spec.ts
@@ -5,12 +5,13 @@ import { MANAGER_LAMBDA, OpKind } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }) => {
     const Tezos = lib;
+    const test = require('jest-retries');
     describe(`Test contract.batch using: ${rpc}`, () => {
         beforeEach(async (done) => {
             await setup();
             done();
         });
-        it('Simple transfers with origination (where the code in JSON Michelson format)', async (done) => {
+        test('Simple transfers with origination (where the code in JSON Michelson format)', 2, async (done: () => void) => {
             const batch = Tezos.contract
                 .batch()
                 .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
@@ -28,7 +29,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             done();
         });
 
-        it('Simple transfers with origination (where the code in Michelson format)', async (done) => {
+        test('Simple transfers with origination (where the code in Michelson format)', 2, async (done: () => void) => {
             const batch = Tezos.contract
                 .batch()
                 .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
@@ -46,7 +47,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             done();
         });
 
-        it('Simple transfers with origination using with', async (done) => {
+        test('Simple transfers with origination using with', 2, async (done: () => void) => {
             const op = await Tezos.contract.batch([
                 {
                     kind: OpKind.TRANSACTION,
@@ -68,7 +69,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             done();
         })
 
-        it('Simple transfers with bad origination', async (done) => {
+        test('Simple transfers with bad origination', 2, async (done: () => void) => {
             expect.assertions(1);
             try {
                 await Tezos.contract
@@ -93,7 +94,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             done();
         });
 
-        it('Test batch from account with low balance', async (done) => {
+        test('Test batch from account with low balance', 2, async (done: () => void) => {
             const LocalTez = await createAddress();
             const op = await Tezos.contract.transfer({ to: await LocalTez.signer.publicKeyHash(), amount: 2 });
             await op.confirmation();
@@ -120,7 +121,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             done();
         });
 
-        it('Chain contract calls', async (done) => {
+        test('Chain contract calls', 2, async (done: () => void) => {
             const op = await Tezos.contract.originate({
                 balance: '1',
                 code: managerCode,
@@ -147,7 +148,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             done();
         });
 
-        it('Batch transfers and method call', async (done) => {
+        test('Batch transfers and method call', 2, async (done: () => void) => {
             const contract = await Tezos.contract.at(knownContract);
             const batchOp = await Tezos.contract
                 .batch([

--- a/integration-tests/contract-tx-wait-2-confirmations.spec.ts
+++ b/integration-tests/contract-tx-wait-2-confirmations.spec.ts
@@ -2,13 +2,14 @@ import { CONFIGS } from "./config";
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
+  const test = require('jest-retries');
   describe(`Test tx and waiting for 2 confirmations using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
       await setup()
       done()
     })
-    it('transfers 2 tez and waits for 2 confirmations', async (done) => {
+    test('transfers 2 tez and waits for 2 confirmations', 2, async (done: () => void) => {
       const op = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 })
       await op.confirmation()
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)

--- a/integration-tests/wallet-no-annotations-call-by-index.spec.ts
+++ b/integration-tests/wallet-no-annotations-call-by-index.spec.ts
@@ -3,13 +3,14 @@ import { noAnnotCode, noAnnotInit } from "./data/token_without_annotation";
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
+  const test = require('jest-retries');
   describe(`Test contract made with wallet API with no annotations calling methods by index using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
       await setup()
       done()
     })
-    it('Test contract made with wallet API with no annotations for methods', async (done) => {
+    test('Test contract made with wallet API with no annotations for methods', 2, async (done: () => void) => {
       // Constants to replace annotations
       const ACCOUNTS = '0';
       const BALANCE = '0';

--- a/integration-tests/wallet-originate-contract-unpair.spec.ts
+++ b/integration-tests/wallet-originate-contract-unpair.spec.ts
@@ -4,6 +4,7 @@ import { Protocols } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
     const Tezos = lib;
+    const test = require('jest-retries');
 
     describe(`Test origination of a token contract using: ${rpc}`, () => {
         beforeEach(async (done) => {
@@ -11,7 +12,7 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
             done();
         });
 
-        test('Originates a contract having UNPAIR with code and init in Michelson', async (done) => {
+        test('Originates a contract having UNPAIR with code and init in Michelson', 2, async (done: () => void) => {
             const op = await Tezos.wallet.originate({
                 code: miStr,
                 init: '(Pair 0 "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn")'
@@ -34,7 +35,7 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
             done();
         });
 
-        test('Originates a contract having UNPAIR with code in Michelson and init in JSON Michelson', async (done) => {
+        test('Originates a contract having UNPAIR with code in Michelson and init in JSON Michelson', 2, async (done: () => void) => {
             const op = await Tezos.wallet.originate({
                 code: miStr,
                 init: { prim: 'Pair', args: [{ int: '0' }, { string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn' }] }
@@ -57,7 +58,7 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
             done();
         });
 
-        test('Originates a contract having UNPAIR with code in Michelson and storage', async (done) => {
+        test('Originates a contract having UNPAIR with code in Michelson and storage', 2, async (done: () => void) => {
             const op = await Tezos.wallet.originate({
                 code: miStr,
                 storage: {
@@ -83,7 +84,7 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
             done();
         });
 
-        test('Originates a contract having UNPAIR with code in JSON Michelson and init in Michelson', async (done) => {
+        test('Originates a contract having UNPAIR with code in JSON Michelson and init in Michelson', 2, async (done: () => void) => {
             const op = await Tezos.wallet.originate({
                 code: miObject,
                 init: '(Pair 0 "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn")'
@@ -106,7 +107,7 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
             done();
         });
 
-        test('Originates a contract having UNPAIR with code and init in JSON Michelson', async (done) => {
+        test('Originates a contract having UNPAIR with code and init in JSON Michelson', 2, async (done: () => void) => {
             const op = await Tezos.wallet.originate({
                 code: miObject,
                 init: { prim: 'Pair', args: [{ int: '0' }, { string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn' }] }
@@ -129,7 +130,7 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
             done();
         });
 
-        test('Originates a contract having UNPAIR with code in JSON Michelson and storage', async (done) => {
+        test('Originates a contract having UNPAIR with code in JSON Michelson and storage', 2, async (done: () => void) => {
             const op = await Tezos.wallet.originate({
                 code: miObject,
                 storage: {

--- a/integration-tests/wallet-originate-vote-contract.spec.ts
+++ b/integration-tests/wallet-originate-vote-contract.spec.ts
@@ -1,16 +1,16 @@
 import { CONFIGS } from "./config";
 import { voteSample } from "./data/vote-contract";
-import { STATUS_CODE } from '@taquito/http-utils';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
+  const test = require('jest-retries');
   describe(`Originate a voting contract using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
       await setup()
       done()
     })
-    it('originates a voting contract made with wallet api and inits the storage', async (done) => {
+    test('originates a voting contract made with wallet api and inits the storage', 2, async (done: () => void) => {
       // TODO: probably remove this as very expensive
       const op = await Tezos.wallet.originate({
         balance: "1",

--- a/integration-tests/wallet-unit-as-param.spec.ts
+++ b/integration-tests/wallet-unit-as-param.spec.ts
@@ -3,13 +3,14 @@ import { depositContractCode, depositContractStorage } from "./data/deposit_cont
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
+  const test = require('jest-retries');
   describe(`Test contract made with wallet API with unit as params using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
       await setup()
       done()
     })
-    it('originates contract made with wallet API and calls deposit method with unit param', async (done) => {
+    test('originates contract made with wallet API and calls deposit method with unit param', 2, async (done: () => void) => {
       const op = await Tezos.wallet.originate({
         balance: "1",
         code: depositContractCode,


### PR DESCRIPTION
There are still integration tests for Taquito failing in CI/CD. These additional retries should help make MRs get through the pipelines more easily.