### PR TITLE
Keep compatibility to delegate to a tz address

### DIFF
--- a/integration-tests/contract-simple-delegation.spec.ts
+++ b/integration-tests/contract-simple-delegation.spec.ts
@@ -1,8 +1,9 @@
 import { CONFIGS } from "./config";
-import { DEFAULT_FEE, DEFAULT_GAS_LIMIT } from "@taquito/taquito";
+import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, Protocols } from "@taquito/taquito";
 
-CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownBakerContract }) => {
+CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownBakerContract, protocol }) => {
   const Tezos = lib;
+  const falphanet = (protocol === Protocols.PsrsRVg1) ? test : test.skip;
   describe(`Test delegation off account using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
@@ -10,7 +11,30 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownBakerContract }) => {
       done()
     })
     it('succeeds in delegating its account to a known baker', async (done) => {
-      const delegate = knownBakerContract || knownBaker;
+      const delegate = knownBaker;
+      try {
+        const op = await Tezos.contract.setDelegate({
+          delegate,
+          source: await Tezos.signer.publicKeyHash(),
+          fee: DEFAULT_FEE.DELEGATION,
+          gasLimit: DEFAULT_GAS_LIMIT.DELEGATION
+        })
+        await op.confirmation()
+        expect(op.hash).toBeDefined();
+        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+  
+        const account = await Tezos.rpc.getDelegate(await Tezos.signer.publicKeyHash())
+        // For Falphanet account will be equal to the knownBakerContract instead of knownBaker 
+        expect(account).toEqual(knownBakerContract || delegate)
+      } catch (ex) {
+        //When running tests more than one time with the same faucet key, the account is already delegated to the given delegate
+        expect(ex.message).toMatch(/delegate\.unchanged|delegation\.unchanged/)
+      }
+      done();
+    });
+
+    falphanet('succeeds in delegating its account to a known baker SG1 address format', async (done) => {
+      const delegate = knownBakerContract!;
       try {
         const op = await Tezos.contract.setDelegate({
           delegate,

--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -110,6 +110,13 @@ export const createSetDelegateOperation = async ({
     storage_limit: storageLimit,
     delegate,
   };
+  // Fix for Falphanet: There is a new version of Delegation.
+  // The type of the delegate field is changed from public_key_hash to baker_hash 
+  // and version field is added to disambiguate from the legacy types with constant value "1".
+  // The legacy types are preserved with the original encoding for compatibility.
+  if((/sg1/i.test(delegate))){
+    Object.assign(operation, { version: '1' });
+  }
   return operation;
 };
 

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -133,12 +133,6 @@ export abstract class OperationEmitter {
       };
     };
 
-    const getVersion = () => {
-      return metadata.protocol !== Protocols.PsrsRVg1 ? null : {
-        version: "1"
-      };
-    };
-
     const constructOps = (cOps: RPCOperation[]): OperationContents[] =>
       // tslint:disable strict-type-predicates
       cOps.map((op: RPCOperation) => {
@@ -177,8 +171,7 @@ export abstract class OperationEmitter {
             return {
               ...op,
               ...getSource(op),
-              ...getFee(op),
-              ...getVersion(),
+              ...getFee(op)
             };
           default:
             throw new Error('Unsupported operation');


### PR DESCRIPTION
We need to be able to delegate to a tz address as well as to a SG1 address on Falphanet.
I made a modification to add {version: '1'} to the operation if the delegate is a SG1 address instead of if the protocol is PsrsRVg1.