### PR TITLE
Update rpc nodes list in Taquito online docs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,6 @@ jobs:
     - run: npm ci
     - run: npm run lerna -- bootstrap
     - run: npm run build
-    - run: cd integration-tests && npm run test:edonet -- --maxWorkers=${{ secrets.NPM_JEST_MAX_WORKERS }}
+    - run: cd integration-tests && npm run test:edonet -- --maxWorkers=8
       env:
         CI: true
-        TEZOS_RPC_EDONET: ${{ secrets.TEZOS_RPC_EDONET }}
-        TEZOS_RPC_FLORENCENET: ${{ secrets.TEZOS_RPC_FLORENCENET }}

--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -17,20 +17,17 @@ author: Roxane Letourneau
 
 - Tezos Giga Node from Tezos Ukraine
     - Mainnet: https://mainnet-tezos.giganode.io
-    - Delphi testnet: https://testnet-tezos.giganode.io
     - Edo testnet: https://edonet-tezos.giganode.io
 - SmartPy nodes
     - Mainnet: https://mainnet.smartpy.io
-    - Zeronet: https://zeronet.smartpy.io
     - Edonet: https://edonet.smartpy.io/
 - Nodes operated by Blockscale on behalf of the Tezos Foundation: 
     - Mainnet: https://rpc.tzbeta.net/
-    - Current protocol/version testnet (Delphinet): https://rpctest.tzbeta.net/
     - Next protocol/version testnet (Edonet): https://rpczero.tzbeta.net/
 - ECAD Labs nodes:
     - Mainnet: https://api.tez.ie/rpc/mainnet
-    - Delphinet: https://api.tez.ie/rpc/delphinet
     - Edonet: https://api.tez.ie/rpc/edonet (edo2net / Chainid is `NetXSgo1ZT2DRUG`)
+    - Florencenet: https://api.tez.ie/rpc/florencenet
 
 ## How to run a node
 


### PR DESCRIPTION
The RPC nodes list in Taquito docs at https://tezostaquito.io/docs/rpc_nodes is out of date

drop the Delphi nodes and add ECAD florencenet node.
Close #694 
