### PR TITLE
Support all token types for the property value of a ticket

### DIFF
--- a/packages/taquito-michelson-encoder/data/sample19_timestamp_ticket.ts
+++ b/packages/taquito-michelson-encoder/data/sample19_timestamp_ticket.ts
@@ -1,0 +1,2680 @@
+export const rpcContractResponse = {
+	balance: '4',
+	script: {
+		code: [
+			{
+				prim: 'parameter',
+				args: [
+					{
+						prim: 'or',
+						args: [
+							{
+								prim: 'or',
+								args: [
+									{
+										prim: 'or',
+										args: [
+											{ prim: 'nat', annots: [ '%buy_tickets' ] },
+											{ prim: 'nat', annots: [ '%place_bet' ] }
+										]
+									},
+									{
+										prim: 'or',
+										args: [
+											{ prim: 'unit', annots: [ '%reset_pool' ] },
+											{ prim: 'address', annots: [ '%update_oracle' ] }
+										]
+									}
+								]
+							},
+							{
+								prim: 'or',
+								args: [
+									{ prim: 'unit', annots: [ '%validate_pool' ] },
+									{
+										prim: 'pair',
+										args: [ { prim: 'string' }, { prim: 'timestamp' }, { prim: 'nat' } ],
+										annots: [ '%validate_pool_confirm' ]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			{
+				prim: 'storage',
+				args: [
+					{
+						prim: 'pair',
+						args: [
+							{
+								prim: 'pair',
+								args: [
+									{
+										prim: 'big_map',
+										args: [ { prim: 'address' }, { prim: 'mutez' } ],
+										annots: [ '%winners' ]
+									},
+									{
+										prim: 'map',
+										args: [ { prim: 'address' }, { prim: 'nat' } ],
+										annots: [ '%bets' ]
+									},
+									{ prim: 'mutez', annots: [ '%current_pot' ] },
+									{ prim: 'timestamp', annots: [ '%opened_at' ] },
+									{
+										prim: 'pair',
+										args: [
+											{ prim: 'string', annots: [ '%pool_type' ] },
+											{ prim: 'mutez', annots: [ '%entrance_fee' ] },
+											{ prim: 'mutez', annots: [ '%minimum_bet' ] },
+											{ prim: 'int', annots: [ '%open_period' ] },
+											{ prim: 'int', annots: [ '%validation_delay' ] },
+											{ prim: 'int', annots: [ '%ticket_validity' ] },
+											{ prim: 'nat', annots: [ '%max_capacity' ] }
+										],
+										annots: [ '%settings' ]
+									},
+									{ prim: 'option', args: [ { prim: 'address' } ], annots: [ '%validator' ] },
+									{ prim: 'bool', annots: [ '%pending_validation' ] },
+									{ prim: 'address', annots: [ '%oracle' ] },
+									{ prim: 'address', annots: [ '%admin' ] }
+								],
+								annots: [ '%data' ]
+							},
+							{
+								prim: 'big_map',
+								args: [ { prim: 'address' }, { prim: 'ticket', args: [ { prim: 'timestamp' } ] } ],
+								annots: [ '%tickets' ]
+							}
+						]
+					}
+				]
+			},
+			{
+				prim: 'code',
+				args: [
+					[
+						{
+							prim: 'LAMBDA',
+							args: [
+								{
+									prim: 'pair',
+									args: [
+										{
+											prim: 'pair',
+											args: [
+												{ prim: 'big_map', args: [ { prim: 'address' }, { prim: 'mutez' } ] },
+												{
+													prim: 'pair',
+													args: [
+														{ prim: 'map', args: [ { prim: 'address' }, { prim: 'nat' } ] },
+														{
+															prim: 'pair',
+															args: [
+																{ prim: 'mutez' },
+																{
+																	prim: 'pair',
+																	args: [
+																		{ prim: 'timestamp' },
+																		{
+																			prim: 'pair',
+																			args: [
+																				{
+																					prim: 'pair',
+																					args: [
+																						{ prim: 'string' },
+																						{
+																							prim: 'pair',
+																							args: [
+																								{ prim: 'mutez' },
+																								{
+																									prim: 'pair',
+																									args: [
+																										{
+																											prim:
+																												'mutez'
+																										},
+																										{
+																											prim:
+																												'pair',
+																											args: [
+																												{
+																													prim:
+																														'int'
+																												},
+																												{
+																													prim:
+																														'pair',
+																													args: [
+																														{
+																															prim:
+																																'int'
+																														},
+																														{
+																															prim:
+																																'pair',
+																															args: [
+																																{
+																																	prim:
+																																		'int'
+																																},
+																																{
+																																	prim:
+																																		'nat'
+																																}
+																															]
+																														}
+																													]
+																												}
+																											]
+																										}
+																									]
+																								}
+																							]
+																						}
+																					]
+																				},
+																				{
+																					prim: 'pair',
+																					args: [
+																						{
+																							prim: 'option',
+																							args: [
+																								{ prim: 'address' }
+																							]
+																						},
+																						{
+																							prim: 'pair',
+																							args: [
+																								{ prim: 'bool' },
+																								{
+																									prim: 'pair',
+																									args: [
+																										{
+																											prim:
+																												'address'
+																										},
+																										{
+																											prim:
+																												'address'
+																										}
+																									]
+																								}
+																							]
+																						}
+																					]
+																				}
+																			]
+																		}
+																	]
+																}
+															]
+														}
+													]
+												}
+											]
+										},
+										{ prim: 'address' }
+									]
+								},
+								{ prim: 'operation' },
+								[
+									{ prim: 'UNPAIR' },
+									{ prim: 'SWAP' },
+									{
+										prim: 'CONTRACT',
+										args: [
+											{
+												prim: 'pair',
+												args: [
+													{ prim: 'string' },
+													{ prim: 'pair', args: [ { prim: 'timestamp' }, { prim: 'nat' } ] }
+												]
+											}
+										],
+										annots: [ '%validate_pool_confirm' ]
+									},
+									{
+										prim: 'IF_NONE',
+										args: [
+											[
+												{
+													prim: 'PUSH',
+													args: [ { prim: 'string' }, { string: 'NO_CONTRACT' } ]
+												},
+												{ prim: 'FAILWITH' }
+											],
+											[]
+										]
+									},
+									{ prim: 'SWAP' },
+									{ prim: 'DUP' },
+									{ prim: 'DUG', args: [ { int: '2' } ] },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CAR' },
+									{
+										prim: 'CONTRACT',
+										args: [
+											{
+												prim: 'pair',
+												args: [
+													{ prim: 'string' },
+													{
+														prim: 'contract',
+														args: [
+															{
+																prim: 'pair',
+																args: [
+																	{ prim: 'string' },
+																	{
+																		prim: 'pair',
+																		args: [ { prim: 'timestamp' }, { prim: 'nat' } ]
+																	}
+																]
+															}
+														]
+													}
+												]
+											}
+										],
+										annots: [ '%get' ]
+									},
+									{
+										prim: 'IF_NONE',
+										args: [
+											[
+												{ prim: 'PUSH', args: [ { prim: 'string' }, { string: 'NO_ORACLE' } ] },
+												{ prim: 'FAILWITH' }
+											],
+											[]
+										]
+									},
+									{ prim: 'PUSH', args: [ { prim: 'mutez' }, { int: '0' } ] },
+									{ prim: 'DIG', args: [ { int: '2' } ] },
+									{ prim: 'DIG', args: [ { int: '3' } ] },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CDR' },
+									{ prim: 'CAR' },
+									{ prim: 'CAR' },
+									{ prim: 'PAIR' },
+									{ prim: 'TRANSFER_TOKENS' }
+								]
+							]
+						},
+						{ prim: 'SWAP' },
+						{ prim: 'UNPAIR' },
+						{ prim: 'SWAP' },
+						{ prim: 'UNPAIR' },
+						{ prim: 'DIG', args: [ { int: '2' } ] },
+						{
+							prim: 'IF_LEFT',
+							args: [
+								[
+									{
+										prim: 'IF_LEFT',
+										args: [
+											[
+												{ prim: 'DIG', args: [ { int: '3' } ] },
+												{ prim: 'DROP' },
+												{
+													prim: 'IF_LEFT',
+													args: [
+														[
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'PUSH', args: [ { prim: 'nat' }, { int: '0' } ] },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '4' } ] },
+															{ prim: 'COMPARE' },
+															{ prim: 'EQ' },
+															{
+																prim: 'IF',
+																args: [
+																	[
+																		{ prim: 'DROP', args: [ { int: '3' } ] },
+																		{
+																			prim: 'PUSH',
+																			args: [
+																				{ prim: 'string' },
+																				{ string: 'ZERO_TICKET_AMOUNT' }
+																			]
+																		},
+																		{ prim: 'FAILWITH' }
+																	],
+																	[
+																		{ prim: 'DUP' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'DIG', args: [ { int: '3' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '4' } ] },
+																		{ prim: 'MUL' },
+																		{ prim: 'AMOUNT' },
+																		{ prim: 'COMPARE' },
+																		{ prim: 'NEQ' },
+																		{
+																			prim: 'IF',
+																			args: [
+																				[
+																					{
+																						prim: 'DROP',
+																						args: [ { int: '3' } ]
+																					},
+																					{
+																						prim: 'PUSH',
+																						args: [
+																							{ prim: 'string' },
+																							{
+																								string:
+																									'INCORRECT_AMOUNT'
+																							}
+																						]
+																					},
+																					{ prim: 'FAILWITH' }
+																				],
+																				[
+																					{ prim: 'SWAP' },
+																					{
+																						prim: 'NONE',
+																						args: [
+																							{
+																								prim: 'ticket',
+																								args: [
+																									{
+																										prim:
+																											'timestamp'
+																									}
+																								]
+																							}
+																						]
+																					},
+																					{ prim: 'SENDER' },
+																					{ prim: 'GET_AND_UPDATE' },
+																					{
+																						prim: 'IF_NONE',
+																						args: [
+																							[
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'NOW' },
+																								{ prim: 'TICKET' }
+																							],
+																							[
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '3' }
+																									]
+																								},
+																								{ prim: 'NOW' },
+																								{ prim: 'TICKET' },
+																								{ prim: 'PAIR' },
+																								{
+																									prim: 'JOIN_TICKETS'
+																								},
+																								{
+																									prim: 'IF_NONE',
+																									args: [
+																										[
+																											{
+																												prim:
+																													'PUSH',
+																												args: [
+																													{
+																														prim:
+																															'string'
+																													},
+																													{
+																														string:
+																															'UNJOIGNABLE_TICKETS'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'FAILWITH'
+																											}
+																										],
+																										[]
+																									]
+																								}
+																							]
+																						]
+																					},
+																					{ prim: 'SOME' },
+																					{ prim: 'SENDER' },
+																					{ prim: 'GET_AND_UPDATE' },
+																					{ prim: 'DROP' },
+																					{ prim: 'SWAP' },
+																					{ prim: 'PAIR' },
+																					{
+																						prim: 'NIL',
+																						args: [ { prim: 'operation' } ]
+																					},
+																					{ prim: 'PAIR' }
+																				]
+																			]
+																		}
+																	]
+																]
+															}
+														],
+														[
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'SWAP' },
+															{
+																prim: 'NONE',
+																args: [
+																	{ prim: 'ticket', args: [ { prim: 'timestamp' } ] }
+																]
+															},
+															{ prim: 'SENDER' },
+															{ prim: 'GET_AND_UPDATE' },
+															{
+																prim: 'IF_NONE',
+																args: [
+																	[
+																		{
+																			prim: 'PUSH',
+																			args: [
+																				{ prim: 'string' },
+																				{ string: 'NO_TICKET' }
+																			]
+																		},
+																		{ prim: 'FAILWITH' }
+																	],
+																	[ { prim: 'READ_TICKET' }, { prim: 'PAIR' } ]
+																]
+															},
+															{ prim: 'UNPAIR' },
+															{ prim: 'SWAP' },
+															{ prim: 'DROP' },
+															{ prim: 'UNPAIR' },
+															{ prim: 'DROP' },
+															{ prim: 'UNPAIR' },
+															{ prim: 'NOW' },
+															{ prim: 'DIG', args: [ { int: '4' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '5' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'DIG', args: [ { int: '2' } ] },
+															{ prim: 'ADD' },
+															{ prim: 'COMPARE' },
+															{ prim: 'LT' },
+															{
+																prim: 'IF',
+																args: [
+																	[
+																		{ prim: 'DROP', args: [ { int: '4' } ] },
+																		{
+																			prim: 'PUSH',
+																			args: [
+																				{ prim: 'string' },
+																				{ string: 'INVALID_TICKET' }
+																			]
+																		},
+																		{ prim: 'FAILWITH' }
+																	],
+																	[
+																		{
+																			prim: 'PUSH',
+																			args: [ { prim: 'nat' }, { int: '1' } ]
+																		},
+																		{ prim: 'SWAP' },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '2' } ] },
+																		{ prim: 'COMPARE' },
+																		{ prim: 'LT' },
+																		{
+																			prim: 'IF',
+																			args: [
+																				[
+																					{
+																						prim: 'DROP',
+																						args: [ { int: '4' } ]
+																					},
+																					{
+																						prim: 'PUSH',
+																						args: [
+																							{ prim: 'string' },
+																							{
+																								string:
+																									'INVALID_TICKETS_AMOUNT'
+																							}
+																						]
+																					},
+																					{ prim: 'FAILWITH' }
+																				],
+																				[
+																					{ prim: 'NOW' },
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '3' } ]
+																					},
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '4' } ]
+																					},
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CAR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CAR' },
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '4' } ]
+																					},
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '5' } ]
+																					},
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CAR' },
+																					{ prim: 'ADD' },
+																					{ prim: 'COMPARE' },
+																					{ prim: 'LT' },
+																					{
+																						prim: 'IF',
+																						args: [
+																							[
+																								{
+																									prim: 'DROP',
+																									args: [
+																										{ int: '4' }
+																									]
+																								},
+																								{
+																									prim: 'PUSH',
+																									args: [
+																										{
+																											prim:
+																												'string'
+																										},
+																										{
+																											string:
+																												'NOT_OPEN'
+																										}
+																									]
+																								},
+																								{ prim: 'FAILWITH' }
+																							],
+																							[
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '3' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '3' }
+																									]
+																								},
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '4' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'SIZE' },
+																								{ prim: 'COMPARE' },
+																								{ prim: 'GE' },
+																								{
+																									prim: 'IF',
+																									args: [
+																										[
+																											{
+																												prim:
+																													'DROP',
+																												args: [
+																													{
+																														int:
+																															'4'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'PUSH',
+																												args: [
+																													{
+																														prim:
+																															'string'
+																													},
+																													{
+																														string:
+																															'MAXIMUM_CAPACITY'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'FAILWITH'
+																											}
+																										],
+																										[
+																											{
+																												prim:
+																													'SWAP'
+																											},
+																											{
+																												prim:
+																													'PUSH',
+																												args: [
+																													{
+																														prim:
+																															'nat'
+																													},
+																													{
+																														int:
+																															'1'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'SUB'
+																											},
+																											{
+																												prim:
+																													'ABS'
+																											},
+																											{
+																												prim:
+																													'NOW'
+																											},
+																											{
+																												prim:
+																													'TICKET'
+																											},
+																											{
+																												prim:
+																													'SOME'
+																											},
+																											{
+																												prim:
+																													'SENDER'
+																											},
+																											{
+																												prim:
+																													'GET_AND_UPDATE'
+																											},
+																											{
+																												prim:
+																													'DROP'
+																											},
+																											{
+																												prim:
+																													'SWAP'
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'4'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'SOME'
+																											},
+																											{
+																												prim:
+																													'SENDER'
+																											},
+																											{
+																												prim:
+																													'UPDATE'
+																											},
+																											{
+																												prim:
+																													'PAIR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'PAIR'
+																											},
+																											{
+																												prim:
+																													'PAIR'
+																											}
+																										]
+																									]
+																								}
+																							]
+																						]
+																					}
+																				]
+																			]
+																		}
+																	]
+																]
+															},
+															{ prim: 'NIL', args: [ { prim: 'operation' } ] },
+															{ prim: 'PAIR' }
+														]
+													]
+												}
+											],
+											[
+												{
+													prim: 'IF_LEFT',
+													args: [
+														[
+															{ prim: 'DROP' },
+															{ prim: 'DUP' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'SENDER' },
+															{ prim: 'COMPARE' },
+															{ prim: 'NEQ' },
+															{
+																prim: 'IF',
+																args: [
+																	[
+																		{ prim: 'DROP', args: [ { int: '3' } ] },
+																		{
+																			prim: 'PUSH',
+																			args: [
+																				{ prim: 'string' },
+																				{ string: 'UNAUTHORIZED_ACTION' }
+																			]
+																		},
+																		{ prim: 'FAILWITH' }
+																	],
+																	[
+																		{ prim: 'NOW' },
+																		{ prim: 'SWAP' },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '2' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'DIG', args: [ { int: '3' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '4' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'ADD' },
+																		{ prim: 'ADD' },
+																		{ prim: 'COMPARE' },
+																		{ prim: 'GT' },
+																		{
+																			prim: 'IF',
+																			args: [
+																				[
+																					{
+																						prim: 'DROP',
+																						args: [ { int: '3' } ]
+																					},
+																					{
+																						prim: 'PUSH',
+																						args: [
+																							{ prim: 'string' },
+																							{
+																								string:
+																									'TOO_EARLY_FOR_RESET'
+																							}
+																						]
+																					},
+																					{ prim: 'FAILWITH' }
+																				],
+																				[
+																					{ prim: 'SELF_ADDRESS' },
+																					{ prim: 'SWAP' },
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'PAIR' },
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '3' } ]
+																					},
+																					{ prim: 'SWAP' },
+																					{ prim: 'EXEC' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'PAIR' },
+																					{
+																						prim: 'NIL',
+																						args: [ { prim: 'operation' } ]
+																					},
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'CONS' },
+																					{ prim: 'PAIR' }
+																				]
+																			]
+																		}
+																	]
+																]
+															}
+														],
+														[
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DROP' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'SENDER' },
+															{ prim: 'COMPARE' },
+															{ prim: 'NEQ' },
+															{
+																prim: 'IF',
+																args: [
+																	[
+																		{ prim: 'DROP', args: [ { int: '3' } ] },
+																		{
+																			prim: 'PUSH',
+																			args: [
+																				{ prim: 'string' },
+																				{ string: 'NOT_AN_ADMIN' }
+																			]
+																		},
+																		{ prim: 'FAILWITH' }
+																	],
+																	[
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '2' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'DIG', args: [ { int: '3' } ] },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'CAR' },
+																		{ prim: 'PAIR' },
+																		{ prim: 'PAIR' }
+																	]
+																]
+															},
+															{ prim: 'NIL', args: [ { prim: 'operation' } ] },
+															{ prim: 'PAIR' }
+														]
+													]
+												}
+											]
+										]
+									}
+								],
+								[
+									{
+										prim: 'IF_LEFT',
+										args: [
+											[
+												{ prim: 'DROP' },
+												{ prim: 'DUP' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CAR' },
+												{
+													prim: 'IF',
+													args: [
+														[
+															{ prim: 'DROP', args: [ { int: '3' } ] },
+															{
+																prim: 'PUSH',
+																args: [
+																	{ prim: 'string' },
+																	{ string: 'ACTIVE_PENDING_VALIDATION' }
+																]
+															},
+															{ prim: 'FAILWITH' }
+														],
+														[
+															{ prim: 'SELF_ADDRESS' },
+															{ prim: 'SWAP' },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'SWAP' },
+															{ prim: 'EXEC' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '3' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{
+																prim: 'PUSH',
+																args: [ { prim: 'bool' }, { prim: 'True' } ]
+															},
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '4' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '4' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '4' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '4' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '4' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'DIG', args: [ { int: '3' } ] },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'DUP' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'SENDER' },
+															{ prim: 'SOME' },
+															{ prim: 'PAIR' },
+															{ prim: 'SWAP' },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'SWAP' },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'SWAP' },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'SWAP' },
+															{ prim: 'DUP' },
+															{ prim: 'DUG', args: [ { int: '2' } ] },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'SWAP' },
+															{ prim: 'CAR' },
+															{ prim: 'PAIR' },
+															{ prim: 'PAIR' },
+															{ prim: 'NIL', args: [ { prim: 'operation' } ] },
+															{ prim: 'DIG', args: [ { int: '2' } ] },
+															{ prim: 'CONS' },
+															{ prim: 'PAIR' }
+														]
+													]
+												}
+											],
+											[
+												{ prim: 'DIG', args: [ { int: '3' } ] },
+												{ prim: 'DROP' },
+												{ prim: 'DUG', args: [ { int: '2' } ] },
+												{ prim: 'DUP' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CDR' },
+												{ prim: 'CAR' },
+												{ prim: 'NOT' },
+												{
+													prim: 'IF',
+													args: [
+														[
+															{ prim: 'DROP', args: [ { int: '3' } ] },
+															{
+																prim: 'PUSH',
+																args: [
+																	{ prim: 'string' },
+																	{ string: 'NO_PENDING_VALIDATION' }
+																]
+															},
+															{ prim: 'FAILWITH' }
+														],
+														[
+															{ prim: 'DUP' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CDR' },
+															{ prim: 'CAR' },
+															{ prim: 'SENDER' },
+															{ prim: 'COMPARE' },
+															{ prim: 'NEQ' },
+															{
+																prim: 'IF',
+																args: [
+																	[
+																		{ prim: 'DROP', args: [ { int: '3' } ] },
+																		{
+																			prim: 'PUSH',
+																			args: [
+																				{ prim: 'string' },
+																				{ string: 'UNAUTHORIZED_SENDER' }
+																			]
+																		},
+																		{ prim: 'FAILWITH' }
+																	],
+																	[
+																		{ prim: 'NOW' },
+																		{ prim: 'SWAP' },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '2' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'DIG', args: [ { int: '2' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '3' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'DIG', args: [ { int: '3' } ] },
+																		{ prim: 'DUP' },
+																		{ prim: 'DUG', args: [ { int: '4' } ] },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CDR' },
+																		{ prim: 'CAR' },
+																		{ prim: 'ADD' },
+																		{ prim: 'ADD' },
+																		{ prim: 'COMPARE' },
+																		{ prim: 'GT' },
+																		{
+																			prim: 'IF',
+																			args: [
+																				[
+																					{
+																						prim: 'DROP',
+																						args: [ { int: '3' } ]
+																					},
+																					{
+																						prim: 'PUSH',
+																						args: [
+																							{ prim: 'string' },
+																							{
+																								string:
+																									'UNAVAILABLE_FOR_VALIDATION'
+																							}
+																						]
+																					},
+																					{ prim: 'FAILWITH' }
+																				],
+																				[
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{
+																						prim: 'PUSH',
+																						args: [
+																							{ prim: 'nat' },
+																							{ int: '100' }
+																						]
+																					},
+																					{ prim: 'SWAP' },
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'MUL' },
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '3' } ]
+																					},
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'PAIR' },
+																					{
+																						prim: 'DIG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '3' } ]
+																					},
+																					{ prim: 'CDR' },
+																					{ prim: 'CAR' },
+																					{
+																						prim: 'ITER',
+																						args: [
+																							[
+																								{ prim: 'SWAP' },
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '3' }
+																									]
+																								},
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '3' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'COMPARE' },
+																								{ prim: 'EQ' },
+																								{
+																									prim: 'IF',
+																									args: [
+																										[
+																											{
+																												prim:
+																													'DROP'
+																											},
+																											{
+																												prim:
+																													'PUSH',
+																												args: [
+																													{
+																														prim:
+																															'nat'
+																													},
+																													{
+																														int:
+																															'0'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'SWAP'
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'PAIR'
+																											}
+																										],
+																										[
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'COMPARE'
+																											},
+																											{
+																												prim:
+																													'GT'
+																											},
+																											{
+																												prim:
+																													'IF',
+																												args: [
+																													[
+																														{
+																															prim:
+																																'DIG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'3'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'DIG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'3'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'CDR'
+																														},
+																														{
+																															prim:
+																																'SUB'
+																														},
+																														{
+																															prim:
+																																'ABS'
+																														},
+																														{
+																															prim:
+																																'SWAP'
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'CDR'
+																														},
+																														{
+																															prim:
+																																'SWAP'
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'COMPARE'
+																														},
+																														{
+																															prim:
+																																'LT'
+																														},
+																														{
+																															prim:
+																																'IF',
+																															args: [
+																																[
+																																	{
+																																		prim:
+																																			'SWAP'
+																																	},
+																																	{
+																																		prim:
+																																			'DROP'
+																																	},
+																																	{
+																																		prim:
+																																			'SWAP'
+																																	},
+																																	{
+																																		prim:
+																																			'CAR'
+																																	},
+																																	{
+																																		prim:
+																																			'PAIR'
+																																	}
+																																],
+																																[
+																																	{
+																																		prim:
+																																			'DROP'
+																																	},
+																																	{
+																																		prim:
+																																			'SWAP'
+																																	},
+																																	{
+																																		prim:
+																																			'DROP'
+																																	}
+																																]
+																															]
+																														}
+																													],
+																													[
+																														{
+																															prim:
+																																'SWAP'
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'CDR'
+																														},
+																														{
+																															prim:
+																																'DIG',
+																															args: [
+																																{
+																																	int:
+																																		'3'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'4'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'SUB'
+																														},
+																														{
+																															prim:
+																																'ABS'
+																														},
+																														{
+																															prim:
+																																'SWAP'
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'CDR'
+																														},
+																														{
+																															prim:
+																																'SWAP'
+																														},
+																														{
+																															prim:
+																																'DUP'
+																														},
+																														{
+																															prim:
+																																'DUG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'COMPARE'
+																														},
+																														{
+																															prim:
+																																'LT'
+																														},
+																														{
+																															prim:
+																																'IF',
+																															args: [
+																																[
+																																	{
+																																		prim:
+																																			'SWAP'
+																																	},
+																																	{
+																																		prim:
+																																			'DROP'
+																																	},
+																																	{
+																																		prim:
+																																			'SWAP'
+																																	},
+																																	{
+																																		prim:
+																																			'CAR'
+																																	},
+																																	{
+																																		prim:
+																																			'PAIR'
+																																	}
+																																],
+																																[
+																																	{
+																																		prim:
+																																			'DROP'
+																																	},
+																																	{
+																																		prim:
+																																			'SWAP'
+																																	},
+																																	{
+																																		prim:
+																																			'DROP'
+																																	}
+																																]
+																															]
+																														}
+																													]
+																												]
+																											}
+																										]
+																									]
+																								}
+																							]
+																						]
+																					},
+																					{ prim: 'SWAP' },
+																					{ prim: 'DROP' },
+																					{ prim: 'SWAP' },
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'CDR' },
+																					{ prim: 'SWAP' },
+																					{ prim: 'DUP' },
+																					{
+																						prim: 'DUG',
+																						args: [ { int: '2' } ]
+																					},
+																					{ prim: 'CAR' },
+																					{ prim: 'COMPARE' },
+																					{ prim: 'EQ' },
+																					{
+																						prim: 'IF',
+																						args: [
+																							[
+																								{ prim: 'DROP' },
+																								{ prim: 'PAIR' }
+																							],
+																							[
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CAR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CAR' },
+																								{ prim: 'GET' },
+																								{
+																									prim: 'IF_NONE',
+																									args: [
+																										[
+																											{
+																												prim:
+																													'SWAP'
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'SWAP'
+																											},
+																											{
+																												prim:
+																													'SOME'
+																											},
+																											{
+																												prim:
+																													'SWAP'
+																											},
+																											{
+																												prim:
+																													'UPDATE'
+																											}
+																										],
+																										[
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'4'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'CDR'
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'ADD'
+																											},
+																											{
+																												prim:
+																													'SOME'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'CAR'
+																											},
+																											{
+																												prim:
+																													'UPDATE'
+																											}
+																										]
+																									]
+																								},
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{
+																									prim: 'IF_NONE',
+																									args: [
+																										[
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'2'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'NONE',
+																												args: [
+																													{
+																														prim:
+																															'ticket',
+																														args: [
+																															{
+																																prim:
+																																	'timestamp'
+																															}
+																														]
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'PAIR'
+																											}
+																										],
+																										[
+																											{
+																												prim:
+																													'PUSH',
+																												args: [
+																													{
+																														prim:
+																															'nat'
+																													},
+																													{
+																														int:
+																															'1'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'NOW'
+																											},
+																											{
+																												prim:
+																													'TICKET'
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'4'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'NONE',
+																												args: [
+																													{
+																														prim:
+																															'ticket',
+																														args: [
+																															{
+																																prim:
+																																	'timestamp'
+																															}
+																														]
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DIG',
+																												args: [
+																													{
+																														int:
+																															'3'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'DUP'
+																											},
+																											{
+																												prim:
+																													'DUG',
+																												args: [
+																													{
+																														int:
+																															'4'
+																													}
+																												]
+																											},
+																											{
+																												prim:
+																													'GET_AND_UPDATE'
+																											},
+																											{
+																												prim:
+																													'IF_NONE',
+																												args: [
+																													[
+																														{
+																															prim:
+																																'SWAP'
+																														},
+																														{
+																															prim:
+																																'SOME'
+																														},
+																														{
+																															prim:
+																																'DIG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'GET_AND_UPDATE'
+																														},
+																														{
+																															prim:
+																																'PAIR'
+																														}
+																													],
+																													[
+																														{
+																															prim:
+																																'DIG',
+																															args: [
+																																{
+																																	int:
+																																		'2'
+																																}
+																															]
+																														},
+																														{
+																															prim:
+																																'PAIR'
+																														},
+																														{
+																															prim:
+																																'JOIN_TICKETS'
+																														},
+																														{
+																															prim:
+																																'IF_NONE',
+																															args: [
+																																[
+																																	{
+																																		prim:
+																																			'DROP',
+																																		args: [
+																																			{
+																																				int:
+																																					'2'
+																																			}
+																																		]
+																																	},
+																																	{
+																																		prim:
+																																			'PUSH',
+																																		args: [
+																																			{
+																																				prim:
+																																					'string'
+																																			},
+																																			{
+																																				string:
+																																					'UNJOIGNABLE_TICKETS'
+																																			}
+																																		]
+																																	},
+																																	{
+																																		prim:
+																																			'FAILWITH'
+																																	}
+																																],
+																																[
+																																	{
+																																		prim:
+																																			'SOME'
+																																	},
+																																	{
+																																		prim:
+																																			'DIG',
+																																		args: [
+																																			{
+																																				int:
+																																					'2'
+																																			}
+																																		]
+																																	},
+																																	{
+																																		prim:
+																																			'GET_AND_UPDATE'
+																																	},
+																																	{
+																																		prim:
+																																			'PAIR'
+																																	}
+																																]
+																															]
+																														}
+																													]
+																												]
+																											}
+																										]
+																									]
+																								},
+																								{ prim: 'UNPAIR' },
+																								{ prim: 'DROP' },
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{
+																									prim: 'DIG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'PAIR' },
+																								{ prim: 'DUP' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{
+																									prim: 'PUSH',
+																									args: [
+																										{
+																											prim:
+																												'mutez'
+																										},
+																										{ int: '0' }
+																									]
+																								},
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'DUP' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{
+																									prim: 'PUSH',
+																									args: [
+																										{
+																											prim: 'bool'
+																										},
+																										{
+																											prim:
+																												'False'
+																										}
+																									]
+																								},
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'DUP' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'NOW' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'DUP' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{
+																									prim: 'NONE',
+																									args: [
+																										{
+																											prim:
+																												'address'
+																										}
+																									]
+																								},
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'DUP' },
+																								{
+																									prim: 'DUG',
+																									args: [
+																										{ int: '2' }
+																									]
+																								},
+																								{ prim: 'CDR' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'SWAP' },
+																								{ prim: 'CAR' },
+																								{ prim: 'PAIR' },
+																								{ prim: 'PAIR' }
+																							]
+																						]
+																					}
+																				]
+																			]
+																		}
+																	]
+																]
+															}
+														]
+													]
+												},
+												{ prim: 'NIL', args: [ { prim: 'operation' } ] },
+												{ prim: 'PAIR' }
+											]
+										]
+									}
+								]
+							]
+						}
+					]
+				]
+			}
+		],
+		storage: {
+			prim: 'Pair',
+			args: [
+				{
+					prim: 'Pair',
+					args: [
+						{ int: '24059' },
+						[],
+						{ int: '0' },
+						{ string: '2019-09-09T12:09:37Z' },
+						{
+							prim: 'Pair',
+							args: [
+								{ string: 'XTZ-USD' },
+								{ int: '2' },
+								{ int: '2' },
+								{ int: '86400' },
+								{ int: '86400' },
+								{ int: '2592000' },
+								{ int: '9' }
+							]
+						},
+						{ prim: 'None' },
+						{ prim: 'False' },
+						{ string: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb' },
+						{ string: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb' }
+					]
+				},
+				{ int: '24060' }
+			]
+		}
+	}
+};
+
+export const storage = rpcContractResponse.script.code.find((x) => x.prim === 'storage')!.args[0] as any;
+
+export const params = rpcContractResponse.script.code.find((x) => x.prim === 'parameter')!.args[0] as any;
+
+export const bigMapValue = {
+	prim: 'Pair',
+	args: [ { string: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw' }, { string: '2021-03-09T16:32:15Z' }, { int: '2' } ]
+};

--- a/packages/taquito-michelson-encoder/data/sample19_timestamp_ticket.ts
+++ b/packages/taquito-michelson-encoder/data/sample19_timestamp_ticket.ts
@@ -2670,8 +2670,10 @@ export const rpcContractResponse = {
 	}
 };
 
+// deepcode ignore no-any: any is good enough
 export const storage = rpcContractResponse.script.code.find((x) => x.prim === 'storage')!.args[0] as any;
 
+// deepcode ignore no-any: any is good enough
 export const params = rpcContractResponse.script.code.find((x) => x.prim === 'parameter')!.args[0] as any;
 
 export const bigMapValue = {

--- a/packages/taquito-michelson-encoder/src/tokens/ticket.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/ticket.ts
@@ -8,7 +8,7 @@ export class EncodeTicketError implements Error {
 }
 
 const ticketerType = { "prim": "contract" };
-const amountType = { "prim":"int" };
+const amountType = { "prim": "int" };
 
 export class TicketToken extends Token {
   static prim = 'ticket';
@@ -30,6 +30,9 @@ export class TicketToken extends Token {
   }
 
   public Execute(val: any, semantics?: Semantic) {
+    if (semantics && semantics[TicketToken.prim]) {
+      return semantics[TicketToken.prim](val, this.val);
+    }
     const ticketer = this.createToken(ticketerType, this.idx);
     const value = this.createToken(this.val.args[0], this.idx);
     const amount = this.createToken(amountType, this.idx);

--- a/packages/taquito-michelson-encoder/src/tokens/ticket.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/ticket.ts
@@ -1,5 +1,4 @@
 import { IntToken } from './comparable/int';
-import { NatToken } from './comparable/nat';
 import { ContractToken } from './contract';
 import { Token, TokenFactory, Semantic } from './token';
 
@@ -8,14 +7,8 @@ export class EncodeTicketError implements Error {
   message = 'Tickets cannot be sent to the blockchain; they are created on-chain';
 }
 
-const readableTicketType = {
-  "prim":"Pair",
-  "args":[
-    {"prim":"contract"},
-    {"prim":"nat"},
-    {"prim":"int"}
-  ]
-}
+const ticketerType = { "prim": "contract" };
+const amountType = { "prim":"int" };
 
 export class TicketToken extends Token {
   static prim = 'ticket';
@@ -36,21 +29,22 @@ export class TicketToken extends Token {
     throw new EncodeTicketError()  
   }
 
-  public Execute(val: any, _semantics?: Semantic) {
-    const ticketer = this.createToken(readableTicketType.args[0], this.idx);
-    const value = this.createToken(readableTicketType.args[1], this.idx);
-    const amount = this.createToken(readableTicketType.args[2], this.idx);
+  public Execute(val: any, semantics?: Semantic) {
+    const ticketer = this.createToken(ticketerType, this.idx);
+    const value = this.createToken(this.val.args[0], this.idx);
+    const amount = this.createToken(amountType, this.idx);
     return {
-      ticketer: ticketer.Execute(val.args[0]),
-      value: value.Execute(val.args[1]),
-      amount: amount.Execute(val.args[2])
+      ticketer: ticketer.Execute(val.args[0], semantics),
+      value: value.Execute(val.args[1], semantics),
+      amount: amount.Execute(val.args[2], semantics)
     }
   }
 
   public ExtractSchema() {
+    const valueSchema = this.createToken(this.val.args[0], this.idx);
     return {
       ticketer: ContractToken.prim,
-      value: NatToken.prim,
+      value: valueSchema.ExtractSchema(),
       amount: IntToken.prim
     }
   }

--- a/packages/taquito-michelson-encoder/test/sample18_nat_ticket.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample18_nat_ticket.spec.ts
@@ -2,7 +2,8 @@ import BigNumber from 'bignumber.js';
 import { bigMapValue, rpcContractResponse, storage } from '../data/sample18_ticket';
 import { Schema } from '../src/schema/storage';
 
-describe('Schema with a ticket inside a big map in storage', () => {
+describe('Schema with a ticket of type nat inside a big map %tickets in storage', () => {
+    // key of the big map is nat and value is ticket of type nat
     it('Should decode storage properly', () => {
         const schema = new Schema(storage);
         expect(schema.Execute(rpcContractResponse.script.storage)).toEqual({

--- a/packages/taquito-michelson-encoder/test/sample19_timestamp_ticket.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample19_timestamp_ticket.spec.ts
@@ -1,0 +1,84 @@
+import BigNumber from 'bignumber.js';
+import { bigMapValue, rpcContractResponse, storage } from '../data/sample19_timestamp_ticket';
+import { Schema } from '../src/schema/storage';
+import { expectMichelsonMap } from './utils';
+
+describe('Schema with a ticket of type timestamp inside a big map %tickets in storage', () => {
+    // key of the big map is address and value is ticket of type timestamp
+    it('Should decode storage properly', () => {
+        const schema = new Schema(storage);
+        expect(schema.Execute(rpcContractResponse.script.storage)).toEqual({
+            data: {
+                winners: '24059',
+                bets: expectMichelsonMap(),
+                current_pot: new BigNumber('0'),
+                opened_at: '2019-09-09T12:09:37.000Z',
+                settings: {
+                    pool_type: 'XTZ-USD',
+                    entrance_fee: new BigNumber('2'),
+                    minimum_bet: new BigNumber('2'),
+                    open_period: new BigNumber('86400'),
+                    validation_delay: new BigNumber('86400'),
+                    ticket_validity: new BigNumber('2592000'),
+                    max_capacity: new BigNumber(9)
+                },
+                validator: null,
+                pending_validation: false,
+                oracle: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+                admin: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb'
+            },
+            tickets: '24060'
+        });
+    });
+
+    it('Should extract schema properly', () => {
+        const schema = new Schema(storage);
+        expect(schema.ExtractSchema()).toEqual({
+            data: {
+                winners: { address: 'mutez' },
+                bets: {
+                    map: {
+                        key: 'address',
+                        value: 'nat'
+                    }
+                },
+                current_pot: 'mutez',
+                opened_at: 'timestamp',
+                settings: {
+                    pool_type: 'string',
+                    entrance_fee: 'mutez',
+                    minimum_bet: 'mutez',
+                    open_period: 'int',
+                    validation_delay: 'int',
+                    ticket_validity: 'int',
+                    max_capacity: 'nat'
+                },
+                validator: 'address',
+                pending_validation: 'bool',
+                oracle: 'address',
+                admin: 'address'
+            },
+            tickets: {
+                address: {
+                    amount: 'int',
+                    ticketer: 'contract',
+                    value: 'timestamp'
+                }
+            }
+        });
+    });
+
+    it('Should parse big map value properly', () => {
+        const schema = new Schema({
+            prim: 'big_map',
+            args: [{ prim: 'address' }, { prim: 'ticket', args: [{ prim: 'timestamp' }] }],
+            annots: ['%tickets']
+        });
+        const value = schema.ExecuteOnBigMapValue(bigMapValue);
+        expect(value).toEqual({
+            ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+            value: '2021-03-09T16:32:15.000Z',
+            amount: new BigNumber('2')
+        });
+    });
+});

--- a/packages/taquito-michelson-encoder/test/tokens/ticket.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/ticket.spec.ts
@@ -1,13 +1,45 @@
 import { BigNumber } from 'bignumber.js';
+import { ParameterSchema, UnitValue } from '../../src/taquito-michelson-encoder';
 import { createToken } from '../../src/tokens/createToken';
 import { TicketToken, EncodeTicketError } from '../../src/tokens/ticket';
 
 describe('Ticket token', () => {
+  // A ticket used to authenticate information of type comparable (cty)
   let tokenTicketNat: TicketToken;
   let tokenTicketTimestamp: TicketToken;
+  let tokenTicketAddress: TicketToken;
+  let tokenTicketBool: TicketToken;
+  let tokenTicketBytes: TicketToken;
+  let tokenTicketChainId: TicketToken;
+  let tokenTicketInt: TicketToken;
+  let tokenTicketKey: TicketToken;
+  let tokenTicketKeyHash: TicketToken;
+  let tokenTicketMutez: TicketToken;
+  // let tokenTicketNever: TicketToken;
+  let tokenTicketOption: TicketToken;
+  let tokenTicketOr: TicketToken;
+  let tokenTicketPair: TicketToken;
+  let tokenTicketSignature: TicketToken;
+  let tokenTicketString: TicketToken;
+  let tokenTicketUnit: TicketToken;
+
   beforeEach(() => {
     tokenTicketNat = createToken({"prim":"ticket","args":[{"prim":"nat"}],"annots":["%receive"]}, 0) as TicketToken;
-    tokenTicketTimestamp = createToken({"prim":"ticket","args":[{"prim":"timestamp"}]}, 0) as TicketToken;
+    tokenTicketTimestamp = createToken({"prim":"ticket","args":[{"prim":"timestamp"}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketAddress = createToken({"prim":"ticket","args":[{"prim":"address"}]}, 0) as TicketToken;
+    tokenTicketBool = createToken({"prim":"ticket","args":[{"prim":"bool"}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketBytes = createToken({"prim":"ticket","args":[{"prim":"bytes"}]}, 0) as TicketToken;
+    tokenTicketChainId = createToken({"prim":"ticket","args":[{"prim":"chain_id"}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketInt = createToken({"prim":"ticket","args":[{"prim":"int"}]}, 0) as TicketToken;
+    tokenTicketKey = createToken({"prim":"ticket","args":[{"prim":"key"}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketKeyHash = createToken({"prim":"ticket","args":[{"prim":"key_hash"}]}, 0) as TicketToken;
+    tokenTicketMutez = createToken({"prim":"ticket","args":[{"prim":"mutez"}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketOption = createToken({"prim":"ticket","args":[{"prim":"option","args":[{"prim":"address"}],"annots":["%setApprover"]}]}, 0) as TicketToken;
+    tokenTicketOr = createToken({"prim":"ticket","args":[{"prim":"or","args":[{"prim":"nat"},{"prim":"string"}]}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketPair = createToken({"prim":"ticket","args":[{"prim":"pair","args":[{"prim":"nat"},{"prim":"string"}]}]}, 0) as TicketToken;
+    tokenTicketSignature = createToken({"prim":"ticket","args":[{"prim":"signature"}],"annots":["%test"]}, 0) as TicketToken;
+    tokenTicketString = createToken({"prim":"ticket","args":[{"prim":"string"}]}, 0) as TicketToken;
+    tokenTicketUnit = createToken({"prim":"ticket","args":[{"prim":"unit"}],"annots":["%test"]}, 0) as TicketToken;
   });
 
   describe('EncodeObject', () => {
@@ -17,6 +49,21 @@ describe('Ticket token', () => {
       expect(() => tokenTicketNat.EncodeObject({})).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.EncodeObject('11')).toThrowError(EncodeTicketError);
       expect(() => tokenTicketTimestamp.EncodeObject(new Date())).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketAddress.EncodeObject('tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketBool.EncodeObject(true)).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketBytes.EncodeObject('CAFE')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketChainId.EncodeObject('NetXSgo1ZT2DRUG')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketInt.EncodeObject(5)).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketKey.EncodeObject('edpkuRkcStobJ569XFxmE6edyRQQzMmtf4ZnmPkTPfSQnt6P3Nym2V')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketKeyHash.EncodeObject('tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketMutez.EncodeObject(1000000)).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketOption.EncodeObject('tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketOption.EncodeObject(null)).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketOr.EncodeObject('string')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketPair.EncodeObject({0: 0, 1: 'string'})).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketSignature.EncodeObject('edsigtkpiSSschcaCt9pUVrpNPf7TTcgvgDEDD6NCEHMy8NNQJCGnMfLZzYoQj74yLjo9wx6MPVV29CvVzgi7qEcEUok3k7AuMg')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketString.EncodeObject('hello')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketUnit.EncodeObject('Unit')).toThrowError(EncodeTicketError);
     });
   });
 
@@ -27,7 +74,22 @@ describe('Ticket token', () => {
       expect(() => tokenTicketNat.Encode([11])).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.Encode([])).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.Encode([{}])).toThrowError(EncodeTicketError);
-      expect(() => tokenTicketTimestamp.EncodeObject([new Date()])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketTimestamp.Encode([new Date()])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketAddress.Encode(['tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketBool.Encode([true])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketBytes.Encode(['CAFE'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketChainId.Encode(['NetXSgo1ZT2DRUG'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketInt.Encode([5])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketKey.Encode(['edpkuRkcStobJ569XFxmE6edyRQQzMmtf4ZnmPkTPfSQnt6P3Nym2V'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketKeyHash.Encode(['tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketMutez.Encode([1000000])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketOption.Encode(['tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketOption.Encode([null])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketOr.Encode(['string'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketPair.Encode([0, 'string'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketSignature.Encode(['edsigtkpiSSschcaCt9pUVrpNPf7TTcgvgDEDD6NCEHMy8NNQJCGnMfLZzYoQj74yLjo9wx6MPVV29CvVzgi7qEcEUok3k7AuMg'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketString.Encode(['hello'])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketUnit.Encode(['Unit'])).toThrowError(EncodeTicketError);
     });
   });
 
@@ -48,5 +110,143 @@ describe('Ticket token', () => {
       });
     });
 
+    it('Should execute on readTicketType with ticket of type address', () => {
+      expect(tokenTicketAddress.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: "tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu",
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type bool', () => {
+      expect(tokenTicketBool.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"prim":"True"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: true,
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type bytes', () => {
+      expect(tokenTicketBytes.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"bytes":"CAFE"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'CAFE',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type chainId', () => {
+      expect(tokenTicketChainId.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"NetXSgo1ZT2DRUG"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'NetXSgo1ZT2DRUG',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type int', () => {
+      expect(tokenTicketInt.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"int":"25"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: new BigNumber(25),
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type key', () => {
+      expect(tokenTicketKey.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"edpkuRkcStobJ569XFxmE6edyRQQzMmtf4ZnmPkTPfSQnt6P3Nym2V"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'edpkuRkcStobJ569XFxmE6edyRQQzMmtf4ZnmPkTPfSQnt6P3Nym2V',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type keyHash', () => {
+      expect(tokenTicketKeyHash.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type mutez', () => {
+      expect(tokenTicketMutez.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"int":"1000000"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: new BigNumber('1000000'),
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type option', () => {
+      expect(tokenTicketOption.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"prim":'Some',"args":[{"string":"tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu"}]},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+        amount: new BigNumber('2')
+      });
+    }); 
+
+    it('Should execute on readTicketType with ticket of type option when value is null', () => {
+      expect(tokenTicketOption.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"prim":"None"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: null,
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type or with right value', () => {
+      expect(tokenTicketOr.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"prim":"Right","args":[{"string":"Hello"}]},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'Hello',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type pair', () => {
+      expect(tokenTicketPair.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"prim":"Pair","args":[{"int":"7"},{"string":"hello"}]},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: {0: new BigNumber('7') , 1: 'hello'},
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type signature', () => {
+      expect(tokenTicketSignature.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"edsigtkpiSSschcaCt9pUVrpNPf7TTcgvgDEDD6NCEHMy8NNQJCGnMfLZzYoQj74yLjo9wx6MPVV29CvVzgi7qEcEUok3k7AuMg"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'edsigtkpiSSschcaCt9pUVrpNPf7TTcgvgDEDD6NCEHMy8NNQJCGnMfLZzYoQj74yLjo9wx6MPVV29CvVzgi7qEcEUok3k7AuMg',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type string', () => {
+      expect(tokenTicketString.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"test"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: 'test',
+        amount: new BigNumber('2')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type unit', () => {
+      expect(tokenTicketUnit.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"prim":"Unit"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: UnitValue,
+        amount: new BigNumber('2')
+      });
+    });
+  });
+
+  describe('Ticket with custom semantic', () => {
+      it('Should use custom semantic when provided', () => {
+        const result = tokenTicketString.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"test"},{"int":"2"}]}, { ticket: () => 'working' });
+        expect(result).toBe('working');
+    });
+  });
+
+  describe('Ticket parameter encoding', () => {
+    it('Ticket parameter are encoded properly', () => {
+      const schema = new ParameterSchema({ prim: 'ticket', args: [{ prim: 'string' }], annots: ['%receive'] });
+      const result = schema.ExtractSchema();
+      expect(result).toEqual({
+        ticketer: 'contract',
+        value: 'string',
+        amount: 'int'
+      });
+    });
   });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/ticket.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/ticket.spec.ts
@@ -4,8 +4,10 @@ import { TicketToken, EncodeTicketError } from '../../src/tokens/ticket';
 
 describe('Ticket token', () => {
   let tokenTicketNat: TicketToken;
+  let tokenTicketTimestamp: TicketToken;
   beforeEach(() => {
     tokenTicketNat = createToken({"prim":"ticket","args":[{"prim":"nat"}],"annots":["%receive"]}, 0) as TicketToken;
+    tokenTicketTimestamp = createToken({"prim":"ticket","args":[{"prim":"timestamp"}]}, 0) as TicketToken;
   });
 
   describe('EncodeObject', () => {
@@ -14,6 +16,7 @@ describe('Ticket token', () => {
       expect(() => tokenTicketNat.EncodeObject(2)).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.EncodeObject({})).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.EncodeObject('11')).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketTimestamp.EncodeObject(new Date())).toThrowError(EncodeTicketError);
     });
   });
 
@@ -24,15 +27,24 @@ describe('Ticket token', () => {
       expect(() => tokenTicketNat.Encode([11])).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.Encode([])).toThrowError(EncodeTicketError);
       expect(() => tokenTicketNat.Encode([{}])).toThrowError(EncodeTicketError);
+      expect(() => tokenTicketTimestamp.EncodeObject([new Date()])).toThrowError(EncodeTicketError);
     });
   });
 
   describe('Execute', () => {
-    it('Should execute on readTicketType', () => {
+    it('Should execute on readTicketType with ticket of type nat', () => {
       expect(tokenTicketNat.Execute({"prim":"Pair","args":[{"string":"KT1EAMUQC1yJ2sRPNPpLHVMGCzroYGe1C1ea"},{"int":"0"},{"int":"1"}]})).toEqual({
         ticketer: 'KT1EAMUQC1yJ2sRPNPpLHVMGCzroYGe1C1ea',
         value: new BigNumber('0'),
         amount: new BigNumber('1')
+      });
+    });
+
+    it('Should execute on readTicketType with ticket of type timestamp', () => {
+      expect(tokenTicketTimestamp.Execute({"prim":"Pair","args":[{"string":"KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw"},{"string":"2021-03-09T16:32:15Z"},{"int":"2"}]})).toEqual({
+        ticketer: 'KT1PVuv7af4VkPsZVZ8oZz9GSSdGnGBCbFWw',
+        value: "2021-03-09T16:32:15.000Z",
+        amount: new BigNumber('2')
       });
     });
 


### PR DESCRIPTION
#686

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

The value stored in a Ticket can be of any comparable Michelson type, and now you can read all Ticket values using Taquito!
