### PR TITLE
Return null when an account has no delegate 

### DIFF
--- a/integration-tests/call-get-delegate-when-no-delegate.spec.ts
+++ b/integration-tests/call-get-delegate-when-no-delegate.spec.ts
@@ -1,0 +1,20 @@
+import { CONFIGS } from "./config";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+  describe(`Test trying to get the delegate when there is none: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup(true)
+      done()
+    })
+    it('returns null when the account has no delegate', async (done) => {
+        const signer = await Tezos.signer.publicKeyHash();
+
+        expect (await Tezos.rpc.getDelegate(signer)).toBeNull();
+        expect (await Tezos.tz.getDelegate(signer)).toBeNull();
+
+      done();
+    });
+  });
+})

--- a/packages/taquito-rpc/src/taquito-rpc.ts
+++ b/packages/taquito-rpc/src/taquito-rpc.ts
@@ -2,7 +2,7 @@
  * @packageDocumentation
  * @module @taquito/rpc
  */
-import { HttpBackend } from '@taquito/http-utils';
+import { HttpBackend, HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import BigNumber from 'bignumber.js';
 import {
   BakingRightsQueryArguments,
@@ -233,13 +233,23 @@ export class RpcClient {
     address: string,
     { block }: { block: string } = defaultRPCOptions
   ): Promise<DelegateResponse> {
-    return this.httpBackend.createRequest<DelegateResponse>({
-      url: this.createURL(
-        `/chains/${this.chain}/blocks/${block}/context/contracts/${address}/delegate`
-      ),
-      method: 'GET',
-    });
+    let delegate: DelegateResponse;
+    try { 
+      delegate = await this.httpBackend.createRequest<DelegateResponse>({
+        url: this.createURL(
+          `/chains/${this.chain}/blocks/${block}/context/contracts/${address}/delegate`
+        ),
+        method: 'GET',
+      });
+    } catch(ex) {
+      if (ex instanceof HttpResponseError && ex.status === STATUS_CODE.NOT_FOUND) {
+        delegate = null;
+    } else {
+      throw ex;
+    }
   }
+  return delegate
+}
 
   /**
    *


### PR DESCRIPTION
#556 


- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [x] You have added integration tests (if relevant/appropriate)
- [x] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

When calling the `getDelegate()` method on an account that is not delegated, Taquito will now return `null` instead of throwing a HTTP 404 exception.  This is a breaking change for users who were handling the undelegated condition with a `catch`