### PR TITLE
Added Teznode to list of community-run nodes

### DIFF
--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -28,6 +28,8 @@ author: Roxane Letourneau
     - Mainnet: https://api.tez.ie/rpc/mainnet
     - Edonet: https://api.tez.ie/rpc/edonet (edo2net / Chainid is `NetXSgo1ZT2DRUG`)
     - Florencenet: https://api.tez.ie/rpc/florencenet
+- Teznode from LetzBake!:
+    - Mainnet: https://teznode.letzbake.com
 
 ## How to run a node
 


### PR DESCRIPTION
The architecture consists of a nginx load-balancer and two Tezos bare-metal nodes. We are using a whitelist approach to access the node so that dangerous calls are prevented. If a rpc required by developers is currently missing, we are very approachable and happy to add the respective rpc to the whitelist. 

https://letzbake.com/
https://t.me/cryptodad77
