### PR TITLE
do not merge - bump the http default timeout to 180 seconds

### DIFF
--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -14,7 +14,7 @@ const XMLHttpRequestCTOR = isNode ? require('xhr2-cookies').XMLHttpRequest : XML
 
 export * from './status_code';
 
-const defaultTimeout = 30000;
+const defaultTimeout = 1800000;
 
 interface HttpRequestOptions {
   url: string;


### PR DESCRIPTION

This PR is created so we get preview builds with a higher timeout.

Related to #751 which will make the timeout user configurable.