### PR TITLE
Allows to fetch bigmap with a key of type string, number or object

### DIFF
--- a/docs/maps_bigmaps.md
+++ b/docs/maps_bigmaps.md
@@ -439,7 +439,7 @@ After that, Taquito will automatically pack the keys locally when you want to fe
 
 It is possible to fetch multiple big map values using Taquito with one call using the `getMultipleValues` method of the `BigMapAbstraction` class. Taquito will ensure that all fetched big maps come from the same block to ensure a consistent state.
 
-The method takes an `array` of `string` (keys) to query and an optional block level as a parameter and returns an object containing the keys and their value in a well-formatted JSON object format.
+The method takes an `array` of keys to query as a parameter and an optional block level and returns a `MichelsonMap` containing the keys and their value in a well-formatted JSON object format.
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';

--- a/docs/maps_bigmaps.md
+++ b/docs/maps_bigmaps.md
@@ -439,7 +439,9 @@ After that, Taquito will automatically pack the keys locally when you want to fe
 
 It is possible to fetch multiple big map values using Taquito with one call using the `getMultipleValues` method of the `BigMapAbstraction` class. Taquito will ensure that all fetched big maps come from the same block to ensure a consistent state.
 
-The method takes an `array` of keys to query as a parameter and an optional block level and returns a `MichelsonMap` containing the keys and their value in a well-formatted JSON object format.
+The method takes an `array` of keys to query as a parameter and an optional block level and returns a `MichelsonMap` containing the keys and their value in a well-formatted JSON object format. The accepted types for the keys are `string`, `number` or `object` (the last one is used when the type of the keys in the big map is a Michelson `pair`).
+
+In the following example, we will fetch 4 big map values at once. The Michelson type of the big map key is an `address` and the type of its value is a `pair` made of a `nat` and a `map`. We see in the example that the address `tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn` is not a key of the big map, so its value is set to `undefined` in the returned MichelsonMap.
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
@@ -452,15 +454,18 @@ Tezos.contract
     return contract.storage()
   })
   .then((storage) => {
-    println('Fetching the big map values...')
+    println('Fetching the big map values...\n')
     return storage['0'].getMultipleValues([
       'tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1', 
       'tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD', 
+      'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
       'tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2'
     ]);
   })
-  .then((values) =>{
-    println(JSON.stringify(values, null, 2))
+  .then((values) => {
+    values.forEach((value, key) => {
+      println(`The value of the key ${key} is:\n${JSON.stringify(value, null, 2)}.\n`)
+    })
   })
   .catch((error) => println(JSON.stringify(error)));
 ```

--- a/integration-tests/contract-fetch-multiple-big-map-keys.spec.ts
+++ b/integration-tests/contract-fetch-multiple-big-map-keys.spec.ts
@@ -49,16 +49,16 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // Fetch multiples keys
             const bigMapValues = await bigMap.getMultipleValues<BigMapVal>(['tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1', 'tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD', 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn', 'tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2']);
-            expect(bigMapValues['tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1']!['0'].toString()).toEqual('2');
-            expect(bigMapValues['tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1']!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
+            expect(bigMapValues.get('tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1')!['0'].toString()).toEqual('2');
+            expect(bigMapValues.get('tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1')!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
 
-            expect(bigMapValues['tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD']!['0'].toString()).toEqual('3');
-            expect(bigMapValues['tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD']!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
+            expect(bigMapValues.get('tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')!['0'].toString()).toEqual('3');
+            expect(bigMapValues.get('tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
 
-            expect(bigMapValues['tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn']).toBeUndefined();
+            expect(bigMapValues.get('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeUndefined();
 
-            expect(bigMapValues['tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2']!['0'].toString()).toEqual('4');
-            expect(bigMapValues['tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2']!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
+            expect(bigMapValues.get('tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2')!['0'].toString()).toEqual('4');
+            expect(bigMapValues.get('tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2')!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
 
 
             // Specify a level
@@ -66,11 +66,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // Fetch multiples keys
             const bigMapValuesWithLevel = await bigMap.getMultipleValues<BigMapVal>(['tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1', 'tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD'], header.level);
-            expect(bigMapValuesWithLevel['tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1']!['0'].toString()).toEqual('2');
-            expect(bigMapValuesWithLevel['tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1']!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
+            expect(bigMapValuesWithLevel.get('tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1')!['0'].toString()).toEqual('2');
+            expect(bigMapValuesWithLevel.get('tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1')!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
 
-            expect(bigMapValuesWithLevel['tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD']!['0'].toString()).toEqual('3');
-            expect(bigMapValuesWithLevel['tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD']!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
+            expect(bigMapValuesWithLevel.get('tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')!['0'].toString()).toEqual('3');
+            expect(bigMapValuesWithLevel.get('tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
 
             done();
         });

--- a/integration-tests/contract-fetch-multiple-big-map-keys.spec.ts
+++ b/integration-tests/contract-fetch-multiple-big-map-keys.spec.ts
@@ -55,6 +55,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             expect(bigMapValues.get('tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')!['0'].toString()).toEqual('3');
             expect(bigMapValues.get('tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')!['1']).toEqual(expect.objectContaining(new MichelsonMap()));
 
+            expect(bigMapValues.has('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeTruthy();
             expect(bigMapValues.get('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeUndefined();
 
             expect(bigMapValues.get('tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2')!['0'].toString()).toEqual('4');

--- a/integration-tests/contract-pair-as-key.spec.ts
+++ b/integration-tests/contract-pair-as-key.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { MichelsonMap } from "@taquito/taquito";
+import { BigMapAbstraction, MichelsonMap } from "@taquito/taquito";
 import { storageContractWithPairAsKey } from "./data/storage-contract-with-pair-as-key";
 import { mapWithPairAsKeyCode, mapWithPairAsKeyStorage } from "./data/bigmap_with_pair_as_key";
 
@@ -84,7 +84,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
           init: mapWithPairAsKeyStorage
         })
         const contract = await op.contract()
-        const storage2 = await contract.storage<any>();
+        const storage2: BigMapAbstraction = await contract.storage();
         const value = await storage2.get({ 'test': 'test2', 'test2': 'test3' })
         expect(value).toEqual('test')
         done();

--- a/packages/taquito-michelson-encoder/src/schema/storage.ts
+++ b/packages/taquito-michelson-encoder/src/schema/storage.ts
@@ -3,7 +3,7 @@ import { BigMapToken } from '../tokens/bigmap';
 import { createToken } from '../tokens/createToken';
 import { OrToken } from '../tokens/or';
 import { PairToken } from '../tokens/pair';
-import { Semantic, Token, TokenValidationError } from '../tokens/token';
+import { BigMapKeyType, Semantic, Token, TokenValidationError } from '../tokens/token';
 import { RpcTransaction } from './model';
 import { Falsy } from './types';
 
@@ -139,7 +139,7 @@ export class Schema {
     return this.bigMap.ValueSchema.Execute(key, semantics);
   }
 
-  EncodeBigMapKey(key: string) {
+  EncodeBigMapKey(key: BigMapKeyType) {
     if (!this.bigMap) {
       throw new Error('No big map schema');
     }

--- a/packages/taquito-michelson-encoder/src/taquito-michelson-encoder.ts
+++ b/packages/taquito-michelson-encoder/src/taquito-michelson-encoder.ts
@@ -5,7 +5,7 @@
 
 export * from './schema/storage';
 export * from './schema/parameter';
-export { Semantic } from './tokens/token';
+export { Semantic, BigMapKeyType } from './tokens/token';
 export * from './errors';
 
 export const UnitValue = Symbol();

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
@@ -56,9 +56,9 @@ export class IntToken extends ComparableToken {
     return { int: new BigNumber(val).toFixed() };
   }
 
-  public ToBigMapKey(val: string) {
+  public ToBigMapKey(val: string | number) {
     return {
-      key: { int: val },
+      key: { int: String(val) },
       type: { prim: IntToken.prim },
     };
   }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
@@ -56,9 +56,9 @@ export class MutezToken extends ComparableToken {
     return { int: String(val).toString() };
   }
 
-  public ToBigMapKey(val: string) {
+  public ToBigMapKey(val: string | number) {
     return {
-      key: { int: val },
+      key: { int: String(val) },
       type: { prim: MutezToken.prim },
     };
   }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
@@ -58,9 +58,9 @@ export class NatToken extends ComparableToken {
     return NatToken.prim;
   }
 
-  public ToBigMapKey(val: string) {
+  public ToBigMapKey(val: string | number) {
     return {
-      key: { int: val },
+      key: { int: String(val) },
       type: { prim: NatToken.prim },
     };
   }

--- a/packages/taquito-michelson-encoder/src/tokens/token.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/token.ts
@@ -1,5 +1,4 @@
 import { MichelsonV1Expression } from '@taquito/rpc';
-import { MichelsonMapKey } from '../michelson-map';
 
 export abstract class TokenValidationError implements Error {
   name: string = 'ValidationError';
@@ -68,12 +67,14 @@ export abstract class Token {
   }
 }
 
+export type BigMapKeyType = string | number | object;
+
 export abstract class ComparableToken extends Token {
   abstract ToBigMapKey(
-    val: string
+    val: BigMapKeyType
   ): {
-    key: { [key: string]: string };
-    type: { prim: string };
+    key: { [key: string]: string | object[] };
+    type: { prim: string, args?: object[] };
   };
 
   abstract ToKey(val: string): any;

--- a/packages/taquito-michelson-encoder/test/tokens/int.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/int.spec.ts
@@ -33,4 +33,19 @@ describe('Int token', () => {
       expect(() => token.Encode([{}])).toThrowError(IntValidationError);
     });
   });
+
+  describe('ToBigMapKey', () => {
+  it('accepts a number as parameter', () => {
+      expect(token.ToBigMapKey(0)).toEqual({
+        key: { int: '0' },
+        type: { prim: IntToken.prim },
+      });
+    });
+  it('accepts a string as parameter', () => {
+      expect(token.ToBigMapKey('0')).toEqual({
+        key: { int: '0' },
+        type: { prim: IntToken.prim },
+      });    
+    });
+  });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/mutez.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/mutez.spec.ts
@@ -32,4 +32,19 @@ describe('Mutez token', () => {
       expect(() => token.Encode([{}])).toThrowError(MutezValidationError);
     });
   });
+
+  describe('ToBigMapKey', () => {
+  it('accepts a number as parameter', () => {
+      expect(token.ToBigMapKey(10000000)).toEqual({
+        key: { int: '10000000' },
+        type: { prim: MutezToken.prim },
+      });
+    });
+  it('accepts a string as parameter', () => {
+      expect(token.ToBigMapKey('10000000')).toEqual({
+        key: { int: '10000000' },
+        type: { prim: MutezToken.prim },
+      });    
+    });
+  });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/nat.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/nat.spec.ts
@@ -41,4 +41,19 @@ describe('Nat token', () => {
       expect(() => token.Encode([{}])).toThrowError(NatValidationError);
     });
   });
+
+  describe('ToBigMapKey', () => {
+  it('accepts a number as parameter', () => {
+      expect(token.ToBigMapKey(10)).toEqual({
+        key: { int: '10' },
+        type: { prim: NatToken.prim },
+      });
+    });
+  it('accepts a string as parameter', () => {
+      expect(token.ToBigMapKey('10')).toEqual({
+        key: { int: '10' },
+        type: { prim: NatToken.prim },
+      });    
+    });
+  });
 });

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -29,7 +29,7 @@ interface Frozenbalancebycycle {
   rewards: BigNumber;
 }
 
-export type BigMapKey = { key: { [key: string]: string }; type: { prim: string } };
+export type BigMapKey = { key: { [key: string]: string | object[] }; type: { prim: string, args?: object[] } };
 
 export interface BlockFullHeader {
   level: number;

--- a/packages/taquito/src/contract/big-map.ts
+++ b/packages/taquito/src/contract/big-map.ts
@@ -37,11 +37,12 @@ export class BigMapAbstraction {
    *
    * @param keysToEncode Array of keys to query (will be encoded properly according to the schema)
    * @param block optional block level to fetch the values from
+   * @param batchSize optional batch size representing the number of requests to execute in parallel
    * @returns A MichelsonMap containing the keys queried in the big map and their value in a well-formatted JSON object format
    *
    */
-  async getMultipleValues<T>(keysToEncode: Array<BigMapKeyType>, block?: number) {
-    return this.provider.getBigMapKeysByID<T>(this.id.toString(), keysToEncode, this.schema, block);
+  async getMultipleValues<T>(keysToEncode: Array<BigMapKeyType>, block?: number, batchSize: number = 5) {
+    return this.provider.getBigMapKeysByID<T>(this.id.toString(), keysToEncode, this.schema, block, batchSize);
   }
 
   toJSON() {

--- a/packages/taquito/src/contract/big-map.ts
+++ b/packages/taquito/src/contract/big-map.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@taquito/michelson-encoder';
+import { Schema, BigMapKeyType } from '@taquito/michelson-encoder';
 import BigNumber from 'bignumber.js';
 import { ContractProvider } from './interface';
 import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
@@ -15,7 +15,7 @@ export class BigMapAbstraction {
    * @returns Return a well formatted json object of a big map value or undefined if the key is not found in the big map
    *
    */
-  async get<T>(keyToEncode: string, block?: number) {
+  async get<T>(keyToEncode: BigMapKeyType , block?: number) {
     try {
       const id = await this.provider.getBigMapKeyByID<T>(this.id.toString(), keyToEncode, this.schema, block);
       return id;
@@ -37,10 +37,10 @@ export class BigMapAbstraction {
    *
    * @param keysToEncode Array of keys to query (will be encoded properly according to the schema)
    * @param block optional block level to fetch the values from
-   * @returns An object containing the keys queried in the big map and their value in a well-formatted JSON object format
+   * @returns A MichelsonMap containing the keys queried in the big map and their value in a well-formatted JSON object format
    *
    */
-  async getMultipleValues<T>(keysToEncode: string[], block?: number) {
+  async getMultipleValues<T>(keysToEncode: Array<BigMapKeyType>, block?: number) {
     return this.provider.getBigMapKeysByID<T>(this.id.toString(), keysToEncode, this.schema, block);
   }
 

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -106,10 +106,11 @@ export interface StorageProvider {
    * @param keysToEncode Array of keys to query (will be encoded properly according to the schema)
    * @param schema Big Map schema (can be determined using your contract type)
    * @param block optional block level to fetch the values from
+   * @param batchSize optional batch size representing the number of requests to execute in parallel
    * @returns An object containing the keys queried in the big map and their value in a well-formatted JSON object format
    *
    */
-   getBigMapKeysByID<T>(id: string, keysToEncode: Array<BigMapKeyType>, schema: Schema, block?: number): Promise<MichelsonMap<MichelsonMapKey, T | undefined>>;
+   getBigMapKeysByID<T>(id: string, keysToEncode: Array<BigMapKeyType>, schema: Schema, block?: number, batchSize?: number): Promise<MichelsonMap<MichelsonMapKey, T | undefined>>;
 }
 
 export interface ContractProvider extends StorageProvider {

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -1,4 +1,4 @@
-import { Schema } from '@taquito/michelson-encoder';
+import { BigMapKeyType, MichelsonMap, MichelsonMapKey, Schema } from '@taquito/michelson-encoder';
 import { OperationBatch } from '../batch/rpc-batch-provider';
 import { Context } from '../context';
 import { DelegateOperation } from '../operations/delegate-operation';
@@ -96,7 +96,7 @@ export interface StorageProvider {
    *
    * @see https://tezos.gitlab.io/api/rpc.html#get-block-id-context-big-maps-big-map-id-script-expr
    */
-  getBigMapKeyByID<T>(id: string, keyToEncode: string, schema: Schema, block?: number): Promise<T>;
+  getBigMapKeyByID<T>(id: string, keyToEncode: BigMapKeyType, schema: Schema, block?: number): Promise<T>;
 
   /**
    *
@@ -109,7 +109,7 @@ export interface StorageProvider {
    * @returns An object containing the keys queried in the big map and their value in a well-formatted JSON object format
    *
    */
-   getBigMapKeysByID<T>(id: string, keysToEncode: string[], schema: Schema, block?: number): Promise<{ [key: string]: T | undefined }>;
+   getBigMapKeysByID<T>(id: string, keysToEncode: Array<BigMapKeyType>, schema: Schema, block?: number): Promise<MichelsonMap<MichelsonMapKey, T | undefined>>;
 }
 
 export interface ContractProvider extends StorageProvider {

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -124,15 +124,15 @@ export class RpcContractProvider extends OperationEmitter
    * @param keys Array of keys to query (will be encoded properly according to the schema)
    * @param schema Big Map schema (can be determined using your contract type)
    * @param block optional block level to fetch the values from
+   * @param batchSize optional batch size representing the number of requests to execute in parallel
    * @returns A MichelsonMap containing the keys queried in the big map and their value in a well-formatted JSON object format
    *
    */
-  async getBigMapKeysByID<T>(id: string, keys: Array<BigMapKeyType>, schema: Schema, block?: number): Promise<MichelsonMap<MichelsonMapKey, T | undefined>> {
+  async getBigMapKeysByID<T>(id: string, keys: Array<BigMapKeyType>, schema: Schema, block?: number, batchSize: number = 5): Promise<MichelsonMap<MichelsonMapKey, T | undefined>> {
     const level = await this.getBlockForRequest(keys, block)
     const bigMapValues = new MichelsonMap<MichelsonMapKey, T | undefined>();
 
     // Execute batch of promises in series
-    const batchSize = 5;
     let position = 0;
     let results: Array<(T | undefined)> = [];
 

--- a/packages/taquito/test/contract/big-map.spec.ts
+++ b/packages/taquito/test/contract/big-map.spec.ts
@@ -63,11 +63,7 @@ describe('BigMapAbstraction test', () => {
                 rpcContractProvider as any
             );
             const result = await bigMap.getMultipleValues(['tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN'])
-            expect(result).toEqual(expect.objectContaining(
-                MichelsonMap.fromLiteral({
-                    tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-                })
-            ));
+            expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toEqual(new BigNumber(3));
             done();
         });
 
@@ -84,17 +80,12 @@ describe('BigMapAbstraction test', () => {
                 }),
                 rpcContractProvider as any
             );
-            expect(
-                await bigMap.getMultipleValues([
-                    'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-                    'tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN'
-                ])
-            ).toEqual(expect.objectContaining(
-                MichelsonMap.fromLiteral({
-                    tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: undefined,
-                    tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3)
-                })
-            ));
+            const result = await bigMap.getMultipleValues([
+                'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+                'tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN'
+            ]);
+            expect(result.get('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeUndefined();
+            expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toEqual(new BigNumber(3));
             done();
         });
     });

--- a/packages/taquito/test/contract/big-map.spec.ts
+++ b/packages/taquito/test/contract/big-map.spec.ts
@@ -1,6 +1,6 @@
 import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import BigNumber from 'bignumber.js';
-import { Schema } from '@taquito/michelson-encoder';
+import { MichelsonMap, Schema } from '@taquito/michelson-encoder';
 import { BigMapAbstraction } from '../../src/contract/big-map';
 
 /**
@@ -51,9 +51,9 @@ describe('BigMapAbstraction test', () => {
         });
 
         it('returns value for 1 key', async (done) => {
-            rpcContractProvider.getBigMapKeysByID.mockResolvedValue({
-                tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3)
-            });
+            rpcContractProvider.getBigMapKeysByID.mockResolvedValue(MichelsonMap.fromLiteral({
+                tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
+            }));
             const bigMap = new BigMapAbstraction(
                 new BigNumber('1'),
                 new Schema({
@@ -62,17 +62,20 @@ describe('BigMapAbstraction test', () => {
                 }),
                 rpcContractProvider as any
             );
-            expect(await bigMap.getMultipleValues(['tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN'])).toEqual({
-                tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3)
-            });
+            const result = await bigMap.getMultipleValues(['tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN'])
+            expect(result).toEqual(expect.objectContaining(
+                MichelsonMap.fromLiteral({
+                    tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
+                })
+            ));
             done();
         });
 
         it('returns values for 2 keys', async (done) => {
-            rpcContractProvider.getBigMapKeysByID.mockResolvedValue({
+            rpcContractProvider.getBigMapKeysByID.mockResolvedValue(MichelsonMap.fromLiteral({
                 tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: undefined,
                 tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3)
-            });
+            }));
             const bigMap = new BigMapAbstraction(
                 new BigNumber('1'),
                 new Schema({
@@ -86,10 +89,95 @@ describe('BigMapAbstraction test', () => {
                     'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
                     'tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN'
                 ])
-            ).toEqual({
-                tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: undefined,
-                tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3)
-            });
+            ).toEqual(expect.objectContaining(
+                MichelsonMap.fromLiteral({
+                    tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: undefined,
+                    tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3)
+                })
+            ));
+            done();
+        });
+    });
+
+    describe('BigMapAbstraction get method', () => {
+        it('The get method accepts a parameter of type number', async (done) => {
+            rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
+            const schema = new Schema({
+                prim: 'big_map',
+                args: [{ prim: 'int' }, { prim: 'string' }]
+            })
+            const bigMap = new BigMapAbstraction(
+                new BigNumber('1'),
+                schema,
+                rpcContractProvider as any
+            );
+            expect(await bigMap.get(23)).toEqual('test');
+            expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith('1', 23, schema, undefined)
+            done();
+        });
+
+        it('The get method accepts a parameter of type string', async (done) => {
+            rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
+            const schema = new Schema({
+                prim: 'big_map',
+                args: [{ prim: 'int' }, { prim: 'string' }]
+            })
+            const bigMap = new BigMapAbstraction(
+                new BigNumber('1'),
+                schema,
+                rpcContractProvider as any
+            );
+            expect(await bigMap.get('23')).toEqual('test');
+            expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith('1', '23', schema, undefined)
+            done();
+        });
+
+        it('The get method accepts a parameter of type string and a level', async (done) => {
+            rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
+            const schema = new Schema({
+                prim: 'big_map',
+                args: [{ prim: 'int' }, { prim: 'string' }]
+            })
+            const bigMap = new BigMapAbstraction(
+                new BigNumber('1'),
+                schema,
+                rpcContractProvider as any
+            );
+            expect(await bigMap.get('23', 123456)).toEqual('test');
+            expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith('1', '23', schema, 123456)
+            done();
+        });
+
+        it('includes type argument when calling the get method', async (done) => {
+            rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
+            const schema = new Schema({
+                prim: 'big_map',
+                args: [{ prim: 'int' }, { prim: 'string' }]
+            })
+            const bigMap = new BigMapAbstraction(
+                new BigNumber('1'),
+                schema,
+                rpcContractProvider as any
+            );
+            expect(await bigMap.get<string>('23')).toEqual('test');
+            expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith('1', '23', schema, undefined)
+            done();
+        });
+
+
+        it('The get method accepts an object as parameter', async (done) => {
+            rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
+            const schema = new Schema({
+                prim: 'big_map',
+                args: [{ "prim": "pair", "args": [{ "prim": "string", annots: ["%test"] }, { "prim": "string", annots: ["%test2"] }] }, { prim: 'string' }]
+            })
+            const bigMap = new BigMapAbstraction(
+                new BigNumber('1'),
+                schema,
+                rpcContractProvider as any
+            );
+            expect(await bigMap.get({ 'test': 'test2', 'test2': 'test3' }, 123456)).toEqual('test');
+            expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith('1', { 'test': 'test2', 'test2': 'test3' }, schema, 123456)
             done();
         });
     });

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -297,16 +297,13 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual(expect.objectContaining(
-        MichelsonMap.fromLiteral({
-          tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: new BigNumber(3),
-          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(7),
-          tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx: new BigNumber(6),
-          tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY: new BigNumber(5),
-          tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh: new BigNumber(4),
-          tz1NAozDvi5e7frVq9cUaC3uXQQannemB8Jw: new BigNumber(1)
-        })
-      ))
+      expect(result.get('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toEqual(new BigNumber(3));
+      expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toEqual(new BigNumber(7));
+      expect(result.get('tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx')).toEqual(new BigNumber(6));
+      expect(result.get('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')).toEqual(new BigNumber(5));
+      expect(result.get('tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh')).toEqual(new BigNumber(4));
+      expect(result.get('tz1NAozDvi5e7frVq9cUaC3uXQQannemB8Jw')).toEqual(new BigNumber(1));
+
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
           bytes: "000035e993d8c7aaa42b5e3ccd86a33390ececc73abd",
@@ -430,12 +427,9 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual(expect.objectContaining(
-        MichelsonMap.fromLiteral({
-          tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: undefined, // value set to undefined
-          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-        })
-      ));
+      expect(result.get('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeUndefined();
+      expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toEqual(new BigNumber(3));
+
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
           bytes: "000035e993d8c7aaa42b5e3ccd86a33390ececc73abd",
@@ -491,12 +485,9 @@ describe('RpcContractProvider test', () => {
         }),
         654321
       );
-      expect(result).toEqual(expect.objectContaining(
-        MichelsonMap.fromLiteral({
-          tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: new BigNumber(34), 
-          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-        })
-      ));
+      expect(result.get('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toEqual(new BigNumber(34));
+      expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toEqual(new BigNumber(3));
+
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
@@ -554,11 +545,9 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual(expect.objectContaining(
-        MichelsonMap.fromLiteral({
-          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: undefined,
-        })
-      ));
+
+      expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toBeUndefined();
+
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
@@ -591,11 +580,9 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual(expect.objectContaining(
-        MichelsonMap.fromLiteral({
-          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-        })
-      ));
+
+      expect(result.get('tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN')).toEqual(new BigNumber(3));
+
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -297,14 +297,16 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual({
+      expect(result).toEqual(expect.objectContaining(
+        MichelsonMap.fromLiteral({
           tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: new BigNumber(3),
           tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(7),
           tz1KqTpEZ7Yob7QbPE4Hy4Wo8fHG8LhKxZSx: new BigNumber(6),
           tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY: new BigNumber(5),
           tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh: new BigNumber(4),
           tz1NAozDvi5e7frVq9cUaC3uXQQannemB8Jw: new BigNumber(1)
-        });
+        })
+      ))
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
           bytes: "000035e993d8c7aaa42b5e3ccd86a33390ececc73abd",
@@ -428,10 +430,12 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual({
+      expect(result).toEqual(expect.objectContaining(
+        MichelsonMap.fromLiteral({
           tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: undefined, // value set to undefined
           tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-        });
+        })
+      ));
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
           bytes: "000035e993d8c7aaa42b5e3ccd86a33390ececc73abd",
@@ -487,10 +491,12 @@ describe('RpcContractProvider test', () => {
         }),
         654321
       );
-      expect(result).toEqual({
+      expect(result).toEqual(expect.objectContaining(
+        MichelsonMap.fromLiteral({
           tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn: new BigNumber(34), 
           tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-        });
+        })
+      ));
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
@@ -548,9 +554,11 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual({
-        tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: undefined,
-      });
+      expect(result).toEqual(expect.objectContaining(
+        MichelsonMap.fromLiteral({
+          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: undefined,
+        })
+      ));
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
@@ -583,9 +591,11 @@ describe('RpcContractProvider test', () => {
           args: [{ prim: "address" }, { prim: "nat" }],
         })
       );
-      expect(result).toEqual({
-        tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
-      });
+      expect(result).toEqual(expect.objectContaining(
+        MichelsonMap.fromLiteral({
+          tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN: new BigNumber(3),
+        })
+      ));
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
         data: {
@@ -598,6 +608,43 @@ describe('RpcContractProvider test', () => {
       expect(mockRpcClient.getBigMapExpr.mock.calls[0][0]).toEqual("133");
       expect(mockRpcClient.getBigMapExpr.mock.calls[0][1]).toEqual(
         "exprvPCPwzweu2FnFYTpZJoAM2vEWmPtHDXvsvNsrsKM6ZHMzeahE7"
+      );
+      done();
+    });
+
+    it("getBigMapKeysByID with a pair as key and a pair as value", async (done) => {
+      mockRpcClient.packData.mockResolvedValue({
+        packed: "0507070100000005746573743201000000057465737433",
+      });
+      mockRpcClient.getBigMapExpr.mockResolvedValue({  prim: "Pair", args: [{ int: "2" }, { string: "3" }] });
+  
+      const result = await rpcContractProvider.getBigMapKeysByID(
+        "133",
+        [
+          { 'test': 'test2', 'test2': 'test3' },
+        ],
+        new Schema({
+          prim: "big_map",
+          args: [{ "prim": "pair", "args": [{ "prim": "string", annots: ["%test"] }, { "prim": "string", annots: ["%test2"] }] }, { "prim": "pair", "args":[{ "prim": "int" }, { "prim": "int" }] }],
+        })
+      );
+      expect(result.has({ 'test': 'test2', 'test2': 'test3' })).toBeTruthy();
+      expect(result.get({ 'test': 'test2', 'test2': 'test3' })).toEqual({
+        0: new BigNumber(2),
+        1: new BigNumber(3)      
+      });
+      expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
+      expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
+        data: {
+          prim: "Pair", args: [{ string: "test2" }, { string: "test3" }]
+        },
+        type: {
+          prim: "pair", args: [{ prim: "string" }, { prim: "string" }]
+        },
+      });
+      expect(mockRpcClient.getBigMapExpr.mock.calls[0][0]).toEqual("133");
+      expect(mockRpcClient.getBigMapExpr.mock.calls[0][1]).toEqual(
+        "exprteZPr9h8pkyKKw9PMFEXqG1jbMBkj4A2KC9Mp5cAAjSrDWvfXs"
       );
       done();
     });

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -193,7 +193,7 @@ describe('RpcContractProvider test', () => {
         packed: "050a00000016000035e993d8c7aaa42b5e3ccd86a33390ececc73abd",
       });
       mockRpcClient.getBigMapExpr.mockResolvedValue({ int: "3" });
-  
+
       const result = await rpcContractProvider.getBigMapKeyByID(
         "133",
         "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn",
@@ -218,13 +218,13 @@ describe('RpcContractProvider test', () => {
       expect(mockRpcClient.getBigMapExpr.mock.calls[0][2]).toBeUndefined();
       done();
     });
-  
+
     it("should call getBigMapKeyByID when a block level is specified", async (done) => {
       mockRpcClient.packData.mockResolvedValue({
         packed: "050a00000016000035e993d8c7aaa42b5e3ccd86a33390ececc73abd",
       });
       mockRpcClient.getBigMapExpr.mockResolvedValue({ int: "3" });
-  
+
       const result = await rpcContractProvider.getBigMapKeyByID(
         "133",
         "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn",
@@ -252,7 +252,7 @@ describe('RpcContractProvider test', () => {
       });
       done();
     });
-  });  
+  });
 
   describe("getBigMapKeysByID", () => {
     it("should call getBigMapKeysByID", async (done) => {
@@ -281,7 +281,7 @@ describe('RpcContractProvider test', () => {
         packed: "050a0000001600001bc28a6b8fb2fb6af99fe3bba054e614539e5f12",
       });
       mockRpcClient.getBigMapExpr.mockResolvedValueOnce({ int: "1" });
-  
+
       const result = await rpcContractProvider.getBigMapKeysByID(
         "133",
         [
@@ -415,7 +415,7 @@ describe('RpcContractProvider test', () => {
         packed: "050a000000160000e7670f32038107a59a2b9cfefae36ea21f5aa63c",
       });
       mockRpcClient.getBigMapExpr.mockResolvedValueOnce({ int: "3" });
-  
+
       const result = await rpcContractProvider.getBigMapKeysByID(
         "133",
         [
@@ -472,11 +472,11 @@ describe('RpcContractProvider test', () => {
         packed: "050a000000160000e7670f32038107a59a2b9cfefae36ea21f5aa63c",
       });
       mockRpcClient.getBigMapExpr.mockResolvedValueOnce({ int: "3" });
-  
+
       const result = await rpcContractProvider.getBigMapKeysByID(
         "133",
         [
-          "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn", 
+          "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn",
           "tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN",
         ],
         new Schema({
@@ -534,7 +534,7 @@ describe('RpcContractProvider test', () => {
         'https://test.com'
       );
       mockRpcClient.getBigMapExpr.mockRejectedValue(expectedError);
-  
+
       const result = await rpcContractProvider.getBigMapKeysByID(
         "133",
         [
@@ -569,7 +569,7 @@ describe('RpcContractProvider test', () => {
         packed: "050a000000160000e7670f32038107a59a2b9cfefae36ea21f5aa63c",
       });
       mockRpcClient.getBigMapExpr.mockResolvedValue({ int: "3" });
-  
+
       const result = await rpcContractProvider.getBigMapKeysByID(
         "133",
         [
@@ -603,8 +603,8 @@ describe('RpcContractProvider test', () => {
       mockRpcClient.packData.mockResolvedValue({
         packed: "0507070100000005746573743201000000057465737433",
       });
-      mockRpcClient.getBigMapExpr.mockResolvedValue({  prim: "Pair", args: [{ int: "2" }, { string: "3" }] });
-  
+      mockRpcClient.getBigMapExpr.mockResolvedValue({ prim: "Pair", args: [{ int: "2" }, { string: "3" }] });
+
       const result = await rpcContractProvider.getBigMapKeysByID(
         "133",
         [
@@ -612,13 +612,13 @@ describe('RpcContractProvider test', () => {
         ],
         new Schema({
           prim: "big_map",
-          args: [{ "prim": "pair", "args": [{ "prim": "string", annots: ["%test"] }, { "prim": "string", annots: ["%test2"] }] }, { "prim": "pair", "args":[{ "prim": "int" }, { "prim": "int" }] }],
+          args: [{ "prim": "pair", "args": [{ "prim": "string", annots: ["%test"] }, { "prim": "string", annots: ["%test2"] }] }, { "prim": "pair", "args": [{ "prim": "int" }, { "prim": "int" }] }],
         })
       );
       expect(result.has({ 'test': 'test2', 'test2': 'test3' })).toBeTruthy();
       expect(result.get({ 'test': 'test2', 'test2': 'test3' })).toEqual({
         0: new BigNumber(2),
-        1: new BigNumber(3)      
+        1: new BigNumber(3)
       });
       expect(mockRpcClient.getBlock.mock.calls[0]).toBeUndefined();
       expect(mockRpcClient.packData.mock.calls[0][0]).toEqual({
@@ -633,6 +633,35 @@ describe('RpcContractProvider test', () => {
       expect(mockRpcClient.getBigMapExpr.mock.calls[0][1]).toEqual(
         "exprteZPr9h8pkyKKw9PMFEXqG1jbMBkj4A2KC9Mp5cAAjSrDWvfXs"
       );
+      done();
+    });
+
+    it("getBigMapKeysByID unexpected exception", async (done) => {
+      mockRpcClient.getBlock.mockResolvedValue({ header: { level: 123456 } });
+      const expectedError = new HttpResponseError(
+        'fail',
+        STATUS_CODE.UNAUTHORIZED,
+        'err',
+        'test',
+        'https://test.com'
+      );
+      mockRpcClient.packData.mockRejectedValue(expectedError);
+
+      try {
+        await rpcContractProvider.getBigMapKeysByID(
+          "133",
+          [
+            "tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn",
+            "tz1gjaF81ZRRvdzjobyfVNsAeSC6PScjfQwN",
+          ],
+          new Schema({
+            prim: "big_map",
+            args: [{ prim: "address" }, { prim: "nat" }],
+          })
+        )
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpResponseError);
+      }
       done();
     });
   });
@@ -1210,12 +1239,12 @@ describe('RpcContractProvider test', () => {
       done();
     });
   });
-  
-    describe('originate with noop parser', () => {
-      it('should throw InvalidCodeParameter', async done => {
-        rpcContractProvider['context'].parser = new NoopParser();
-        try {
-          await rpcContractProvider.originate({
+
+  describe('originate with noop parser', () => {
+    it('should throw InvalidCodeParameter', async done => {
+      rpcContractProvider['context'].parser = new NoopParser();
+      try {
+        await rpcContractProvider.originate({
           delegate: 'test_delegate',
           balance: '200',
           code: miStr, // needs to be JSON Michelson
@@ -1224,7 +1253,7 @@ describe('RpcContractProvider test', () => {
           gasLimit: 10600,
           storageLimit: 257,
         });
-      } catch( err) {
+      } catch (err) {
         expect(err).toBeInstanceOf(InvalidCodeParameter);
         expect(err.message).toEqual('Wrong code parameter type, expected an array');
       }
@@ -1240,8 +1269,8 @@ describe('RpcContractProvider test', () => {
           code: [
             { prim: 'parameter', args: [{ prim: 'int' }] },
             {
-                prim: 'code',
-                args: [[{ prim: 'DUP' }]]
+              prim: 'code',
+              args: [[{ prim: 'DUP' }]]
             }
           ],
           storage: 'test',
@@ -1249,36 +1278,36 @@ describe('RpcContractProvider test', () => {
           gasLimit: 10600,
           storageLimit: 257,
         });
-      } catch( err) {
+      } catch (err) {
         expect(err).toBeInstanceOf(InvalidCodeParameter);
         expect(err.message).toEqual('The storage section is missing from the script');
       }
       done();
     });
 
-  it('should throw InvalidInitParameter', async done => {
-    rpcContractProvider['context'].parser = new NoopParser();
-    try {
-      await rpcContractProvider.originate({
-        delegate: 'test_delegate',
-        balance: '200',
-        code: [
-          { prim: 'parameter', args: [{ prim: 'int' }] },
-          {
+    it('should throw InvalidInitParameter', async done => {
+      rpcContractProvider['context'].parser = new NoopParser();
+      try {
+        await rpcContractProvider.originate({
+          delegate: 'test_delegate',
+          balance: '200',
+          code: [
+            { prim: 'parameter', args: [{ prim: 'int' }] },
+            {
               prim: 'code',
               args: [[{ prim: 'DUP' }]]
-          },
-          { prim: 'storage', args: [{ prim: 'pair', args: [{ prim: 'int' }, { prim: 'address' }] }] }
-        ],
-        init: 'test',
-        fee: 10000,
-        gasLimit: 10600,
-        storageLimit: 257,
-      });
-    } catch (err) {
-      expect(err).toBeInstanceOf(InvalidInitParameter);
-      expect(err.message).toEqual('Wrong init parameter type, expected JSON Michelson');
-    }
+            },
+            { prim: 'storage', args: [{ prim: 'pair', args: [{ prim: 'int' }, { prim: 'address' }] }] }
+          ],
+          init: 'test',
+          fee: 10000,
+          gasLimit: 10600,
+          storageLimit: 257,
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidInitParameter);
+        expect(err.message).toEqual('Wrong init parameter type, expected JSON Michelson');
+      }
       done();
     });
 
@@ -1307,6 +1336,6 @@ describe('RpcContractProvider test', () => {
 
         done();
       });
-    }); 
+    });
   });
 });


### PR DESCRIPTION
Replace #513 

Breaking change for `BigMapAbstraction.getMultipleValues()` and `RpcContractProvider.getBigMapKeysByID()` that will return a `MichelsonMap` instead of an object to support keys of type object (michelson pair)

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
