### PR TITLE
Upgrading v9

### DIFF
--- a/docs/upgrading_guide.md
+++ b/docs/upgrading_guide.md
@@ -1,13 +1,35 @@
 ---
-title: Upgrading to v7/delphi
+title: Upgrading Guide
 author: Roxane Letourneau
 ---
 
-:::warning Breaking changes
-With this major number update to support the `delphi` Tezos protocol, we have also implemented some breaking changes to the Taquito API. This document explains how to update your projects.
+# Upgrading to version 9
+
+Please take note of the two following breaking changes: 
+- Breaking change introduced for the method `getMultipleValues` of the `BigMapAbstraction` class and the method `getBigMapKeysByID` of the `RpcContractProvider` class: they now return a MichelsonMap instead of an object. This is meant to support keys of type object that are encountered when the Michelson type of the big map key is a `pair`.
+
+- To give more flexibility to the user on the retry strategy used in the `ObservableSubscription` class, we removed the parameters `observableSubscriptionRetryDelay` and `observableSubscriptionRetries` introduced in version `8.1.1-beta` and replaced them to accept an `OperatorFunction`. When users configure the `ObservableSubscription` to retry on error, we use the `retry` operators from `rxjs` by default. An example showing how to set a custom retry strategy is available [here](https://github.com/ecadlabs/taquito/blob/master/example/example-streamer-custom-retry-logic.ts).
+
+
+# Upgrading to version 8
+
+## Breaking change - Typescript upgrade
+
+We decided to update the Typescript version that we are using to take advantage of the newer features it brings in our Michel-Codec package.
+
+You might get the following error if a Typescript upgrade is needed in your project:
+```
+Error: node_modules/@taquito/michel-codec/dist/types/michelson-types.d.ts:122:34 - error TS1110: Type expected.
+export declare type ProtocolID = `${Protocol}`;
+```
+
+# Upgrading to version 7
+
+:::note Breaking changes
+With this major number update to support the `delphi` Tezos protocol, we have also implemented some breaking changes to the Taquito API. The following sections explains how to update your projects.
 :::
 
-This page explains each breaking change, including:
+The following sections explain each breaking change, including:
 
 - the reasons that motivated it,
 - code examples that demonstrate how to update your code (how it was in prior versions versus how it needs to be using v7), and

--- a/docs/version.md
+++ b/docs/version.md
@@ -2,6 +2,35 @@
 title: Versions
 author: Jev Bjorsell
 ---
+# Taquito v9.0.0-beta
+
+## Summary
+
+### Enhancements
+
+- Florence compatibility support
+- Allows fetching big map with a key of type string, number, or object. 
+- Accept an operator for the retry strategy of the `ObservableSubscription` class
+- Updated beacon-sdk version to v2.2.4 which includes several performance improvements for p2p pairing.
+
+### Documentation updates
+- Added documentation about the Michelson encoder package [here](https://tezostaquito.io/docs/michelson_encoder).
+
+
+## Forward compatibility for Florence
+
+This version ships with official support for the new Florence protocol which will come into effect on Mainnet in May.
+
+## @taquito/taquito - Allows fetching big map with a key of type string, number, or object. 
+
+In the precedent versions, fetching a value in a big map required the parameter to be a string, even in such cases when the key of the big map was a number. The `get` and `getMultipleValues` methods of the `BigMapAbstraction` and `getBigMapKeyByID` and `getBigMapKeysByID` methods of the `RpcContractProvider` class now accept a string, a number or an object for the key we want to fetch.
+
+This introduced a breaking change for the method `getMultipleValues` of the `BigMapAbstraction` class and the method `getBigMapKeysByID` of the `RpcContractProvider` class as they now return a `MichelsonMap` instead of an object. This is meant to support keys of type object that are encountered when the Michelson type of the big map key is a pair.
+
+## @taquito/taquito - Accept an operator for the retry strategy of the ObservableSubscription class
+
+To give more flexibility to the user on the retry strategy, we removed the parameters `observableSubscriptionRetryDelay` and `observableSubscriptionRetries` introduced in version 8.1.1-beta and replaced them to accept an `OperatorFunction`. When users configure the ObservableSubscription to retry on error, we use the `retry` operators from `rxjs` by default. An example showing how to set a custom retry strategy is available [here](https://github.com/ecadlabs/taquito/blob/master/example/example-streamer-custom-retry-logic.ts).
+
 # Taquito v8.1.1-beta
 
 ## Summary

--- a/docs/version.md
+++ b/docs/version.md
@@ -11,7 +11,7 @@ author: Jev Bjorsell
 - Florence compatibility support
 - Allows fetching big map with a key of type string, number, or object. 
 - Accept an operator for the retry strategy of the `ObservableSubscription` class
-- Updated beacon-sdk version to v2.2.4 which includes several performance improvements for p2p pairing.
+- Updated beacon-sdk version to v2.2.5 which includes several performance improvements for p2p pairing.
 
 ### Documentation updates
 - Added documentation about the Michelson encoder package [here](https://tezostaquito.io/docs/michelson_encoder).

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -48,7 +48,7 @@
       "items": ["ledger_integration_test", "rpc_nodes_integration_test"]
     },
     {
-      "Upgrading Guide": ["v7_breaking_changes"]
+      "Upgrading Guide": ["upgrading_guide"]
     },
     {
       "type": "link",


### PR DESCRIPTION
#673 

Changed page `Upgrading to v7/delphi` to `Upgrading Guide` and added instructions for v8 and v9