### PR TITLE
Fix signature validation when containing a valid KT1 pattern address …

### DIFF
--- a/packages/taquito-utils/src/validators.ts
+++ b/packages/taquito-utils/src/validators.ts
@@ -39,7 +39,7 @@ function validatePrefixedValue(value: any, prefixes: Prefix[]) {
   }
 
   // Remove annotation from contract address before doing the validation
-  const contractAddress = /(KT1\w{33})(\%(.*))?/.exec(value);
+  const contractAddress = /^(KT1\w{33})(\%(.*))?/.exec(value);
   if (contractAddress) {
     value = contractAddress[1];
   }

--- a/packages/taquito-utils/test/validators.spec.ts
+++ b/packages/taquito-utils/test/validators.spec.ts
@@ -115,6 +115,11 @@ describe('validateSignature', () => {
     ).toEqual(ValidationResult.VALID);
     expect(
       validateSignature(
+        'edsigthp7LbR5JQ1HRnxKdvhphTJs2omjnu6DF7LhRokPbPHXjkv2EqmCwu3KT1jKRZjrrgb749Yao26qMdcDFbXKrjA7KLSKRC'
+      )
+    ).toEqual(ValidationResult.VALID);
+    expect(
+      validateSignature(
         'sigd9ugzpERZmBfyVAAPG4KZfpR4qYA4U51EcALp2hijGgJq3aRqFQANo4hudg3uWbSTaKRKzYhXeoG1TStq5jowaGx1dP9H'
       )
     ).toEqual(ValidationResult.VALID);


### PR DESCRIPTION
This PR fixes signature validation when a base58 signature contains a valid KT1 pattern address, like `edsigthp7LbR5JQ1HRnxKdvhphTJs2omjnu6DF7LhRokPbPHXjkv2EqmCwu3KT1jKRZjrrgb749Yao26qMdcDFbXKrjA7KLSKRC`.