### PR TITLE
Added big_map_diff, lazy_storage_diff properties and failing_noop operation to RPC types

### DIFF
--- a/packages/taquito-rpc/src/opkind.ts
+++ b/packages/taquito-rpc/src/opkind.ts
@@ -11,4 +11,5 @@ export enum OpKind {
   DOUBLE_BAKING_EVIDENCE = 'double_baking_evidence',
   PROPOSALS = 'proposals',
   BALLOT = 'ballot',
+  FAILING_NOOP = 'failing_noop'
 }

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -515,6 +515,12 @@ export interface ContractBigMapDiffItem {
   key_hash: string;
   key: MichelsonV1Expression;
   value?: MichelsonV1Expression;
+  action?: DiffActionEnum;
+  big_map?: BigNumber;
+  source_big_map?: BigNumber;
+  destination_big_map?: BigNumber;
+  key_type?: MichelsonV1Expression;
+  value_type?: MichelsonV1Expression;
 }
 
 export type ContractBigMapDiff = ContractBigMapDiffItem[];
@@ -536,6 +542,7 @@ export interface OperationResultTransaction {
   allocated_destination_contract?: boolean;
   errors?: TezosGenericOperationError[];
   consumed_milligas?: string;
+  lazy_storage_diff?: LazyStorageDiff[];
 }
 
 export interface OperationResultReveal {
@@ -580,8 +587,58 @@ export interface OperationMetadataBalanceUpdates {
 
 export type OperationResultStatusEnum = 'applied' | 'failed' | 'skipped' | 'backtracked';
 
+export type DiffActionEnum = 'update' | 'remove' | 'copy' | 'alloc';
+
+export type LazyStorageDiffKindEnum = 'big_map' | 'sapling_state';
+
+export interface LazyStorageDiff {
+  kind: LazyStorageDiffKindEnum;
+  id: string;
+  diff: LazyStorageDiffBigMap | LazyStorageDiffSaplingState;
+}
+
+export interface LazyStorageDiffBigMap {
+  action: DiffActionEnum;
+  updates?: LazyStorageDiffUpdatesBigMap;
+  source?: string;
+  key_type?: MichelsonV1Expression;
+  value_type?: MichelsonV1Expression;
+}
+
+export interface LazyStorageDiffSaplingState {
+  action: DiffActionEnum;
+  updates?: LazyStorageDiffUpdatesSaplingState;
+  source?: string;
+  memo_size?: number;
+}
+
+export interface LazyStorageDiffUpdatesBigMap {
+  key_hash: string;
+  key: MichelsonV1Expression;
+  value?: MichelsonV1Expression;
+}
+
+export type CommitmentsAndCiphertexts = [SaplingTransactionCommitment, SaplingTransactionCiphertext];
+
+export type SaplingTransactionCommitment = string;
+
+export interface LazyStorageDiffUpdatesSaplingState {
+  commitments_and_ciphertexts: CommitmentsAndCiphertexts[];
+  nullifiers: string[];
+}
+
+export interface SaplingTransactionCiphertext {
+  cv: string;
+  epk: string;
+  payload_enc: string;
+  nonce_enc: string;
+  payload_out: string;
+  nonce_out: string;
+}
+
 export interface OperationResultOrigination {
   status: OperationResultStatusEnum;
+  big_map_diff?: ContractBigMapDiff;
   balance_updates?: OperationBalanceUpdates;
   originated_contracts?: string[];
   consumed_gas?: string;
@@ -589,6 +646,7 @@ export interface OperationResultOrigination {
   paid_storage_size_diff?: string;
   errors?: TezosGenericOperationError[];
   consumed_milligas?: string;
+  lazy_storage_diff?: LazyStorageDiff[];
 }
 
 export interface OperationContentsAndResultMetadataOrigination {

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -72,6 +72,11 @@ export interface OperationContentsEndorsementWithSlot  {
   slot: number;
 }
 
+export interface OperationContentsFailingNoop {
+  kind: OpKind.FAILING_NOOP;
+  arbitrary: string;
+}
+
 export interface OperationContentsRevelation {
   kind: OpKind.SEED_NONCE_REVELATION;
   level: number;
@@ -168,7 +173,8 @@ export type OperationContents =
   | OperationContentsTransaction
   | OperationContentsOrigination
   | OperationContentsDelegation
-  | OperationContentsEndorsementWithSlot;
+  | OperationContentsEndorsementWithSlot
+  | OperationContentsFailingNoop;
 
 export interface OperationContentsAndResultMetadataExtended {
   balance_updates: OperationMetadataBalanceUpdates[];
@@ -377,7 +383,7 @@ export interface BallotsResponse {
   pass: number;
 }
 
-export type PeriodKindResponse = 'proposal' | 'testing_vote' | 'testing' | 'promotion_vote';
+export type PeriodKindResponse = 'proposal' | 'testing_vote' | 'testing' | 'promotion_vote' | 'exploration' | 'cooldown' | 'promotion' | 'adoption';
 
 export type CurrentProposalResponse = string | null;
 
@@ -481,6 +487,7 @@ export interface OperationBalanceUpdatesItem {
   cycle?: number;
   contract?: string;
   change: string;
+  origin?: MetadataBalanceUpdatesOriginEnum;
 }
 
 export type OperationBalanceUpdates = OperationBalanceUpdatesItem[];
@@ -512,8 +519,8 @@ export interface OperationResultDelegation {
 }
 
 export interface ContractBigMapDiffItem {
-  key_hash: string;
-  key: MichelsonV1Expression;
+  key_hash?: string;
+  key?: MichelsonV1Expression;
   value?: MichelsonV1Expression;
   action?: DiffActionEnum;
   big_map?: BigNumber;
@@ -589,25 +596,33 @@ export type OperationResultStatusEnum = 'applied' | 'failed' | 'skipped' | 'back
 
 export type DiffActionEnum = 'update' | 'remove' | 'copy' | 'alloc';
 
-export type LazyStorageDiffKindEnum = 'big_map' | 'sapling_state';
+// export type LazyStorageDiffKindEnum = 'big_map' | 'sapling_state';
 
-export interface LazyStorageDiff {
-  kind: LazyStorageDiffKindEnum;
-  id: string;
-  diff: LazyStorageDiffBigMap | LazyStorageDiffSaplingState;
-}
+export type LazyStorageDiff = LazyStorageDiffBigMap | LazyStorageDiffSaplingState;
 
 export interface LazyStorageDiffBigMap {
+  kind: 'big_map';
+  id: string;
+  diff: LazyStorageDiffBigMapItems;
+}
+
+export interface LazyStorageDiffSaplingState {
+  kind: 'sapling_state';
+  id: string;
+  diff: LazyStorageDiffSaplingStateItems;
+}
+
+export interface LazyStorageDiffBigMapItems {
   action: DiffActionEnum;
-  updates?: LazyStorageDiffUpdatesBigMap;
+  updates?: LazyStorageDiffUpdatesBigMap[];
   source?: string;
   key_type?: MichelsonV1Expression;
   value_type?: MichelsonV1Expression;
 }
 
-export interface LazyStorageDiffSaplingState {
+export interface LazyStorageDiffSaplingStateItems {
   action: DiffActionEnum;
-  updates?: LazyStorageDiffUpdatesSaplingState;
+  updates?: LazyStorageDiffUpdatesSaplingState[];
   source?: string;
   memo_size?: number;
 }
@@ -731,7 +746,7 @@ export interface TestChainStatus {
 
 export interface MaxOperationListLength {
   max_size: number;
-  max_op: number;
+  max_op?: number;
 }
 
 export interface Level {

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -1,6 +1,6 @@
 import { RpcClient } from '../src/taquito-rpc';
 import BigNumber from 'bignumber.js';
-import { OperationContentsAndResultEndorsement, OperationContentsAndResultEndorsementWithSlot } from '../src/types';
+import { LazyStorageDiffBigMap, OperationContentsAndResultEndorsement, OperationContentsAndResultEndorsementWithSlot, OperationResultTransaction } from '../src/types';
 import { OperationContentsAndResultTransaction } from '../src/types';
 
 /**
@@ -479,8 +479,8 @@ describe('RpcClient test', () => {
           origination_size: 257,
           block_security_deposit: '512000000',
           endorsement_security_deposit: '64000000',
-          baking_reward_per_endorsement: ['1250000','187500'],
-          endorsement_reward: ['1250000','833333'],
+          baking_reward_per_endorsement: ['1250000', '187500'],
+          endorsement_reward: ['1250000', '833333'],
           cost_per_byte: '250',
           hard_storage_limit_per_operation: '60000',
           test_chain_duration: '61440',
@@ -530,7 +530,7 @@ describe('RpcClient test', () => {
     });
   });
 
-   describe('getConstants Proto006', () => {
+  describe('getConstants Proto006', () => {
     it('properties return by the RPC are accessible and the ones that do not belong to proto6 are undefined', async done => {
       httpBackend.createRequest.mockReturnValue(
         Promise.resolve({
@@ -555,8 +555,8 @@ describe('RpcClient test', () => {
           origination_size: 257,
           block_security_deposit: '512000000',
           endorsement_security_deposit: '64000000',
-          baking_reward_per_endorsement: ['1250000','187500'],
-          endorsement_reward: ['1250000','833333'],
+          baking_reward_per_endorsement: ['1250000', '187500'],
+          endorsement_reward: ['1250000', '833333'],
           cost_per_byte: '1000',
           hard_storage_limit_per_operation: '60000',
           test_chain_duration: '1966080',
@@ -577,7 +577,7 @@ describe('RpcClient test', () => {
 
       expect(response.origination_size).toBeDefined();
       expect(response.origination_size!).toEqual(257);
-      
+
       expect(response.max_anon_ops_per_block).toBeUndefined();
       expect(response.block_reward).toBeUndefined();
       expect(response.origination_burn).toBeUndefined();
@@ -612,7 +612,7 @@ describe('RpcClient test', () => {
           block_security_deposit: '512000000',
           endorsement_security_deposit: '64000000',
           block_reward: '16000000',
-          baking_reward_per_endorsement: ['1250000','187500'],
+          baking_reward_per_endorsement: ['1250000', '187500'],
           endorsement_reward: '2000000',
           cost_per_byte: '1000',
           hard_storage_limit_per_operation: '60000',
@@ -797,236 +797,236 @@ describe('RpcClient test', () => {
     it('query the right url and property for operation', async done => {
       httpBackend.createRequest.mockReturnValue(
         Promise.resolve({
+          protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
+          chain_id: 'NetXSgo1ZT2DRUG',
+          hash: 'BKjqpGqKggVrYbkBmBUYjLx8QdCUxBLaVGr1GWKho4ziBo1KQFX',
+          header: {
+            level: 90973,
+            proto: 1,
+            predecessor: 'BMF7j462upRKLRWEdmFYTCMK3kuEfbQdR2Apo7noc1ZwzPZi2ji',
+            timestamp: '2021-03-16T17:49:35Z',
+            validation_pass: 4,
+            operations_hash: 'LLoZv71M2tWPD8mMjDhf7QcE5ZaHrtYCu4wFRhmPkBWvwCEMxacei',
+            fitness: [
+              '01',
+              '000000000001635c'
+            ],
+            context: 'CoV8F9ro52txU4rGRGNXfQZgbE3pZVMygNV4UGjf6foKhBMb8MJC',
+            priority: 0,
+            proof_of_work_nonce: '6102c8089c360500',
+            signature: 'sigkj5nVVW6Zq7F9dEstPs5o2s1vTnUfwhsWi3UnmwrjYVwN9gfmXUBArzSLeXEUNQBM4KUYSg385i1ajR9TugSkM2swFzQp'
+          },
+          metadata: {
             protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
-            chain_id: 'NetXSgo1ZT2DRUG',
-            hash: 'BKjqpGqKggVrYbkBmBUYjLx8QdCUxBLaVGr1GWKho4ziBo1KQFX',
-            header: {
+            next_protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
+            test_chain_status: {
+              status: 'not_running'
+            },
+            max_operations_ttl: 60,
+            max_operation_data_length: 16384,
+            max_block_header_length: 238,
+            max_operation_list_length: [
+              {
+                max_size: 32768,
+                max_op: 32
+              },
+              {
+                max_size: 32768
+              },
+              {
+                max_size: 135168,
+                max_op: 132
+              },
+              {
+                max_size: 524288
+              }
+            ],
+            baker: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+            level: {
               level: 90973,
-              proto: 1,
-              predecessor: 'BMF7j462upRKLRWEdmFYTCMK3kuEfbQdR2Apo7noc1ZwzPZi2ji',
-              timestamp: '2021-03-16T17:49:35Z',
-              validation_pass: 4,
-              operations_hash: 'LLoZv71M2tWPD8mMjDhf7QcE5ZaHrtYCu4wFRhmPkBWvwCEMxacei',
-              fitness: [
-                '01',
-                '000000000001635c'
-              ],
-              context: 'CoV8F9ro52txU4rGRGNXfQZgbE3pZVMygNV4UGjf6foKhBMb8MJC',
-              priority: 0,
-              proof_of_work_nonce: '6102c8089c360500',
-              signature: 'sigkj5nVVW6Zq7F9dEstPs5o2s1vTnUfwhsWi3UnmwrjYVwN9gfmXUBArzSLeXEUNQBM4KUYSg385i1ajR9TugSkM2swFzQp'
+              level_position: 90972,
+              cycle: 44,
+              cycle_position: 860,
+              voting_period: 22,
+              voting_period_position: 860,
+              expected_commitment: false
             },
-            metadata: {
-              protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
-              next_protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
-              test_chain_status: {
-                status: 'not_running'
-              },
-              max_operations_ttl: 60,
-              max_operation_data_length: 16384,
-              max_block_header_length: 238,
-              max_operation_list_length: [
-                {
-                  max_size: 32768,
-                  max_op: 32
-                },
-                {
-                  max_size: 32768
-                },
-                {
-                  max_size: 135168,
-                  max_op: 132
-                },
-                {
-                  max_size: 524288
-                }
-              ],
-              baker: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
-              level: {
-                level: 90973,
-                level_position: 90972,
-                cycle: 44,
-                cycle_position: 860,
-                voting_period: 22,
-                voting_period_position: 860,
-                expected_commitment: false
-              },
-              level_info: {
-                level: 90973,
-                level_position: 90972,
-                cycle: 44,
-                cycle_position: 860,
-                expected_commitment: false
-              },
-              voting_period_kind: 'proposal',
-              voting_period_info: {
-                voting_period: {
-                  index: 22,
-                  kind: 'proposal',
-                  start_position: 90112,
-                },
-                position: 860,
-                remaining: 3235
-              },
-              nonce_hash: null,
-              consumed_gas: '73225095',
-              deactivated: [
-                
-              ],
-              balance_updates: [
-                {
-                  kind: 'contract',
-                  contract: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
-                  change: '-512000000'
-                },
-                {
-                  kind: 'freezer',
-                  category: 'deposits',
-                  delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
-                  cycle: 44,
-                  change: '512000000'
-                },
-                {
-                  kind: 'freezer',
-                  category: 'rewards',
-                  delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
-                  cycle: 44,
-                  change: '38750000'
-                }
-              ]
+            level_info: {
+              level: 90973,
+              level_position: 90972,
+              cycle: 44,
+              cycle_position: 860,
+              expected_commitment: false
             },
-            operations: [
-              [
-                {
-                  protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
-                  chain_id: 'NetXSgo1ZT2DRUG',
-                  hash: 'onefqcSYA5FNfNW68ghLqQajxnM9cZ3vvdNaTDR1Mhv34LBAhaG',
-                  branch: 'BMF7j462upRKLRWEdmFYTCMK3kuEfbQdR2Apo7noc1ZwzPZi2ji',
-                  contents: [
-                    {
-                      kind: 'transaction',
-                      source: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8',
-                      fee: '2820',
-                      counter: '184578',
-                      gas_limit: '24760',
-                      storage_limit: '1',
-                      amount: '0',
-                      destination: 'KT1LSuT4NgCQyZK1CWpss7FcJTTw68NDgPyR',
-                      parameters: {
-                        entrypoint: 'mint',
-                        value: {
-                          prim: 'Pair',
-                          args: [
-                            {
-                              string: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8'
-                            },
-                            {
-                              int: '100'
-                            }
-                          ]
+            voting_period_kind: 'proposal',
+            voting_period_info: {
+              voting_period: {
+                index: 22,
+                kind: 'proposal',
+                start_position: 90112,
+              },
+              position: 860,
+              remaining: 3235
+            },
+            nonce_hash: null,
+            consumed_gas: '73225095',
+            deactivated: [
+
+            ],
+            balance_updates: [
+              {
+                kind: 'contract',
+                contract: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+                change: '-512000000'
+              },
+              {
+                kind: 'freezer',
+                category: 'deposits',
+                delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+                cycle: 44,
+                change: '512000000'
+              },
+              {
+                kind: 'freezer',
+                category: 'rewards',
+                delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+                cycle: 44,
+                change: '38750000'
+              }
+            ]
+          },
+          operations: [
+            [
+              {
+                protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
+                chain_id: 'NetXSgo1ZT2DRUG',
+                hash: 'onefqcSYA5FNfNW68ghLqQajxnM9cZ3vvdNaTDR1Mhv34LBAhaG',
+                branch: 'BMF7j462upRKLRWEdmFYTCMK3kuEfbQdR2Apo7noc1ZwzPZi2ji',
+                contents: [
+                  {
+                    kind: 'transaction',
+                    source: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8',
+                    fee: '2820',
+                    counter: '184578',
+                    gas_limit: '24760',
+                    storage_limit: '1',
+                    amount: '0',
+                    destination: 'KT1LSuT4NgCQyZK1CWpss7FcJTTw68NDgPyR',
+                    parameters: {
+                      entrypoint: 'mint',
+                      value: {
+                        prim: 'Pair',
+                        args: [
+                          {
+                            string: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8'
+                          },
+                          {
+                            int: '100'
+                          }
+                        ]
+                      }
+                    },
+                    metadata: {
+                      balance_updates: [
+                        {
+                          kind: 'contract',
+                          contract: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8',
+                          change: '-2820'
+                        },
+                        {
+                          kind: 'freezer',
+                          category: 'fees',
+                          delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+                          cycle: 44,
+                          change: '2820'
                         }
-                      },
-                      metadata: {
+                      ],
+                      operation_result: {
+                        status: 'applied',
+                        storage: [
+                          {
+                            int: '33681'
+                          },
+                          {
+                            bytes: '0002a7f8d8600737ff279e4b9a4b1518157b653a314d'
+                          },
+                          {
+                            prim: 'False'
+                          },
+                          {
+                            int: '300'
+                          }
+                        ],
+                        big_map_diff: [
+                          {
+                            action: 'update',
+                            big_map: '33681',
+                            key_hash: 'expruAQuDQJ9ojnpqipCAbR23gBSSff7AxaMT9UBRjpZpiDHfJ6b6L',
+                            key: {
+                              bytes: '0002a7f8d8600737ff279e4b9a4b1518157b653a314d'
+                            },
+                            value: {
+                              prim: 'Pair',
+                              args: [
+                                {
+                                  int: '102'
+                                },
+                                [
+
+                                ]
+                              ]
+                            }
+                          }
+                        ],
                         balance_updates: [
                           {
                             kind: 'contract',
                             contract: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8',
-                            change: '-2820'
-                          },
-                          {
-                            kind: 'freezer',
-                            category: 'fees',
-                            delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
-                            cycle: 44,
-                            change: '2820'
+                            change: '-250'
                           }
                         ],
-                        operation_result: {
-                          status: 'applied',
-                          storage: [
-                            {
-                              int: '33681'
-                            },
-                            {
-                              bytes: '0002a7f8d8600737ff279e4b9a4b1518157b653a314d'
-                            },
-                            {
-                              prim: 'False'
-                            },
-                            {
-                              int: '300'
-                            }
-                          ],
-                          big_map_diff: [
-                            {
+                        consumed_gas: '24660',
+                        consumed_milligas: '24659284',
+                        storage_size: '5335',
+                        paid_storage_size_diff: '1',
+                        lazy_storage_diff: [
+                          {
+                            kind: 'big_map',
+                            id: '33681',
+                            diff: {
                               action: 'update',
-                              big_map: '33681',
-                              key_hash: 'expruAQuDQJ9ojnpqipCAbR23gBSSff7AxaMT9UBRjpZpiDHfJ6b6L',
-                              key: {
-                                bytes: '0002a7f8d8600737ff279e4b9a4b1518157b653a314d'
-                              },
-                              value: {
-                                prim: 'Pair',
-                                args: [
-                                  {
-                                    int: '102'
+                              updates: [
+                                {
+                                  key_hash: 'expruAQuDQJ9ojnpqipCAbR23gBSSff7AxaMT9UBRjpZpiDHfJ6b6L',
+                                  key: {
+                                    bytes: '0002a7f8d8600737ff279e4b9a4b1518157b653a314d'
                                   },
-                                  [
-                                    
-                                  ]
-                                ]
-                              }
-                            }
-                          ],
-                          balance_updates: [
-                            {
-                              kind: 'contract',
-                              contract: 'tz3beCZmQhd5Q1KNMZbiLCarXVo9aqpPHYe8',
-                              change: '-250'
-                            }
-                          ],
-                          consumed_gas: '24660',
-                          consumed_milligas: '24659284',
-                          storage_size: '5335',
-                          paid_storage_size_diff: '1',
-                          lazy_storage_diff: [
-                            {
-                              kind: 'big_map',
-                              id: '33681',
-                              diff: {
-                                action: 'update',
-                                updates: [
-                                  {
-                                    key_hash: 'expruAQuDQJ9ojnpqipCAbR23gBSSff7AxaMT9UBRjpZpiDHfJ6b6L',
-                                    key: {
-                                      bytes: '0002a7f8d8600737ff279e4b9a4b1518157b653a314d'
-                                    },
-                                    value: {
-                                      prim: 'Pair',
-                                      args: [
-                                        {
-                                          int: '102'
-                                        },
-                                        [
-                                          
-                                        ]
+                                  value: {
+                                    prim: 'Pair',
+                                    args: [
+                                      {
+                                        int: '102'
+                                      },
+                                      [
+
                                       ]
-                                    }
+                                    ]
                                   }
-                                ]
-                              }
+                                }
+                              ]
                             }
-                          ]
-                        }
+                          }
+                        ]
                       }
                     }
-                  ],
-                  signature: 'sigmCS2nZquXi3vXX8p7iwc6TVYC87FsGYkxSgEMiQESbM5dnnP4SGe4YHLRFXuRwcs1VaNLsiFWzVQVnpbNDfAhYhPgRnCG',
-                },
-              ],
+                  }
+                ],
+                signature: 'sigmCS2nZquXi3vXX8p7iwc6TVYC87FsGYkxSgEMiQESbM5dnnP4SGe4YHLRFXuRwcs1VaNLsiFWzVQVnpbNDfAhYhPgRnCG',
+              },
             ],
-          })
-        );
+          ],
+        })
+      );
 
       const response = await client.getBlock();
 
@@ -1129,6 +1129,594 @@ describe('RpcClient test', () => {
       expect(endorsementWithSlot.slot).toEqual(4);
       done();
     });
+
+
+    it('query the right url and properties (big_map_diff and lazy_storage_diff) in transaction operation result, proto 9', async done => {
+      httpBackend.createRequest.mockReturnValue(
+        Promise.resolve({
+          "protocol": "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i",
+          "chain_id": "NetXdQprcVkpaWU",
+          "hash": "BLQFAtBgdUtRHoceLfvfVEL6ick7JvZrNoyvAdvqJGD1HWuJ7fV",
+          "header": {
+            "level": 1470478,
+            "proto": 9,
+            "predecessor": "BKqxeSBXxYZhjjuFc8At4vEtYjZQJKEPxb83iJqetYDU3CGYQ42",
+            "timestamp": "2021-05-14T00:13:58Z",
+            "validation_pass": 4,
+            "operations_hash": "LLoaX8tJAJqhkhXhc2cy7yzwjQbikUYmQxQKYqQvYm9Tfq9E9tML7",
+            "fitness": [
+              "01",
+              "00000000000c700e"
+            ],
+            "context": "CoWFaDTwc3TnXws8hfdzE8QNUA3WCvH64XBR2ZaC9EBKePBwpkSy",
+            "priority": 0,
+            "proof_of_work_nonce": "31e6641dd3560300",
+            "signature": "sigw8azwmbdkJjMNoGD6Ls2idXAdxuexUZZV5VMTpJnx1PADBqhFgDma42PGyVLEfd4FybianKrEJcTVMBb6GMgdZtSDYbYL"
+          },
+          "metadata": {
+            "protocol": "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i",
+            "next_protocol": "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i",
+            "test_chain_status": {
+              "status": "not_running"
+            },
+            "max_operations_ttl": 60,
+            "max_operation_data_length": 32768,
+            "max_block_header_length": 238,
+            "max_operation_list_length": [
+              {
+                "max_size": 4194304,
+                "max_op": 2048
+              },
+              {
+                "max_size": 32768
+              },
+              {
+                "max_size": 135168,
+                "max_op": 132
+              },
+              {
+                "max_size": 524288
+              }
+            ],
+            "baker": "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT",
+            "level": {
+              "level": 1470478,
+              "level_position": 1470477,
+              "cycle": 359,
+              "cycle_position": 13,
+              "voting_period": 47,
+              "voting_period_position": 4110,
+              "expected_commitment": false
+            },
+            "level_info": {
+              "level": 1470478,
+              "level_position": 1470477,
+              "cycle": 359,
+              "cycle_position": 13,
+              "expected_commitment": false
+            },
+            "voting_period_kind": "proposal",
+            "voting_period_info": {
+              "voting_period": {
+                "index": 47,
+                "kind": "proposal",
+                "start_position": 1466367
+              },
+              "position": 4110,
+              "remaining": 16369
+            },
+            "nonce_hash": null,
+            "consumed_gas": "1644308817",
+            "deactivated": [],
+            "balance_updates": [
+              {
+                "kind": "contract",
+                "contract": "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT",
+                "change": "-512000000",
+                "origin": "block"
+              },
+              {
+                "kind": "freezer",
+                "category": "deposits",
+                "delegate": "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT",
+                "cycle": 359,
+                "change": "512000000",
+                "origin": "block"
+              },
+              {
+                "kind": "freezer",
+                "category": "rewards",
+                "delegate": "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT",
+                "cycle": 359,
+                "change": "33750000",
+                "origin": "block"
+              }
+            ]
+          },
+          "operations": [
+            [
+              {
+                "protocol": "PsFLorenaUUuikDWvMDr6fGBRG8kt3e3D3fHoXK1j1BFRxeSH4i",
+                "chain_id": "NetXdQprcVkpaWU",
+                "hash": "oo4ZXrmij79uZfWKPzxQHsyVS3TLecHDVx8ZrLv6qpeijLLzP3b",
+                "branch": "BKqxeSBXxYZhjjuFc8At4vEtYjZQJKEPxb83iJqetYDU3CGYQ42",
+                "contents": [
+                  {
+                    "kind": "transaction",
+                    "source": "tz1PaJwmmL2nrRt5K6HvwFEc6fUfxNe6Dyp5",
+                    "fee": "12543",
+                    "counter": "12961179",
+                    "gas_limit": "122564",
+                    "storage_limit": "212",
+                    "amount": "500000",
+                    "destination": "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9",
+                    "parameters": {
+                      "entrypoint": "collect",
+                      "value": {
+                        "prim": "Pair",
+                        "args": [
+                          {
+                            "int": "1"
+                          },
+                          {
+                            "int": "140470"
+                          }
+                        ]
+                      }
+                    },
+                    "metadata": {
+                      "balance_updates": [
+                        {
+                          "kind": "contract",
+                          "contract": "tz1PaJwmmL2nrRt5K6HvwFEc6fUfxNe6Dyp5",
+                          "change": "-12543",
+                          "origin": "block"
+                        },
+                        {
+                          "kind": "freezer",
+                          "category": "fees",
+                          "delegate": "tz1W5VkdB5s7ENMESVBtwyt9kyvLqPcUczRT",
+                          "cycle": 359,
+                          "change": "12543",
+                          "origin": "block"
+                        }
+                      ],
+                      "operation_result": {
+                        "status": "applied",
+                        "storage": [
+                          [
+                            {
+                              "prim": "Pair",
+                              "args": [
+                                {
+                                  "bytes": "01d4bbb83486df92642008e9ce812481f4d564611100"
+                                },
+                                {
+                                  "prim": "Pair",
+                                  "args": [
+                                    {
+                                      "int": "1618452581"
+                                    },
+                                    {
+                                      "bytes": "01123aaf8d2c25e0ddafa6d98e16582de7478f092500"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "prim": "True"
+                            },
+                            {
+                              "bytes": "00005db799bf9b0dc319ba1cf21ab01461a9639043ca"
+                            },
+                            {
+                              "int": "521"
+                            }
+                          ],
+                          {
+                            "prim": "Pair",
+                            "args": [
+                              {
+                                "bytes": "01b752c7f3de31759bce246416a6823e86b9756c6c00"
+                              },
+                              {
+                                "prim": "Pair",
+                                "args": [
+                                  {
+                                    "int": "78796"
+                                  },
+                                  {
+                                    "int": "522"
+                                  }
+                                ]
+                              }
+                            ]
+                          },
+                          {
+                            "int": "0"
+                          },
+                          {
+                            "int": "142549"
+                          },
+                          {
+                            "int": "523"
+                          }
+                        ],
+                        "big_map_diff": [
+                          {
+                            "action": "update",
+                            "big_map": "523",
+                            "key_hash": "exprttR8DRSn1Ry4mfsAUQTnEqNrHGppnGdyk7hz3hTinLEWsX3HQg",
+                            "key": {
+                              "int": "140470"
+                            },
+                            "value": {
+                              "prim": "Pair",
+                              "args": [
+                                {
+                                  "prim": "Pair",
+                                  "args": [
+                                    {
+                                      "bytes": "0000c7e376baa5650223728c95963f77119148e4f5f4"
+                                    },
+                                    {
+                                      "int": "14"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "prim": "Pair",
+                                  "args": [
+                                    {
+                                      "int": "77582"
+                                    },
+                                    {
+                                      "int": "500000"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          }
+                        ],
+                        "balance_updates": [
+                          {
+                            "kind": "contract",
+                            "contract": "tz1PaJwmmL2nrRt5K6HvwFEc6fUfxNe6Dyp5",
+                            "change": "-500000",
+                            "origin": "block"
+                          },
+                          {
+                            "kind": "contract",
+                            "contract": "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9",
+                            "change": "500000",
+                            "origin": "block"
+                          }
+                        ],
+                        "consumed_gas": "91530",
+                        "consumed_milligas": "91529556",
+                        "storage_size": "16397849",
+                        "lazy_storage_diff": [
+                          {
+                            "kind": "big_map",
+                            "id": "523",
+                            "diff": {
+                              "action": "update",
+                              "updates": [
+                                {
+                                  "key_hash": "exprttR8DRSn1Ry4mfsAUQTnEqNrHGppnGdyk7hz3hTinLEWsX3HQg",
+                                  "key": {
+                                    "int": "140470"
+                                  },
+                                  "value": {
+                                    "prim": "Pair",
+                                    "args": [
+                                      {
+                                        "prim": "Pair",
+                                        "args": [
+                                          {
+                                            "bytes": "0000c7e376baa5650223728c95963f77119148e4f5f4"
+                                          },
+                                          {
+                                            "int": "14"
+                                          }
+                                        ]
+                                      },
+                                      {
+                                        "prim": "Pair",
+                                        "args": [
+                                          {
+                                            "int": "77582"
+                                          },
+                                          {
+                                            "int": "500000"
+                                          }
+                                        ]
+                                      }
+                                    ]
+                                  }
+                                }
+                              ]
+                            }
+                          },
+                          {
+                            "kind": "big_map",
+                            "id": "522",
+                            "diff": {
+                              "action": "update",
+                              "updates": []
+                            }
+                          },
+                          {
+                            "kind": "big_map",
+                            "id": "521",
+                            "diff": {
+                              "action": "update",
+                              "updates": []
+                            }
+                          }
+                        ]
+                      },
+                      "internal_operation_results": [
+                        {
+                          "kind": "transaction",
+                          "source": "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9",
+                          "nonce": 26,
+                          "amount": "0",
+                          "destination": "KT1RJ6PbjHpwc3M5rw5s2Nbmefwbuwbdxton",
+                          "parameters": {
+                            "entrypoint": "transfer",
+                            "value": [
+                              {
+                                "prim": "Pair",
+                                "args": [
+                                  {
+                                    "bytes": "016498b7494a18a572c1d24484038545662c0454ed00"
+                                  },
+                                  [
+                                    {
+                                      "prim": "Pair",
+                                      "args": [
+                                        {
+                                          "bytes": "00002b2c68041fe4a6d3219220a12d64a7cc06288e7a"
+                                        },
+                                        {
+                                          "prim": "Pair",
+                                          "args": [
+                                            {
+                                              "int": "77582"
+                                            },
+                                            {
+                                              "int": "1"
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                ]
+                              }
+                            ]
+                          },
+                          "result": {
+                            "status": "applied",
+                            "storage": [
+                              {
+                                "prim": "Pair",
+                                "args": [
+                                  {
+                                    "bytes": "016498b7494a18a572c1d24484038545662c0454ed00"
+                                  },
+                                  {
+                                    "prim": "Pair",
+                                    "args": [
+                                      {
+                                        "int": "78796"
+                                      },
+                                      {
+                                        "int": "511"
+                                      }
+                                    ]
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "Pair",
+                                "args": [
+                                  {
+                                    "int": "512"
+                                  },
+                                  {
+                                    "int": "513"
+                                  }
+                                ]
+                              },
+                              {
+                                "prim": "False"
+                              },
+                              {
+                                "int": "514"
+                              }
+                            ],
+                            "big_map_diff": [
+                              {
+                                "action": "update",
+                                "big_map": "511",
+                                "key_hash": "exprtjwzEHJr4evsEBcd8va7d8fyb6aA8LRkfsGdVhXGxM9Unjgk3i",
+                                "key": {
+                                  "prim": "Pair",
+                                  "args": [
+                                    {
+                                      "bytes": "016498b7494a18a572c1d24484038545662c0454ed00"
+                                    },
+                                    {
+                                      "int": "77582"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "int": "14"
+                                }
+                              },
+                              {
+                                "action": "update",
+                                "big_map": "511",
+                                "key_hash": "exprtw5AgJ5izrup4msD2ovuwgoVciojz4fGz6YoknvHvjo7xEMzcm",
+                                "key": {
+                                  "prim": "Pair",
+                                  "args": [
+                                    {
+                                      "bytes": "00002b2c68041fe4a6d3219220a12d64a7cc06288e7a"
+                                    },
+                                    {
+                                      "int": "77582"
+                                    }
+                                  ]
+                                },
+                                "value": {
+                                  "int": "1"
+                                }
+                              }
+                            ],
+                            "balance_updates": [
+                              {
+                                "kind": "contract",
+                                "contract": "tz1PaJwmmL2nrRt5K6HvwFEc6fUfxNe6Dyp5",
+                                "change": "-16750",
+                                "origin": "block"
+                              }
+                            ],
+                            "consumed_gas": "26673",
+                            "consumed_milligas": "26672257",
+                            "storage_size": "47030669",
+                            "paid_storage_size_diff": "67",
+                            "lazy_storage_diff": [
+                              {
+                                "kind": "big_map",
+                                "id": "514",
+                                "diff": {
+                                  "action": "update",
+                                  "updates": []
+                                }
+                              },
+                              {
+                                "kind": "big_map",
+                                "id": "513",
+                                "diff": {
+                                  "action": "update",
+                                  "updates": []
+                                }
+                              },
+                              {
+                                "kind": "big_map",
+                                "id": "512",
+                                "diff": {
+                                  "action": "update",
+                                  "updates": []
+                                }
+                              },
+                              {
+                                "kind": "big_map",
+                                "id": "511",
+                                "diff": {
+                                  "action": "update",
+                                  "updates": [
+                                    {
+                                      "key_hash": "exprtw5AgJ5izrup4msD2ovuwgoVciojz4fGz6YoknvHvjo7xEMzcm",
+                                      "key": {
+                                        "prim": "Pair",
+                                        "args": [
+                                          {
+                                            "bytes": "00002b2c68041fe4a6d3219220a12d64a7cc06288e7a"
+                                          },
+                                          {
+                                            "int": "77582"
+                                          }
+                                        ]
+                                      },
+                                      "value": {
+                                        "int": "1"
+                                      }
+                                    },
+                                    {
+                                      "key_hash": "exprtjwzEHJr4evsEBcd8va7d8fyb6aA8LRkfsGdVhXGxM9Unjgk3i",
+                                      "key": {
+                                        "prim": "Pair",
+                                        "args": [
+                                          {
+                                            "bytes": "016498b7494a18a572c1d24484038545662c0454ed00"
+                                          },
+                                          {
+                                            "int": "77582"
+                                          }
+                                        ]
+                                      },
+                                      "value": {
+                                        "int": "14"
+                                      }
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                ],
+                "signature": "sigvCzuirg8Dgwe37iXHEhBxD4NJ9aUUTn6679jzSF9Uwq2yJ3GbK4rnVEuKS935CateN8L4fHDD13RtRWomBUE4M92QqEvN"
+              }
+            ]
+          ]
+        })
+      );
+
+      const response = await client.getBlock();
+
+      expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
+        method: 'GET',
+        url: 'root/chains/test/blocks/head',
+      });
+
+
+      const transaction = response.operations[0][0].contents[0] as OperationContentsAndResultTransaction;
+      expect(transaction.kind).toEqual('transaction');
+      expect(transaction.metadata.operation_result.lazy_storage_diff).toBeDefined();
+
+      expect(transaction.metadata.operation_result.lazy_storage_diff![0].kind).toEqual('big_map');
+      expect(transaction.metadata.operation_result.lazy_storage_diff![0].id).toEqual('523');
+      expect(transaction.metadata.operation_result.lazy_storage_diff![0].diff.action).toEqual('update');
+
+      expect(transaction.metadata.operation_result.lazy_storage_diff![0].diff.updates).toBeDefined();
+      const update0 = transaction.metadata.operation_result.lazy_storage_diff![0] as LazyStorageDiffBigMap;
+      expect(update0.diff.updates).toBeDefined();
+      expect(update0.diff.updates![0].key_hash).toEqual('exprttR8DRSn1Ry4mfsAUQTnEqNrHGppnGdyk7hz3hTinLEWsX3HQg');
+
+      expect(transaction.metadata.operation_result.big_map_diff).toBeDefined();
+      expect(transaction.metadata.operation_result.big_map_diff![0].action).toEqual('update');
+      expect(transaction.metadata.operation_result.big_map_diff![0].big_map!.toString()).toEqual('523');
+
+      expect(transaction.metadata.internal_operation_results).toBeDefined();
+      expect(transaction.metadata.internal_operation_results![0].kind).toEqual('transaction');
+      expect(transaction.metadata.internal_operation_results![0].source).toEqual('KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9');
+      expect(transaction.metadata.internal_operation_results![0].nonce).toEqual(26);
+
+      const result = transaction.metadata.internal_operation_results![0].result as OperationResultTransaction;
+      expect(result.status).toEqual('applied');
+      expect(result.big_map_diff).toBeDefined();
+      expect(result.big_map_diff![0].action).toEqual('update');
+      expect(result.big_map_diff![0].key_hash).toEqual('exprtjwzEHJr4evsEBcd8va7d8fyb6aA8LRkfsGdVhXGxM9Unjgk3i');
+      expect(result.balance_updates).toBeDefined();
+      expect(result.balance_updates![0].kind).toEqual('contract');
+      expect(result.balance_updates![0].origin).toEqual('block');
+      expect(result.lazy_storage_diff).toBeDefined();
+      expect(result.lazy_storage_diff![0].kind).toEqual('big_map');
+      expect(result.lazy_storage_diff![0].id).toEqual('514');
+      done();
+    });
+
   });
 
   describe('getBakingRights', () => {
@@ -1493,11 +2081,11 @@ describe('RpcClient test', () => {
           "index": 87,
           "kind": "proposal",
           "start_position": 89088
-          },
+        },
         "position": 902,
         "remaining": 121
       };
-      
+
       httpBackend.createRequest.mockReturnValue(Promise.resolve(mockedResponse));
       const response = await client.getCurrentPeriod();
       expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
@@ -1518,11 +2106,11 @@ describe('RpcClient test', () => {
           "index": 87,
           "kind": "proposal",
           "start_position": 89088
-          },
+        },
         "position": 902,
         "remaining": 121
       };
-      
+
       httpBackend.createRequest.mockReturnValue(Promise.resolve(mockedResponse));
       const response = await client.getSuccessorPeriod();
       expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({


### PR DESCRIPTION
Closes #818 
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
