### PR TITLE
fix(taquito-signer): ensure correct byte is used to determine parity

### DIFF
--- a/packages/taquito-signer/src/ec-key.ts
+++ b/packages/taquito-signer/src/ec-key.ts
@@ -45,7 +45,9 @@ export class ECKey {
 
     this._key = decrypt(b58cdecode(this.key, prefix[keyPrefix]));
     const keyPair = new elliptic.ec(this.curve).keyFromPrivate(this._key);
-    const pref = keyPair.getPublic().getY().toArray()[31] % 2 ? 3 : 2;
+    const keyPairY = keyPair.getPublic().getY().toArray();
+    const parityByte = keyPairY.length < 32 ? keyPairY[keyPairY.length - 1] : keyPairY[31];
+    const pref = parityByte % 2 ? 3 : 2;
     const pad = new Array(32).fill(0);
     this._publicKey = toBuffer(
       new Uint8Array([pref].concat(pad.concat(keyPair.getPublic().getX().toArray()).slice(-32)))

--- a/packages/taquito-signer/test/taquito-signer.spec.ts
+++ b/packages/taquito-signer/test/taquito-signer.spec.ts
@@ -115,6 +115,21 @@ describe('inmemory-signer', () => {
     done();
   });
 
+  it('Tz2 having "y" coordinate shorter than 32 bytes', async (done) => {
+    const signer = new InMemorySigner('spsk24EJohZHJkZnWEzj3w9wE7BFARpFmq5WAo9oTtqjdJ2t4pyoB3');
+    expect(await signer.publicKey()).toEqual(
+      'sppk7bcmsCiZmrzrfGpPHnZMx73s6pUC4Tf1zdASQ3rgXfq8uGP3wgV'
+    );
+    expect(await signer.publicKeyHash()).toEqual('tz2T7hMiWgLAtpsB1JXEP59h3QA8rNVAP1Ue');
+    expect(await signer.secretKey()).toEqual(
+      'spsk24EJohZHJkZnWEzj3w9wE7BFARpFmq5WAo9oTtqjdJ2t4pyoB3'
+    );
+    expect((await signer.sign('1234', new Uint8Array([3]))).sig).toEqual(
+      'sigmVKa3AcvzDTPGD7rJXkrMh8XMVkVQUkLwGLL3h1APWgicRKBmgjZ3624vqHA2FufBrLTQuPS9YBN1h2Z16kexp9F8NRXp'
+    );
+    done();
+  });
+
   it('Tz3', async (done) => {
     const signer = new InMemorySigner('p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1');
     expect(await signer.publicKey()).toEqual(


### PR DESCRIPTION
We were looking at the byte at position 31 of the "y" coordinate to determine which prefix to use (3
if odd or 2 if even) when deriving the public key. The bug happened in cases where the "y"
coordinate was shorter than 32 bytes. The value at position 31 was undefined, so the prefix "2" was
always used enven if the "y" coordinate was odd.

fix #848

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
