### PR TITLE
correct  Taquito docs version number update

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -33,7 +33,7 @@ module.exports = {
         src: 'img/a_taquito.png'
       },
       items: [
-        { to: 'docs/version', label: 'v9.1', position: 'right' },
+        { to: 'docs/version', label: 'v9.1.0', position: 'right' },
         { to: 'docs/quick_start', label: 'Docs', position: 'right' },
         { href: "https://twitter.com/TezosTaquito", label: 'Twitter', position: 'right' },
         { href: "https://github.com/ecadlabs/taquito", label: 'GitHub', position: 'right' }


### PR DESCRIPTION
the update for the version of Taquito Docs was set to v9.1, it should have been v9.1.0  so this corrects it :)