### PR TITLE
Draft: chore: changed codeql ci job to self-hosted

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyse:
     name: Analyse
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Signed-off-by: Gino Imbrailo <ginoimbrailo@gmail.com>

After redeploying the self-hosted GitHub runners for Taquito we would like the CodeQL action to run on self-hosted runners again.
