### PR TITLE
docs(michelson encoder): modification of the doc after change in the …

### DIFF
--- a/docs/michelson_encoder.md
+++ b/docs/michelson_encoder.md
@@ -105,14 +105,6 @@ const storageSchema = new Schema(storageType);
 const extractSchema = storageSchema.ExtractSchema();
 println(JSON.stringify(extractSchema, null, 2));
 ```
-Note that for `big_map`, an object is returned where the key is the type of the big map key and the value is the type of the big map value.
-
-```js live noInline 
-const storageType = { prim: 'big_map', args: [{ prim: 'address' }, { prim: 'int' }] };
-const storageSchema = new Schema(storageType);
-const extractSchema = storageSchema.ExtractSchema();
-println(JSON.stringify(extractSchema, null, 2));
-```
 
 Here is another example using a complex storage:
 


### PR DESCRIPTION
…ExtractSchema for big_map

Removed obsolete documentation due to changing the big_map representation in the
Schema.ExtractSchema method.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
