### PR TITLE
Key ordering

### DIFF
--- a/integration-tests/contract-with-key-collections.spec.ts
+++ b/integration-tests/contract-with-key-collections.spec.ts
@@ -1,0 +1,77 @@
+import { CONFIGS } from "./config";
+import { MichelsonMap } from "@taquito/taquito";
+import { contractWithKeyCollections } from "./data/contract-with-key-collections";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+
+  describe(`Test contract with key collections using: ${rpc}`, () => {
+    type Storage = { keySet: string[], keyMap: MichelsonMap<string, number>; }
+
+    beforeEach(async (done) => {
+      await setup();
+      done();
+    });
+
+    it('Originate a contract with set and map of keys and change them using corresponding methods', async (done) => {
+      const initialStorage: Storage = {
+        keySet: [
+          'edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g',
+          'edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh',
+          'sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo',
+          'p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV',
+          'p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT',
+          'p2pk6842BMz2Se9XuMxQDe7yVdaEvpjNGQ7DYjKTQwzMUtryaHmZcV9',
+        ],
+        keyMap: MichelsonMap.fromLiteral({
+          'edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh': 10,
+          'p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT': 40,
+          'sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo': 100,
+          'sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj': 23,
+          'p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV': 17
+        }) as MichelsonMap<string, number>
+      };
+
+      const op = await Tezos.contract.originate({
+        balance: '1',
+        code: contractWithKeyCollections,
+        storage: initialStorage
+      });
+      await op.confirmation();
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+
+      const contract = await op.contract();
+      let storage = await contract.storage<Storage>();
+      expect([...storage['keySet']].sort()).toEqual([...initialStorage.keySet].sort());
+      expect(storage['keyMap'].get('edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh')?.toString()).toEqual('10');
+      expect(storage['keyMap'].get('sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo')?.toString()).toEqual('100');
+      expect(storage['keyMap'].get('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV')?.toString()).toEqual('17');
+
+      const newKeySet = [
+        'p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi',
+        'p2pk6842BMz2Se9XuMxQDe7yVdaEvpjNGQ7DYjKTQwzMUtryaHmZcV9',
+        'sppk7cudBXaXQUvbxb3f7tpKVSm6yKaYmjzqnPqvK6MrxFnnyxDEiim',
+        'p2pk66DZ3igTFpyqeezoqvFycrD5dHpJC6idPL4CWLCU1qT3Fu9j15V',
+        'sppk7ZWnHCVLsPE4CDFUTH424Qj2gUiJ3sp581nvexfz21w8gPjRVce'
+      ] 
+      const setOp = await contract.methods['setSet'](newKeySet).send();
+      await setOp.confirmation();
+      storage = await contract.storage<Storage>();
+      expect([...storage['keySet']].sort()).toEqual([...newKeySet].sort());
+
+      const newKeyMap = MichelsonMap.fromLiteral({
+        'p2pk66EcJmNvMMCauhfptZ5ffFXutNMytfxhcM7TkFMVLkySbgZ2dU9': 200,
+        'p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi': 201,
+      }) as MichelsonMap<string, number>;
+      const mapOp = await contract.methods['setMap'](newKeyMap).send();
+      await mapOp.confirmation();
+      storage = await contract.storage<Storage>();
+      expect(storage['keyMap'].get('p2pk66EcJmNvMMCauhfptZ5ffFXutNMytfxhcM7TkFMVLkySbgZ2dU9')?.toString()).toEqual('200');
+      expect(storage['keyMap'].get('p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi')?.toString()).toEqual('201');
+      expect(storage['keyMap'].get('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV')).toBeUndefined();
+
+      done();
+    });
+  });
+});

--- a/integration-tests/data/contract-with-key-collections.ts
+++ b/integration-tests/data/contract-with-key-collections.ts
@@ -1,0 +1,51 @@
+export const contractWithKeyCollections = [{
+  "prim": "parameter",
+  "args": [
+    {
+      "prim": "or",
+      "args": [
+        {
+          "prim": "map",
+          "args": [{ "prim": "key" }, { "prim": "int" }],
+          "annots": ["%setMap"]
+        },
+        {
+          "prim": "set", "args": [{ "prim": "key" }],
+          "annots": ["%setSet"]
+        }]
+    }
+  ]
+},
+{
+  "prim": "storage",
+  "args": [
+    {
+      "prim": "pair",
+      "args":
+        [{
+          "prim": "map",
+          "args": [{ "prim": "key" }, { "prim": "int" }],
+          "annots": ["%keyMap"]
+        },
+        {
+          "prim": "set", "args": [{ "prim": "key" }],
+          "annots": ["%keySet"]
+        }]
+    }
+  ]
+},
+{
+  "prim": "code",
+  "args": [
+    [{ "prim": "UNPAIR" },
+    {
+      "prim": "IF_LEFT",
+      "args":
+        [[{ "prim": "SWAP" }, { "prim": "CDR" }, { "prim": "SWAP" },
+        { "prim": "PAIR" }],
+        [{ "prim": "SWAP" }, { "prim": "CAR" }, { "prim": "PAIR" }]]
+    },
+    { "prim": "NIL", "args": [{ "prim": "operation" }] },
+    { "prim": "PAIR" }]
+  ]
+}]

--- a/packages/taquito-michelson-encoder/src/tokens/key.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/key.ts
@@ -1,5 +1,7 @@
 import { ComparableToken, TokenFactory, TokenValidationError } from './token';
-import { encodeKey, validatePublicKey, ValidationResult } from '@taquito/utils';
+import { encodeKey, validatePublicKey, ValidationResult, Prefix } from '@taquito/utils';
+
+const publicKeyPrefixLength = 4;
 
 export class KeyValidationError extends TokenValidationError {
   name: string = 'KeyValidationError';
@@ -68,5 +70,26 @@ export class KeyToken extends ComparableToken {
       key: { string: val },
       type: { prim: KeyToken.prim },
     };
+  }
+
+  compare(key1: string, key2: string): number {
+    const keyPrefix1 = this.getPrefix(key1);
+    const keyPrefix2 = this.getPrefix(key2);
+
+    if (keyPrefix1 === Prefix.EDPK && keyPrefix2 !== Prefix.EDPK) {
+      return -1;
+    }
+    else if (keyPrefix1 === Prefix.SPPK && keyPrefix2 !== Prefix.SPPK) {
+      return keyPrefix2 === Prefix.EDPK ? 1 : -1;
+    }
+    else if (keyPrefix1 === Prefix.P2PK && keyPrefix2 !== Prefix.P2PK) {
+      return 1;
+    }
+
+    return super.compare(key1, key2);
+  }
+
+  private getPrefix(val: string) {
+    return val.substring(0, publicKeyPrefixLength);
   }
 }

--- a/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
@@ -59,8 +59,12 @@ describe('Key token', () => {
     });
   });
 
- describe('compare', () => {
+  describe('compare', () => {
     it('Should compare key properly', () => {
+      // edpk... and edpk... -> Alphabetical comparison
+      // sppk... and sppk... -> Alphabetical comparison
+      // p2pk... and p2pk... -> Bytes comparison starting from the 5th byte: [3, 178, 139, 127, x, <start> b1, b2, ..., bn <end>]
+
       expect(token.compare("edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(-1);
       expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(0);
       expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh")).toEqual(1);
@@ -73,9 +77,11 @@ describe('Key token', () => {
       expect(token.compare("sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(1);
       expect(token.compare("sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(-1);
 
-      expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV")).toEqual(-1);
+      expect(token.compare("p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(-1);
       expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(0);
-      expect(token.compare("p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(1);
+      expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV")).toEqual(1);
+      expect(token.compare("p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi", "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV")).toEqual(-1);
+      expect(token.compare("p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV", "p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi")).toEqual(1);
       expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(1);
       expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj")).toEqual(1);
     });

--- a/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
@@ -44,9 +44,9 @@ describe('Key token', () => {
     });
   });
 
-  describe('Tokey', () => {
+  describe('ToKey', () => {
     it('Should transform Michelson bytes data to a key of type string', () => {
-      expect(token.ToKey({ "bytes": "00ebcf82872f4942052704e95dc4bfa0538503dbece27414a39b6650bcecbff896" })).toEqual('edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g');
+      expect(token.ToKey({ bytes: "00ebcf82872f4942052704e95dc4bfa0538503dbece27414a39b6650bcecbff896" })).toEqual('edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g');
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
@@ -59,10 +59,25 @@ describe('Key token', () => {
     });
   });
 
-  describe('compare', () => {
+ describe('compare', () => {
     it('Should compare key properly', () => {
-      expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh")).toEqual(1);
       expect(token.compare("edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(-1);
+      expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(0);
+      expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh")).toEqual(1);
+      expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj")).toEqual(-1);
+      expect(token.compare("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV")).toEqual(-1);
+
+      expect(token.compare("sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj", "sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo")).toEqual(-1);
+      expect(token.compare("sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj", "sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj")).toEqual(0);
+      expect(token.compare("sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo", "sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj")).toEqual(1);
+      expect(token.compare("sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(1);
+      expect(token.compare("sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(-1);
+
+      expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV")).toEqual(-1);
+      expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(0);
+      expect(token.compare("p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV", "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT")).toEqual(1);
+      expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g")).toEqual(1);
+      expect(token.compare("p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT", "sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj")).toEqual(1);
     });
   });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/map.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/map.spec.ts
@@ -285,14 +285,22 @@ describe('Map token', () => {
       ) as MapToken;
       const map = MichelsonMap.fromLiteral({
         "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g": 90,
+        "sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj": 45,
         "edpktm3zeGMzfzFuqgyYftt7uNyVRANTjrJCdU7bURwgGb9bRZwmJq": 30,
+        "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT": 99,
         "edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh": 1,
+        "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV": 60,
+        "p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi": 70,
       })
       const result = token.Encode([map]);
       expect(result).toEqual([
         { prim: 'Elt', args: [{ string: 'edpktm3zeGMzfzFuqgyYftt7uNyVRANTjrJCdU7bURwgGb9bRZwmJq' }, { int: '30' }] },
         { prim: 'Elt', args: [{ string: 'edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh' }, { int: '1' }] },
         { prim: 'Elt', args: [{ string: 'edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g' }, { int: '90' }] },
+        { prim: 'Elt', args: [{ string: 'sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj' }, { int: '45' }] },
+        { prim: 'Elt', args: [{ string: 'p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi' }, { int: '70' }] },
+        { prim: 'Elt', args: [{ string: 'p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV' }, { int: '60' }] },
+        { prim: 'Elt', args: [{ string: 'p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT' }, { int: '99' }] },
       ]);
     });
 
@@ -304,13 +312,21 @@ describe('Map token', () => {
       ) as MapToken;
       const map = new MichelsonMap();
       map.set("edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g", 30);
+      map.set('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV', 23);
       map.set("edpktm3zeGMzfzFuqgyYftt7uNyVRANTjrJCdU7bURwgGb9bRZwmJq", 1);
       map.set('edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh', 2);
+      map.set('sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj', 17);
+      map.set('p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT', 17);
+      map.set('p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi', 90);
       const result = token.Encode([map]);
       expect(result).toEqual([
         { prim: 'Elt', args: [{ string: 'edpktm3zeGMzfzFuqgyYftt7uNyVRANTjrJCdU7bURwgGb9bRZwmJq' }, { int: '1' }] },
         { prim: 'Elt', args: [{ string: 'edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh' }, { int: '2' }] },
         { prim: 'Elt', args: [{ string: 'edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g' }, { int: '30' }] },
+        { prim: 'Elt', args: [{ string: 'sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj' }, { int: '17' }] },
+        { prim: 'Elt', args: [{ string: 'p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi' }, { int: '90' }] },
+        { prim: 'Elt', args: [{ string: 'p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV' }, { int: '23' }] },
+        { prim: 'Elt', args: [{ string: 'p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT' }, { int: '17' }] },
       ]);
     })
 


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [x] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet
Fixed key sorting in literal sets and maps when these collections have mixed key types.

## Details
Before this fix, we couldn't send key sets containing multiple key types (Ed25519, Secp256k1, P256) to RPC, e.g.
```json
[
   "edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g",
   "sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo",
   "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT"
]
```
If we try to use this set we'll get an error `michelson_v1.unordered_set_literal`, as the michelson encoder sorts the set using the default compare method, method of the `ComparableToken` class. In other words, the encoder sorts the set using alphabetic sorting.
Unfortunately, I've found no description of the expected behavior in docs for this case, but the [current implementation says](https://gitlab.com/tezos/tezos/-/blob/master/src/lib_crypto/signature.ml#L268-277):
1. Ed25519 keys should go first, then Secp256k1 keys, and P256 keys finally.
2. if two keys are the same type:
    * if the type is Ed25519  -> compare keys using the alphabetical comparison;
    * is Secp256k1 ->  compare keys using the alphabetical comparison;
    * is P256  -> ~~alphabetical comparison~~ use the custom comparison, I wrote details below;

### Comparison algorithm of P256 keys
If we try to use the following set as literal:
```
[
   "p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV",
   "p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi",
   "p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT"
]
```
We also get the error, `michelson_v1.unordered_set_literal`. The P256 keys use the custom comparison that I haven't found an implementation of. I suppose the implementation is [located somewhere here](https://gitlab.com/tezos/tezos/-/blob/master/src/lib_crypto/p256.ml), but I don't know OCaml :) 
After several tests I guess the algorithm probably is the following:
1. Decode keys from b58;
2. Compare receiving bytes ignoring the first byte;
Maybe I'm wrong, but I've tried to test on different keys, and I couldn't reproduce the error.

<details>
  <summary>Source Code of the test contract (ReasonLIGO)</summary>

```reason
type storage = {
    keySet: set(key),
    keyMap: map(key, int)
};

type parameter =
    | SetSet (set(key))
    | SetMap (map(key, int));

type main_result = (list (operation), storage);
   
let main = ((action, storage) : (parameter, storage)) : main_result => (
 ([]: list(operation)),
 switch (action) { 
  | SetSet(new_set) => { ...storage, keySet: new_set }; 
  | SetMap(new_map) => { ...storage, keyMap: new_map }; 
 }
)
```
</details>