### PR TITLE
fix-test-contract-empty-implicit-account-into-a-new-implicit-account.spec.ts

### DIFF
--- a/packages/taquito/src/contract/estimate.ts
+++ b/packages/taquito/src/contract/estimate.ts
@@ -52,7 +52,7 @@ export class Estimate {
   constructor(
     private readonly _milligasLimit: number | string,
     private readonly _storageLimit: number | string,
-    private readonly opSize: number | string,
+    public readonly opSize: number | string,
     private readonly minimalFeePerStorageByteMutez: number | string,
     /**
      * @description Base fee in mutez (1 mutez = 1e10−6 tez)


### PR DESCRIPTION
This is a temporary fix. The consumed_gas returned by the RPC 
`helpers/scripts/run_operation` seems too low in this particular case. Thus the `gasLimit` and the `fee` returned by the estimate are too low. See https://gitlab.com/tezos/tezos/-/issues/1754


Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
