### PR TITLE
perf(EstimateProvider) combine 2 calls to rpc.getConstants into 1

### DIFF
--- a/packages/taquito/src/parser/michel-codec-parser.ts
+++ b/packages/taquito/src/parser/michel-codec-parser.ts
@@ -1,16 +1,15 @@
 import { Context } from '../context';
 import { ParserProvider } from './interface';
-import { Expr, Parser, Prim } from '@taquito/michel-codec';
-import { Protocols } from '../constants';
+import { Expr, Parser, Prim, ProtocolID } from '@taquito/michel-codec';
 import { OriginateParams } from '../operations/types';
 import { InvalidInitParameter, InvalidCodeParameter } from '../contract/errors';
 
 export class MichelCodecParser implements ParserProvider {
     constructor(private context: Context) { }
 
-    private async getNextProto() {
+    private async getNextProto(): Promise<ProtocolID> {
         const { next_protocol } = await this.context.rpc.getBlockMetadata();
-        return next_protocol as Protocols;
+        return next_protocol as ProtocolID;
     }
 
     async parseScript(src: string): Promise<Expr[] | null> {


### PR DESCRIPTION
Small optimization.
There were two distinct calls to the RPC constants endpoint in the `RPCEstimateProvider` class: one in the `getAccountLimits` method and the other in the `prepareEstimate` method.
They have been combined into one call.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
