### PR TITLE
Allow to set HttpBackend on IpfsHttpHandler (#1092)

### DIFF
--- a/packages/taquito-tzip16/src/handlers/ipfs-handler.ts
+++ b/packages/taquito-tzip16/src/handlers/ipfs-handler.ts
@@ -4,14 +4,14 @@ import { Handler, Tzip16Uri } from "../metadata-provider";
 
 export class IpfsHttpHandler implements Handler {
     private _ipfsGateway: string;
-    private _httpBackend = new HttpBackend();
+    public httpBackend = new HttpBackend();
 
     constructor(ipfsGatheway?:string){
         this._ipfsGateway = ipfsGatheway? ipfsGatheway: 'ipfs.io';
     }
 
     async getMetadata(_contractAbstraction: ContractAbstraction<ContractProvider | Wallet>, { location }: Tzip16Uri, _context: Context): Promise<string> {
-        return this._httpBackend.createRequest<string>({
+        return this.httpBackend.createRequest<string>({
             url: `https://${this._ipfsGateway}/ipfs/${location.substring(2)}/`,
             method: 'GET',
             headers: {'Content-Type': 'text/plain'},

--- a/packages/taquito-tzip16/test/handlers/ipfs-handler.spec.ts
+++ b/packages/taquito-tzip16/test/handlers/ipfs-handler.spec.ts
@@ -6,15 +6,15 @@ describe('Tzip16 http handler test', () => {
     };
     let mockContractAbstraction: any = {};
     let mockContext: any = {};
-    
+
     const ipfsHandler = new IpfsHttpHandler();
 
 	beforeEach(() => {
 		mockHttpBackend = {
             createRequest: jest.fn()
         };
-        
-        ipfsHandler['_httpBackend'] = mockHttpBackend as any;
+
+        ipfsHandler['httpBackend'] = mockHttpBackend as any;
     })
 
 	it('Should return a string representing the metadata fetched by the httpBackend', async (done) => {
@@ -25,7 +25,7 @@ describe('Tzip16 http handler test', () => {
             location: '//QmcMUKkhXowQjCPtDVVXyFJd7W9LmC92Gs5kYH1KjEisdjn'
         }
         const metadata = await ipfsHandler.getMetadata(mockContractAbstraction, tzip16Uri, mockContext)
-		
+
 		expect(metadata).toEqual(`{ "name": "Taquito test" }`);
 		done();
 	});


### PR DESCRIPTION
Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet
`httpBackend` of IpfsHttpHandler has been updated to be a public field.


## Related Issue
https://github.com/ecadlabs/taquito/issues/1092
