### PR TITLE
@taquito/http-utils: replace xhr2-cookies with neo-xhr

### DIFF
--- a/packages/taquito-http-utils/package-lock.json
+++ b/packages/taquito-http-utils/package-lock.json
@@ -5444,6 +5444,14 @@
 			"integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
 			"dev": true
 		},
+		"neo-xhr": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/neo-xhr/-/neo-xhr-1.1.1.tgz",
+			"integrity": "sha512-JjZlLG5khwCVPsqBoPY5HiVHL6UBp2wYtNzghDS/JiyRNQGn3Qh8E1u8uFpgUJhgZLdjBEEuE4hyufWB4XBZqQ==",
+			"requires": {
+				"cookiejar": "^2.1.1"
+			}
+		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -7605,14 +7613,6 @@
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
 			"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
 			"dev": true
-		},
-		"xhr2-cookies": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
-			"integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
-			"requires": {
-				"cookiejar": "^2.1.1"
-			}
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/packages/taquito-http-utils/package.json
+++ b/packages/taquito-http-utils/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "dependencies": {
-    "xhr2-cookies": "^1.1.0"
+    "neo-xhr": "^1.1.1"
   },
   "devDependencies": {
     "@types/jest": "^26.0.23",

--- a/packages/taquito-http-utils/signature.json
+++ b/packages/taquito-http-utils/signature.json
@@ -143,7 +143,7 @@
             ]
           },
           "dependencies": {
-            "xhr2-cookies": "^1.1.0"
+            "neo-xhr": "^1.1.1"
           },
           "devDependencies": {
             "@types/jest": "^26.0.16",

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -10,7 +10,7 @@ const isNode =
   typeof process !== 'undefined' && process.versions != null && process.versions.node != null;
 // tslint:enable: strict-type-predicates
 
-const XMLHttpRequestCTOR = isNode ? require('xhr2-cookies').XMLHttpRequest : XMLHttpRequest;
+const XMLHttpRequestCTOR = isNode ? require('neo-xhr').XMLHttpRequest : XMLHttpRequest;
 
 export * from './status_code';
 export { VERSION } from './version';


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [x] You have added integration tests (if relevant/appropriate)
- [x] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [x] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

[neo-xhr](https://github.com/fraidev/neo-xhr) is a fork of [xhr2-cookies](https://github.com/souldreamer/xhr2-cookies) without deprecated uses of `new Buffer`.

## Related Issue

https://github.com/ecadlabs/taquito/issues/1113
