### PR TITLE
Refactor(michel-codec) use newest protocol behaviour by default

### DIFF
--- a/packages/taquito-michel-codec/src/macros.ts
+++ b/packages/taquito-michel-codec/src/macros.ts
@@ -1,5 +1,5 @@
 import { Prim, Expr, IntLiteral } from "./micheline";
-import { DefaultProtocol, Protocol, ProtocolOptions, ProtoGreaterOfEqual } from "./michelson-types";
+import { DefaultProtocol, Protocol, ProtocolOptions, ProtoInferiorTo } from "./michelson-types";
 import { Tuple, NoArgs, ReqArgs, NoAnnots } from "./utils";
 
 export class MacroError extends Error {
@@ -383,7 +383,25 @@ export function expandMacros(ex: Prim, opt?: ProtocolOptions): Expr {
 
     // UNPAPPAIIR macro
     if (unpairRe.test(ex.prim)) {
-        if (ProtoGreaterOfEqual(proto,  Protocol.PtEdo2Zk)) {
+        if (ProtoInferiorTo(proto,  Protocol.PtEdo2Zk) && assertArgs(ex, 0)) {
+            const { r } = parsePairUnpairExpr(ex, ex.prim.slice(3), ex.annots || [], (l, r, top) => [top, ...(r || []), ...(l || [])]);
+            return r.map(([v, a]) => {
+                const leaf: Prim[] = [
+                    { prim: "DUP" },
+                    mkPrim({ prim: "CAR", annots: a[0] !== null ? [a[0]] : undefined }),
+                    {
+                        prim: "DIP",
+                        args: [[mkPrim({ prim: "CDR", annots: a[1] !== null ? [a[1]] : undefined })]],
+                    }
+                ];
+
+                return v === 0 ? leaf : {
+                    prim: "DIP",
+                    args: v === 1 ? [[leaf]] : [{ int: String(v) }, [leaf]],
+                };
+            });
+        }
+        else {
             if (ex.prim === "UNPAIR") {
                 return ex;
             }
@@ -401,23 +419,6 @@ export function expandMacros(ex: Prim, opt?: ProtocolOptions): Expr {
                     };
                 });
             }
-        } else if (assertArgs(ex, 0)) {
-            const { r } = parsePairUnpairExpr(ex, ex.prim.slice(3), ex.annots || [], (l, r, top) => [top, ...(r || []), ...(l || [])]);
-            return r.map(([v, a]) => {
-                const leaf: Prim[] = [
-                    { prim: "DUP" },
-                    mkPrim({ prim: "CAR", annots: a[0] !== null ? [a[0]] : undefined }),
-                    {
-                        prim: "DIP",
-                        args: [[mkPrim({ prim: "CDR", annots: a[1] !== null ? [a[1]] : undefined })]],
-                    }
-                ];
-
-                return v === 0 ? leaf : {
-                    prim: "DIP",
-                    args: v === 1 ? [[leaf]] : [{ int: String(v) }, [leaf]],
-                };
-            });
         }
     }
 
@@ -530,14 +531,7 @@ export function expandMacros(ex: Prim, opt?: ProtocolOptions): Expr {
     if (duupRe.test(ex.prim)) {
         let n = 0;
         while (ex.prim[1 + n] === "U") { n++; }
-        if (ProtoGreaterOfEqual(proto,  Protocol.PtEdo2Zk)) {
-            if (n === 1) {
-                return ex;
-            }
-            if (assertArgs(ex, 0)) {
-                return mkPrim({ prim: "DUP", args: [{ int: String(n) }], annots: ex.annots });
-            }
-        } else {
+        if (ProtoInferiorTo(proto, Protocol.PtEdo2Zk)){
             if (n === 1) {
                 if (ex.args === undefined) {
                     return ex; // skip
@@ -575,6 +569,14 @@ export function expandMacros(ex: Prim, opt?: ProtocolOptions): Expr {
                         args: [{ int: String(n) }],
                     },
                 ];
+            }
+        }
+        else {
+            if (n === 1) {
+                return ex;
+            }
+            if (assertArgs(ex, 0)) {
+                return mkPrim({ prim: "DUP", args: [{ int: String(n) }], annots: ex.annots });
             }
         }
     }

--- a/packages/taquito-michel-codec/src/michelson-typecheck.ts
+++ b/packages/taquito-michel-codec/src/michelson-typecheck.ts
@@ -8,7 +8,8 @@ import {
     refContract,
     MichelsonTypeAddress,
     ProtoGreaterOfEqual,
-    MichelsonContractView
+    MichelsonContractView,
+    ProtoInferiorTo
 } from "./michelson-types";
 import {
     unpackAnnotations, MichelsonError, isNatural,
@@ -959,7 +960,7 @@ function functionTypeInternal(inst: MichelsonCode, stack: MichelsonType[], ctx: 
         case "FAILWITH":
         {
             const s = args(0, null)[0];
-            if (ProtoGreaterOfEqual(proto, Protocol.PtEdo2Zk)) {
+            if(!ProtoInferiorTo(proto, Protocol.PtEdo2Zk)){
                 ensurePackableType(s);
             }
             return { failed: s };

--- a/packages/taquito-michel-codec/src/michelson-types.ts
+++ b/packages/taquito-michel-codec/src/michelson-types.ts
@@ -237,6 +237,10 @@ export function ProtoGreaterOfEqual(a: ProtocolID, b: ProtocolID): boolean {
     return protoLevel[a] >= protoLevel[b];
 }
 
+export function ProtoInferiorTo(a: ProtocolID, b: ProtocolID): boolean {
+    return protoLevel[a] < protoLevel[b];
+}
+
 export interface ProtocolOptions {
     protocol?: ProtocolID;
 }

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -725,6 +725,7 @@ describe('RpcContractProvider test', () => {
 
   describe('originate', () => {
     it('should produce a reveal and origination operation', async (done) => {
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo' });
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       const result = await rpcContractProvider.originate({
         delegate: 'test_delegate',
@@ -757,7 +758,7 @@ describe('RpcContractProvider test', () => {
               storage_limit: '257',
             },
           ],
-          protocol: 'test_proto',
+          protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo',
           signature: 'test_sig',
         },
         opbytes: 'test',
@@ -766,6 +767,7 @@ describe('RpcContractProvider test', () => {
     });
 
     it('should not convert balance to mutez when mutez flag is set to true', async (done) => {
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo' });
       const result = await rpcContractProvider.originate({
         delegate: 'test_delegate',
         balance: '200',
@@ -798,7 +800,7 @@ describe('RpcContractProvider test', () => {
               storage_limit: '257',
             },
           ],
-          protocol: 'test_proto',
+          protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo',
           signature: 'test_sig',
         },
         opbytes: 'test',
@@ -807,6 +809,7 @@ describe('RpcContractProvider test', () => {
     });
 
     it('estimate when no fees are specified', async (done) => {
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo' });
       const estimate = new Estimate(1000, 1000, 180, 1000);
       mockEstimate.originate.mockResolvedValue(estimate);
 
@@ -838,7 +841,7 @@ describe('RpcContractProvider test', () => {
               storage_limit: estimate.storageLimit.toString(),
             },
           ],
-          protocol: 'test_proto',
+          protocol: 'PsDELPH1Kxsxt8f9eWbxQeRxkjfbxoqM52jvs5Y5fBxWWh4ifpo',
           signature: 'test_sig',
         },
         opbytes: 'test',


### PR DESCRIPTION
I changed the logic of the if/else statements where we act differently according to the protocol hash.

The behavior regarding macro expansion is different since the Edo protocol. There were checks in the codebase (using ProtoGreaterOfEqual) to see if the protocol used was higher than Edo and if so to apply the "Edo Since" behavior. However, if a user was using Taquito with a new protocol that is not yet supported (not part of the Protocol enum), the default behavior to expand macro was the "before Edo". I made a change so the  "Edo Since" behavior is used by default unless the protocol used is inferior to Edo (which is less likely).
