### PR TITLE
Use dedicated endpoint to reach Tezos mainnet archive nodes

### DIFF
--- a/integration-tests/rpc-get-protocol-constants.spec.ts
+++ b/integration-tests/rpc-get-protocol-constants.spec.ts
@@ -12,7 +12,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
 
     describe('Fetch constants for all protocols on Mainnet', () => {
 
-        const rpcUrl = 'https://mainnet.api.tez.ie/';
+        const rpcUrl = 'https://mainnet-archive.api.tez.ie/';
         Tezos.setRpcProvider(rpcUrl)
         it('succesfully fails at fetching constants for level 0', async (done) => {
             try {


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] ~~Your code builds cleanly without any errors or warnings~~ N/A
- [ ] ~~You have added unit tests~~ N/A
- [ ] ~~You have added integration tests (if relevant/appropriate)~~ N/A
- [ ] ~~All public methods or types have TypeDoc coverage with a complete description, and ideally an @example~~ N/A
- [ ] ~~You have added or updated corresponding documentation~~ N/A
- [ ] ~~If relevant, you have written a first draft summary describing the change for inclusion in Release Notes.~~ N/A

## Release Note Draft Snippet

Closes #1216

Update `rpcUrl` constant to point to the dedicated Tezos `archive` node endpoint  `https://mainnet-archive.api.tez.ie`
