### PR TITLE
fix(contractabstraction): Getting ContractAbstraction for large contracts takes too much resources (memory, time)

### DIFF
--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -24,34 +24,33 @@ export class ContractView {
     private callbackParametersSchema: ParameterSchema,
     private parameterSchema: ParameterSchema,
     private args: any[]
-  ) { }
+  ) {}
 
   /**
    *
-   * @description Find which lambda contract to use based on the current network, 
-   * encode parameters to Michelson, 
+   * @description Find which lambda contract to use based on the current network,
+   * encode parameters to Michelson,
    * create an instance of Lambdaview to retrive data, and
-   * Decode Michelson response 
+   * Decode Michelson response
    *
    * @param Options Address of a lambda contract (sandbox users)
    */
   async read(customLambdaAddress?: string) {
-
     let lambdaAddress;
 
-    // TODO Verify if the 'customLambdaAdress' is a valid originated contract and if not, return an appropriate error message. 
+    // TODO Verify if the 'customLambdaAdress' is a valid originated contract and if not, return an appropriate error message.
     if (customLambdaAddress) {
-      lambdaAddress = customLambdaAddress
+      lambdaAddress = customLambdaAddress;
     } else if (this.chainId === ChainIds.GRANADANET) {
-      lambdaAddress = DefaultLambdaAddresses.GRANADANET
+      lambdaAddress = DefaultLambdaAddresses.GRANADANET;
     } else if (this.chainId === ChainIds.HANGZHOUNET) {
-      lambdaAddress = DefaultLambdaAddresses.HANGZHOUNET
+      lambdaAddress = DefaultLambdaAddresses.HANGZHOUNET;
     } else if (this.chainId === ChainIds.ITHACANET) {
-      lambdaAddress = DefaultLambdaAddresses.ITHACANET
+      lambdaAddress = DefaultLambdaAddresses.ITHACANET;
     } else if (this.chainId === ChainIds.MAINNET) {
-      lambdaAddress = DefaultLambdaAddresses.MAINNET
+      lambdaAddress = DefaultLambdaAddresses.MAINNET;
     } else {
-      throw new UndefinedLambdaContractError()
+      throw new UndefinedLambdaContractError();
     }
 
     const lambdaContract = await this.provider.at(lambdaAddress);
@@ -61,7 +60,6 @@ export class ContractView {
     const response = this.callbackParametersSchema.Execute(failedWith);
     return response;
   }
-
 }
 
 const validateArgs = (args: any[], schema: ParameterSchema, name: string) => {
@@ -73,11 +71,15 @@ const validateArgs = (args: any[], schema: ParameterSchema, name: string) => {
 };
 
 // lambda view tzip4
-const isView = (schema: ParameterSchema): boolean => {
+const isView = (parameterSchema: ParameterSchema): boolean => {
   let isView = false;
-  const sigs = schema.ExtractSignatures();
-  if ((sigs[0][sigs[0].length - 1] === 'contract')) {
-    isView = true;
+  const schema = parameterSchema.ExtractSchema();
+  if (typeof schema === 'object' && schema !== null) {
+    const keysSchema = Object.keys(schema);
+    const lastKey = schema[keysSchema[keysSchema.length - 1]];
+    if (lastKey === 'contract') {
+      isView = true;
+    }
   }
   return isView;
 };
@@ -140,7 +142,7 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
     if (this.viewSchema.length !== 0) {
       this._initializeOnChainViews(this, rpc, this.viewSchema);
     }
-    this._initializeMethods(this, provider, this.entrypoints.entrypoints, this.chainId);  
+    this._initializeMethods(this, provider, this.entrypoints.entrypoints, this.chainId);
   }
 
   private _initializeMethods(
@@ -154,10 +156,8 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
     const parameterSchema = this.parameterSchema;
     const keys = Object.keys(entrypoints);
     if (parameterSchema.isMultipleEntryPoint) {
-      keys.forEach(smartContractMethodName => {
-        const smartContractMethodSchema = new ParameterSchema(
-          entrypoints[smartContractMethodName]
-        );
+      keys.forEach((smartContractMethodName) => {
+        const smartContractMethodSchema = new ParameterSchema(entrypoints[smartContractMethodName]);
 
         this.methods[smartContractMethodName] = function (...args: any[]) {
           return currentContract.contractMethodFactory.createContractMethodFlatParams(
@@ -178,14 +178,14 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
         if (isContractProvider(provider)) {
           if (isView(smartContractMethodSchema)) {
             const view = function (...args: any[]) {
-              const entrypointParamWithoutCallback = (entrypoints[smartContractMethodName] as any).args[0];
+              const entrypointParamWithoutCallback = (entrypoints[smartContractMethodName] as any)
+                .args[0];
               const smartContractMethodSchemaWithoutCallback = new ParameterSchema(
                 entrypointParamWithoutCallback
               );
-              const parametersCallback = (entrypoints[smartContractMethodName] as any).args[1].args[0];
-              const smartContractMethodCallbackSchema = new ParameterSchema(
-                parametersCallback
-              );
+              const parametersCallback = (entrypoints[smartContractMethodName] as any).args[1]
+                .args[0];
+              const smartContractMethodCallbackSchema = new ParameterSchema(parametersCallback);
 
               validateArgs(args, smartContractMethodSchemaWithoutCallback, smartContractMethodName);
               return new ContractView(
@@ -201,16 +201,15 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
             this.views[smartContractMethodName] = view;
           }
         }
-
       });
 
       // Deal with methods with no annotations which were not discovered by the RPC endpoint
       // Methods with no annotations are discovered using parameter schema
       const anonymousMethods = Object.keys(parameterSchema.ExtractSchema()).filter(
-        key => Object.keys(entrypoints).indexOf(key) === -1
+        (key) => Object.keys(entrypoints).indexOf(key) === -1
       );
 
-      anonymousMethods.forEach(smartContractMethodName => {
+      anonymousMethods.forEach((smartContractMethodName) => {
         this.methods[smartContractMethodName] = function (...args: any[]) {
           return currentContract.contractMethodFactory.createContractMethodFlatParams(
             parameterSchema,
@@ -253,7 +252,11 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
     }
   }
 
-  private _initializeOnChainViews(currentContract: ContractAbstraction<T>, rpc: RpcClientInterface, allContractViews: ViewSchema[]){
+  private _initializeOnChainViews(
+    currentContract: ContractAbstraction<T>,
+    rpc: RpcClientInterface,
+    allContractViews: ViewSchema[]
+  ) {
     const storageType = this.schema.val;
     const storageValue = this.script.storage;
 
@@ -267,7 +270,7 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
           args
         );
       };
-    })
+    });
   }
 
   /**

--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -1,5 +1,10 @@
 import { ParameterSchema, Schema, ViewSchema } from '@taquito/michelson-encoder';
-import { EntrypointsResponse, RpcClientInterface, ScriptResponse } from '@taquito/rpc';
+import {
+  EntrypointsResponse,
+  MichelsonV1Expression,
+  RpcClientInterface,
+  ScriptResponse,
+} from '@taquito/rpc';
 import { ChainIds, DefaultLambdaAddresses } from '../constants';
 import { Wallet } from '../wallet';
 import { ContractMethodFactory } from './contract-methods/contract-method-factory';
@@ -71,13 +76,11 @@ const validateArgs = (args: any[], schema: ParameterSchema, name: string) => {
 };
 
 // lambda view tzip4
-const isView = (parameterSchema: ParameterSchema): boolean => {
+const isView = (entrypoint: MichelsonV1Expression): boolean => {
   let isView = false;
-  const schema = parameterSchema.ExtractSchema();
-  if (typeof schema === 'object' && schema !== null) {
-    const keysSchema = Object.keys(schema);
-    const lastKey = schema[keysSchema[keysSchema.length - 1]];
-    if (lastKey === 'contract') {
+  if ('prim' in entrypoint && entrypoint.prim === 'pair' && entrypoint.args) {
+    const lastElement = entrypoint.args[entrypoint.args.length - 1];
+    if ('prim' in lastElement && lastElement.prim === 'contract') {
       isView = true;
     }
   }
@@ -176,7 +179,7 @@ export class ContractAbstraction<T extends ContractProvider | Wallet> {
         };
 
         if (isContractProvider(provider)) {
-          if (isView(smartContractMethodSchema)) {
+          if (isView(entrypoints[smartContractMethodName])) {
             const view = function (...args: any[]) {
               const entrypointParamWithoutCallback = (entrypoints[smartContractMethodName] as any)
                 .args[0];

--- a/packages/taquito/test/contract/contractView.spec.ts
+++ b/packages/taquito/test/contract/contractView.spec.ts
@@ -79,17 +79,17 @@ describe('ContractView test', () => {
     mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
   });
 
-  it('should return contract views', async (done) => {
+  it('should create instances of ContractView for the entry points that match the tzip4 view signature', async (done) => {
+    // The tzip4 view signature is a pair where its second arguments is a contract.
     mockRpcClient.getEntrypoints.mockResolvedValue({
       entrypoints: {
         transfer: {
           prim: 'pair',
           args: [
-            { prim: 'pair', args: [{ prim: 'address' }, { prim: 'address' }] },
+            { prim: 'pair', args: [{ prim: 'address', annots: ['test'] }, { prim: 'address' }] },
             { prim: 'nat' },
           ],
         },
-        mint: { prim: 'nat' },
         getTotalSupply: {
           prim: 'pair',
           args: [{ prim: 'unit' }, { prim: 'contract', args: [{ prim: 'nat' }] }],
@@ -105,11 +105,12 @@ describe('ContractView test', () => {
             { prim: 'contract', args: [{ prim: 'nat' }] },
           ],
         },
-        approve: { prim: 'pair', args: [{ prim: 'address' }, { prim: 'nat' }] },
       },
     });
 
     const result = await rpcContractProvider.at('test');
+
+    expect(() => result.views.transfer()).toThrow(); // Entry point transfer is not a view
     expect(result.views.getTotalSupply([['Unit']])).toBeInstanceOf(ContractView);
     expect(result.views.getBalance('tz1c1X8vD4pKV9TgV1cyosR7qdnkc8FTEyM1')).toBeInstanceOf(
       ContractView
@@ -127,69 +128,6 @@ describe('ContractView test', () => {
         'test'
       )
     ).toThrowError(InvalidParameterError);
-    done();
-  });
-
-  it('should return contract views', async (done) => {
-    mockRpcClient.getEntrypoints.mockResolvedValue({
-      entrypoints: {
-        transfer: {
-          prim: 'pair',
-          args: [
-            { prim: 'pair', args: [{ prim: 'address' }, { prim: 'address' }] },
-            { prim: 'nat' },
-          ],
-        },
-        mint: { prim: 'nat' },
-        getTotalSupply: {
-          prim: 'pair',
-          args: [{ prim: 'unit' }, { prim: 'contract', args: [{ prim: 'nat' }] }],
-        },
-        getBalance: {
-          prim: 'pair',
-          args: [
-            { prim: 'address', annots: [':owner', '%viewParam'] },
-            {
-              prim: 'contract',
-              args: [{ prim: 'nat' }],
-              annots: ['%viewCallbackTo'],
-            },
-          ],
-        },
-        getAllowance: {
-          prim: 'pair',
-          args: [
-            {
-              prim: 'pair',
-              args: [
-                { prim: 'address', annots: [':owner'] },
-                { prim: 'address', annots: [':spender'] },
-              ],
-              annots: ['%viewParam'],
-            },
-            {
-              prim: 'contract',
-              args: [{ prim: 'nat' }],
-              annots: ['%viewCallbackTo'],
-            },
-          ],
-          annots: ['%getAllowance'],
-        },
-        approve: { prim: 'pair', args: [{ prim: 'address' }, { prim: 'nat' }] },
-      },
-    });
-
-    const result = await rpcContractProvider.at('test');
-
-    expect(result.views.getBalance('tz1c1X8vD4pKV9TgV1cyosR7qdnkc8FTEyM1')).toBeInstanceOf(
-      ContractView
-    );
-    expect(
-      result.views.getAllowance(
-        'tz1c1X8vD4pKV9TgV1cyosR7qdnkc8FTEyM1',
-        'tz1Nu949TjA4zzJ1iobz76fHPZbWUraRVrCE'
-      )
-    ).toBeInstanceOf(ContractView);
     done();
   });
 });


### PR DESCRIPTION
Use ExtractSchema instead of ExtractSignature in the ContactAbstraction to determine if an entry
point is a lambda view. For some particular contracts having nested pair and option types,
ExtractSignature leads to memory issues by generating all possible signatures.

fix #1270

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
