### PR TITLE
fix(ithacanet): block needs to be HEAD~2

### DIFF
--- a/integration-tests/contract-estimation-tests.spec.ts
+++ b/integration-tests/contract-estimation-tests.spec.ts
@@ -181,7 +181,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol,rpc }) => {
       expect(estimate.minimalFeeMutez).toEqual(688);
       expect(estimate.totalCost).toEqual(688);
       expect(estimate.usingBaseFeeMutez).toEqual(688);
-      expect(estimate.consumedMilligas).toEqual(3513873);
+      expect(estimate.consumedMilligas).toEqual(3513987);
       done();
     })
 
@@ -217,7 +217,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol,rpc }) => {
       expect(estimate.minimalFeeMutez).toEqual(890);
       expect(estimate.totalCost).toEqual(129390);
       expect(estimate.usingBaseFeeMutez).toEqual(890);
-      expect(estimate.consumedMilligas).toEqual(4942374);
+      expect(estimate.consumedMilligas).toEqual(4942488);
       done();
     })
 
@@ -245,7 +245,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol,rpc }) => {
       expect(estimate.minimalFeeMutez).toEqual(693);
       expect(estimate.totalCost).toEqual(79943);
       expect(estimate.usingBaseFeeMutez).toEqual(693);
-      expect(estimate.consumedMilligas).toEqual(3507270);
+      expect(estimate.consumedMilligas).toEqual(3507384);
       done();
     })
 
@@ -276,7 +276,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol,rpc }) => {
       expect(estimate.minimalFeeMutez).toEqual(900);
       expect(estimate.totalCost).toEqual(159400);
       expect(estimate.usingBaseFeeMutez).toEqual(900);
-      expect(estimate.consumedMilligas).toEqual(4929168);
+      expect(estimate.consumedMilligas).toEqual(4929282);
       // Do the actual operation
       const op2 = await contract.methods.do(originate2()).send();
       await op2.confirmation();

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -17,7 +17,7 @@ import {
   PrepareOperationParams,
   RPCOperation,
   RPCOpWithFee,
-  RPCOpWithSource
+  RPCOpWithSource,
 } from './types';
 
 export interface PreparedOperation {
@@ -41,13 +41,15 @@ export abstract class OperationEmitter {
   constructor(protected context: Context) {}
 
   protected async isRevealOpNeeded(op: RPCOperation[] | ParamsWithKind[], pkh: string) {
-    return (!await this.isAccountRevealRequired(pkh) || !this.isRevealRequiredForOpType(op)) ? false : true;
+    return !(await this.isAccountRevealRequired(pkh)) || !this.isRevealRequiredForOpType(op)
+      ? false
+      : true;
   }
 
   protected async isAccountRevealRequired(publicKeyHash: string) {
     const manager = await this.rpc.getManagerKey(publicKeyHash);
-      const haveManager = manager && typeof manager === 'object' ? !!manager.key : !!manager;
-      return !haveManager;
+    const haveManager = manager && typeof manager === 'object' ? !!manager.key : !!manager;
+    return !haveManager;
   }
 
   protected isRevealRequiredForOpType(op: RPCOperation[] | ParamsWithKind[]) {
@@ -58,7 +60,7 @@ export abstract class OperationEmitter {
       }
     }
     return opRequireReveal;
-  };
+  }
 
   // Originally from sotez (Copyright (c) 2018 Andrew Kishino)
   protected async prepareOperation({
@@ -70,7 +72,7 @@ export abstract class OperationEmitter {
     let ops: RPCOperation[] = [];
     let head: BlockHeaderResponse;
 
-    const blockHeaderPromise = this.rpc.getBlockHeader();
+    const blockHeaderPromise = this.rpc.getBlockHeader({ block: 'head~2' });
     const blockMetaPromise = this.rpc.getBlockMetadata();
 
     if (Array.isArray(operation)) {
@@ -94,7 +96,7 @@ export abstract class OperationEmitter {
     const [header, metadata, headCounter] = await Promise.all([
       blockHeaderPromise,
       blockMetaPromise,
-      counterPromise
+      counterPromise,
     ]);
 
     if (!header) {
@@ -176,7 +178,7 @@ export abstract class OperationEmitter {
               ...op,
               ...getSource(op),
               ...getFee(op),
-            }
+            };
           default:
             throw new Error('Unsupported operation');
         }


### PR DESCRIPTION
When preparing an operation the block was set to head. In the Ithaca protocol, the block needs to be
`HEAD~2`. Setting the branch field to `HEAD` or `HEAD~1` may result in the operation not being included
because it will not be anchored on a block belonging to the chain. (The blocks at the current and
previous levels are not necessary final.)

fix #1230

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
