### PR TITLE
Limit GH Action workflows concurrency

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -3,6 +3,11 @@ name: Algolia indexing
 on:
   schedule:
     - cron: '0 0 * * *'
+
+concurrency:
+  group: algolia-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   delete-current-algolia-index:
     env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 14 * * 1'
 
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyse:
     name: Analyse

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches:
       - master
+
+concurrency:
+  group: edge-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy-edge-package:
     runs-on: ecad-taquito

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - master
+
+concurrency:
+  group: deploy-website-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-website:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,9 +5,12 @@ on:
   push:
     branches:
       - master
+
+concurrency:
+  group: integration-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-
-
   lint-and-test:
     runs-on: ecad-taquito
     strategy:

--- a/.github/workflows/preview_website.yml
+++ b/.github/workflows/preview_website.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: preview-website-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 ## This job will deploy the netlify preview builds
   publish-website-preview:


### PR DESCRIPTION
Closes #1342 

# Description
When working on PR or when merging to `master` we should always make sure to run pipeline against the latest code.

Currently when we push new commits to a PR the new pipelines for the latest code are queued up and need to wait for previous pipelines to complete.

By limiting workflow concurrency old pipelines will be cancel automatically when a newer commit is pushed to a PR.

# Test Plan
Testing this changes to show that when new commits are pushed old pipelines are automatically cancelled.

![Peek 2022-01-21 14-03](https://user-images.githubusercontent.com/22307776/150606317-eec698f4-b475-4cd7-8990-1d4ef23bcc71.gif)
