### PR TITLE
Run Taquito integration tests from public GH runners

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -14,7 +14,7 @@ jobs:
       ALGOLIA_UPDATE_API_KEY: ${{secrets.ALGOLIA_UPDATE_API_KEY}}
       ALGOLIA_SEARCH_API_KEY: ${{secrets.ALGOLIA_SEARCH_API_KEY}}
       ALGOLIA_APPLICATION_ID: ${{secrets.ALGOLIA_APPLICATION_ID}}
-    runs-on: ecad-taquito
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   deploy-edge-package:
-    runs-on: ecad-taquito
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   lint-and-test:
-    runs-on: ecad-taquito
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [12.x]
@@ -44,7 +44,7 @@ jobs:
         RUN_INTEGRATION: true
 
   integration-tests-hangzhounet:
-    runs-on: ecad-taquito
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [12.x]
@@ -64,13 +64,17 @@ jobs:
     - run: npm run lerna -- bootstrap
     - run: npm run build
       if: steps.lerna-build-cache.outputs.cache-hit != 'true'
+    - name: Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
     - run: cd integration-tests && npm run test:hangzhounet -- --maxWorkers=8
       env:
         CI: true
         TEZOS_RPC_HANGZHOUNET: ${{ secrets.TEZOS_RPC_HANGZHOUNET }}
 
   integration-tests-ithacanet:
-    runs-on: ecad-taquito
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [12.x]
@@ -90,6 +94,10 @@ jobs:
     - run: npm run lerna -- bootstrap
     - run: npm run build
       if: steps.lerna-build-cache.outputs.cache-hit != 'true'
+    - name: Tailscale
+      uses: tailscale/github-action@v1
+      with:
+        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
     - run: cd integration-tests && npm run test:ithacanet -- --maxWorkers=8
       env:
         CI: true


### PR DESCRIPTION
# Description

We've been running Taquito integration tests with our self-hosted runners for some times now; however due to our current infrastructure we can't scale self-hosted runner on demand the way we would like to. Furthermore the operational cost for maintaining the runners is starting to put some weight on the SRE team.

As Github offers unlimited minutes when using runners for public repositories I suggest we switch all our CI/CD jobs to public runners. Since we make use of endpoint and services internal to our network I'm using the [tailscale/github-action](https://github.com/tailscale/github-action/actions) to authenticate the runner to our internal network. Worth noting that I configured Tailscale ACLs to restrict communication only to required services.  

# Test Plan
All pipelines succeeded :green_circle:  
