### PR TITLE
Don't limit concurrency for pipelines triggered on master branch

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -5,8 +5,8 @@ on:
     - cron: '0 0 * * *'
 
 concurrency:
-  group: algolia-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   delete-current-algolia-index:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,8 +10,8 @@ on:
     - cron: '0 14 * * 1'
 
 concurrency:
-  group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   analyse:

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 concurrency:
-  group: edge-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   deploy-edge-package:

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -6,8 +6,8 @@ on:
       - master
 
 concurrency:
-  group: deploy-website-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   publish-website:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,8 @@ on:
       - master
 
 concurrency:
-  group: integration-tests-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
   lint-and-test:

--- a/.github/workflows/preview_website.yml
+++ b/.github/workflows/preview_website.yml
@@ -5,8 +5,8 @@ on:
     branches: [master]
 
 concurrency:
-  group: preview-website-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 jobs:
 ## This job will deploy the netlify preview builds


### PR DESCRIPTION
Closes #1342 

# Description

@roxaneletourneau pointed out that we should keep concurrency enabled for pushes to the `master` branch to detect easily commits causing problems to the pipelines.

Conditionals aren't natively supported in `concurrency` blocks however I'm using a workaround by using the OR operator found in https://github.community/t/concurrency-cancel-in-progress-but-not-when-ref-is-master/194707/4?u=danielelisi

The trick is with the expression `${{ startsWith(github.ref, 'refs/pull/') || github.run_number }}`  since commits to `master` branch will always create separate concurrency groups based on the ever increasing `github.run_number` variable 

# Test Plan
I can't really test this change without committing to master so just code review and have faith pls :angel: 