### PR TITLE
fix(beacon wallet): fixed global name in taquito-beacon-wallet.umd.js…

### DIFF
--- a/packages/taquito-beacon-wallet/rollup.config.ts
+++ b/packages/taquito-beacon-wallet/rollup.config.ts
@@ -10,7 +10,7 @@ const libraryName = 'taquito-beacon-wallet';
 export default {
   input: `src/${libraryName}.ts`,
   output: [
-    { file: pkg.main, name: camelCase(libraryName), format: 'umd', sourcemap: true },
+    { file: pkg.main, name: camelCase(libraryName), format: 'umd', sourcemap: true, globals: { '@airgap/beacon-sdk': 'beacon'} },
     { file: pkg.module, format: 'es', sourcemap: true },
   ],
   external: [],


### PR DESCRIPTION
… file

Dapps using taquito and beacon without npm were running into the following issuse: Cannot read
propery 'DappClient' of undefined. Fixed by replacing global.beaconSdk by global.beacon when
generating the umd file.

fix #787

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
