### PR TITLE
cleanup tests that do not require skipithacanet anymore

### DIFF
--- a/integration-tests/contract-call-with-xtz-amount.spec.ts
+++ b/integration-tests/contract-call-with-xtz-amount.spec.ts
@@ -11,17 +11,15 @@ import {
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : test;
-  const skipHangzhounet = protocol === Protocols.PtHangz2 ? test.skip : test;
-  const skipHangzhouAndIthaca =
-    protocol === Protocols.PtHangz2 || Protocols.Psithaca2 ? test.skip : test;
+  const ithacanet = protocol === Protocols.Psithaca2 ? test: test.skip;
+  const hangzhounet = protocol === Protocols.PtHangz2 ? test: test.skip;
 
   describe(`Test contract call with amount using: ${rpc}`, () => {
     beforeEach(async (done) => {
       await setup();
       done();
     });
-    skipIthacanet(
+    hangzhounet(
       'originates a contract on Hangzhou with SUB and sends base layer tokens when calling contract methods',
       async (done) => {
         const op = await Tezos.contract.originate({
@@ -48,7 +46,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       }
     );
 
-    skipIthacanet('fail to originate a contract on Hangzhou with SUB_MUTEZ', async () => {
+    hangzhounet('fail to originate a contract on Hangzhou with SUB_MUTEZ', async () => {
       try {
         await Tezos.contract.originate({
           balance: '0',
@@ -62,8 +60,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       }
     });
 
-    skipHangzhouAndIthaca(
-      //restore to skipHangzhou when forger supports new sub_mutez for Ithaca
+    ithacanet(
       'originates a contract on Ithaca with SUB MUTEZ and sends base layer tokens when calling contract methods',
       async (done) => {
         const op = await Tezos.contract.originate({
@@ -90,7 +87,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       }
     );
 
-    skipHangzhounet('fail to originate a contract on Ithaca with SUB', async () => {
+    ithacanet('fail to originate a contract on Ithaca with SUB', async () => {
       try {
         await Tezos.contract.originate({
           balance: '0',

--- a/integration-tests/contract-estimation-tests.spec.ts
+++ b/integration-tests/contract-estimation-tests.spec.ts
@@ -7,10 +7,8 @@ import { managerCode } from "./data/manager_code";
 
 CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol,rpc }) => {
   const Tezos = lib;
-
   const hangzhounet = (protocol === Protocols.PtHangz2) ? test : test.skip;
   const ithacanet = (protocol === Protocols.PsiThaCa) ? test : test.skip;
-  const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : test;
 
   describe(`Estimate scenario using: ${rpc}`, () => {
     let LowAmountTez: TezosToolkit;
@@ -324,11 +322,11 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol,rpc }) => {
       done();
     });
 
-  skipIthacanet('Estimate transfer to regular address with a fixed fee', async (done) => {
+  it('Estimate transfer to regular address with a fixed fee', async (done) => {
       // fee, gasLimit and storage limit are not taken into account
       const params = { fee: 2000, to: await Tezos.signer.publicKeyHash(), mutez: true, amount: amt - (1382 + DEFAULT_FEE.REVEAL) }
 
-      if (protocol === Protocols.PsiThaCa) {
+      if (protocol === Protocols.Psithaca2) {
         await expect(LowAmountTez.estimate.transfer(params)).rejects.toEqual(
           expect.objectContaining({
             message: expect.stringContaining('balance_too_low'),

--- a/integration-tests/contract-originate-contract-with-single-sapling-state.spec.ts
+++ b/integration-tests/contract-originate-contract-with-single-sapling-state.spec.ts
@@ -5,8 +5,8 @@ import { singleSaplingStateContractHangzhou } from './data/single_sapling_state_
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : test;
-  const skipHangzhounet = protocol === Protocols.PtHangz2 ? test.skip : test;
+  const ithacanet = protocol === Protocols.Psithaca2 ? test: test.skip;
+  const hangzhounet = protocol === Protocols.PtHangz2 ? test: test.skip;
 
   describe(`Test origination of contracts with sapling using: ${rpc}`, () => {
     beforeEach(async (done) => {
@@ -14,7 +14,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       done();
     });
 
-     skipHangzhounet('Originates a contract with a single sapling state in its storage for Ithaca', async (done: () => void) => {
+    ithacanet('Originates a contract with a single sapling state in its storage for Ithaca', async (done: () => void) => {
        const op = await Tezos.contract.originate({
         code: singleSaplingStateContract,
          init: '{}'
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
        done();
      });
 
-    skipIthacanet('Originates a contract with a single sapling state in its storage for Hangzhou', async (done: () => void) => {
+     hangzhounet('Originates a contract with a single sapling state in its storage for Hangzhou', async (done: () => void) => {
       const op = await Tezos.contract.originate({
         code: singleSaplingStateContractHangzhou,
         init: '{}'

--- a/integration-tests/contract-sub-mutez.spec.ts
+++ b/integration-tests/contract-sub-mutez.spec.ts
@@ -3,16 +3,15 @@ import { CONFIGS } from './config';
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : test;
-  const skipHangzhounet = protocol === Protocols.PtHangz2 ? test.skip : test;
-  const skipHangzhouAndIthaca = protocol === Protocols.PtHangz2 || Protocols.Psithaca2 ? test.skip : test;
+  const ithacanet = protocol === Protocols.Psithaca2 ? test: test.skip;
+  const hangzhounet = protocol === Protocols.PtHangz2 ? test: test.skip;
 
   describe(`Test contract call with amount using: ${rpc}`, () => {
     beforeEach(async (done) => {
       await setup();
       done();
     });
-    skipIthacanet(
+    hangzhounet(
       'originate a contract on Hangzhou with SUB',
       async () => {
         const op = await Tezos.contract.originate({
@@ -35,7 +34,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       }
     );
 
-     skipIthacanet('fail to originate a contract on Hangzhou with SUB_MUTEZ', async () => {
+    hangzhounet('fail to originate a contract on Hangzhou with SUB_MUTEZ', async () => {
        try {
          await Tezos.contract.originate({
              code: `{ parameter (or (or (mutez %decrement) (mutez %increment)) (mutez %reset)) ;
@@ -52,7 +51,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
        }
      });
 
-     skipHangzhouAndIthaca(
+     ithacanet(
        'originate a contract on Ithaca with SUB MUTEZ',
        //restore to skipHangzhou when forger supports new sub_mutez for Ithaca
        async () => {
@@ -75,7 +74,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
        }
      );
 
-     skipHangzhounet('fail to originate a contract on Ithaca with SUB', async () => {
+     ithacanet('fail to originate a contract on Ithaca with SUB', async () => {
         try {
          await Tezos.contract.originate({
              code: `{ parameter (or (or (mutez %decrement) (mutez %increment)) (mutez %reset)) ;

--- a/integration-tests/contract-unit-as-param.spec.ts
+++ b/integration-tests/contract-unit-as-param.spec.ts
@@ -5,10 +5,8 @@ import { depositContractCodeIthaca, depositContractStorageIthaca } from "./data/
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const testRetry = require('jest-retries');
-  const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : testRetry;
-  const skipHangzhounet = protocol === Protocols.PtHangz2 ? test.skip : test;
-  const skipHangzhouAndIthaca = protocol === Protocols.PtHangz2 || Protocols.Psithaca2 ? test.skip : test;
+  const ithacanet = protocol === Protocols.Psithaca2 ? test: test.skip;
+  const hangzhounet = protocol === Protocols.PtHangz2 ? test: test.skip;
   
   describe(`Test contract with unit as params using: ${rpc}`, () => {
 
@@ -16,7 +14,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       await setup()
       done()
     })
-    skipIthacanet('Originates contract and calls deposit method with unit param', async (done: () => void) => {
+    hangzhounet('Originates contract and calls deposit method with unit param', async (done: () => void) => {
       const op = await Tezos.contract.originate({
         balance: "1",
         code: depositContractCodeHangzhou,
@@ -30,8 +28,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       done();
     })
 
-    skipHangzhouAndIthaca('Originates contract and calls deposit method with unit param', async (done: () => void) => {
-      //restore to skipHangzhou when forger supports new sub_mutez for Ithaca
+    ithacanet('Originates contract and calls deposit method with unit param', async (done: () => void) => {
       const op = await Tezos.contract.originate({
         balance: "1",
         code: depositContractCodeIthaca,

--- a/integration-tests/rpc-nodes.spec.ts
+++ b/integration-tests/rpc-nodes.spec.ts
@@ -18,7 +18,6 @@ CONFIGS().forEach(
   }) => {
     const Tezos = lib;
     const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : test;
-    const skipHangzhounet = protocol === Protocols.PtHangz2 ? test.skip : test;
 
     beforeEach(async (done) => {
       await setup();

--- a/integration-tests/wallet-unit-as-param.spec.ts
+++ b/integration-tests/wallet-unit-as-param.spec.ts
@@ -5,17 +5,15 @@ import { depositContractCodeIthaca, depositContractStorageIthaca } from "./data/
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const testRetry = require('jest-retries');
-  const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : testRetry;
-  const skipHangzhounet = protocol === Protocols.PtHangz2 ? test.skip : test;
-  const skipHangzhouAndIthaca = protocol === Protocols.PtHangz2 || Protocols.Psithaca2 ? test.skip : test;
+  const ithacanet = protocol === Protocols.Psithaca2 ? test: test.skip;
+  const hangzhounet = protocol === Protocols.PtHangz2 ? test: test.skip;
 
   describe(`Test contract made with wallet API with unit as params using: ${rpc}`, () => {
     beforeEach(async (done) => {
       await setup()
       done()
     })
-    skipIthacanet('originates contract made with wallet API and calls deposit method with unit param', async (done: () => void) => {
+    hangzhounet('originates contract made with wallet API and calls deposit method with unit param', async (done: () => void) => {
       const op = await Tezos.wallet.originate({
         balance: "1",
         code: depositContractCodeHangzhou,
@@ -29,8 +27,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
       done();
     })
 
-    skipHangzhouAndIthaca('originates contract made with wallet API and calls deposit method with unit param', async (done) => {
-      //restore to skipHangzhou when forger supports new sub_mutez for Ithaca
+    ithacanet('originates contract made with wallet API and calls deposit method with unit param', async (done) => {
       const op = await Tezos.wallet.originate({
         balance: "1",
         code: depositContractCodeIthaca,


### PR DESCRIPTION
Step two in migrating integration tests to Ithacanet2

CLOSE #1376 