### PR TITLE
refactor: Make the read calls using the configured TzReadProvider instead of the RPC

### DIFF
--- a/packages/taquito-contracts-library/src/read-provider-wrapper.ts
+++ b/packages/taquito-contracts-library/src/read-provider-wrapper.ts
@@ -1,0 +1,89 @@
+import { BigNumber } from 'bignumber.js';
+import {
+  EntrypointsResponse,
+  MichelsonV1Expression,
+  SaplingDiffResponse,
+  ScriptedContracts,
+} from '@taquito/rpc';
+import { ContractsLibrary } from './taquito-contracts-library';
+import { BigMapQuery, BlockIdentifier, SaplingStateQuery, TzReadProvider } from '@taquito/taquito';
+
+export class ReadWrapperContractsLibrary implements TzReadProvider {
+  constructor(private readProvider: TzReadProvider, private contractslibrary: ContractsLibrary) {}
+
+  async getScript(address: string, block: BlockIdentifier): Promise<ScriptedContracts> {
+    const contractData = this.contractslibrary.getContract(address);
+    if (contractData) {
+      return contractData.script;
+    } else {
+      return this.readProvider.getScript(address, block);
+    }
+  }
+
+  async getEntrypoints(contract: string): Promise<EntrypointsResponse> {
+    const contractData = this.contractslibrary.getContract(contract);
+    if (contractData) {
+      return contractData.entrypoints;
+    } else {
+      return this.readProvider.getEntrypoints(contract);
+    }
+  }
+
+  getBalance(address: string, block: BlockIdentifier): Promise<BigNumber> {
+    return this.readProvider.getBalance(address, block);
+  }
+  getDelegate(address: string, block: BlockIdentifier): Promise<string | null> {
+    return this.readProvider.getDelegate(address, block);
+  }
+  getNextProtocol(block: BlockIdentifier): Promise<string> {
+    return this.readProvider.getNextProtocol(block);
+  }
+  getProtocolConstants(
+    block: BlockIdentifier
+  ): Promise<{
+    time_between_blocks?: BigNumber[] | undefined;
+    minimal_block_delay?: BigNumber | undefined;
+    hard_gas_limit_per_operation: BigNumber;
+    hard_gas_limit_per_block: BigNumber;
+    hard_storage_limit_per_operation: BigNumber;
+    cost_per_byte: BigNumber;
+  }> {
+    return this.readProvider.getProtocolConstants(block);
+  }
+  getStorage(contract: string, block: BlockIdentifier): Promise<MichelsonV1Expression> {
+    return this.readProvider.getStorage(contract, block);
+  }
+  getStorageTypeAndValue(
+    contract: string,
+    block: BlockIdentifier
+  ): Promise<{ storageType: MichelsonV1Expression; storageValue: MichelsonV1Expression }> {
+    return this.readProvider.getStorageTypeAndValue(contract, block);
+  }
+  getBlockHash(block: BlockIdentifier): Promise<string> {
+    return this.readProvider.getBlockHash(block);
+  }
+  getBlockLevel(block: BlockIdentifier): Promise<number> {
+    return this.readProvider.getBlockLevel(block);
+  }
+  getCounter(pkh: string, block: BlockIdentifier): Promise<string> {
+    return this.readProvider.getCounter(pkh, block);
+  }
+  getBlockTimestamp(block: BlockIdentifier): Promise<string> {
+    return this.readProvider.getBlockTimestamp(block);
+  }
+  getBigMapValue(bigMapQuery: BigMapQuery, block: BlockIdentifier): Promise<MichelsonV1Expression> {
+    return this.readProvider.getBigMapValue(bigMapQuery, block);
+  }
+  getSaplingDiffById(
+    saplingStateQuery: SaplingStateQuery,
+    block: BlockIdentifier
+  ): Promise<SaplingDiffResponse> {
+    return this.readProvider.getSaplingDiffById(saplingStateQuery, block);
+  }
+  getChainId(): Promise<string> {
+    return this.readProvider.getChainId();
+  }
+  isAccountRevealed(publicKeyHash: string, block: BlockIdentifier): Promise<boolean> {
+    return this.readProvider.isAccountRevealed(publicKeyHash, block);
+  }
+}

--- a/packages/taquito-contracts-library/src/rpc-wrapper.ts
+++ b/packages/taquito-contracts-library/src/rpc-wrapper.ts
@@ -41,6 +41,10 @@ import {
 } from '@taquito/rpc';
 import { ContractsLibrary } from './taquito-contracts-library';
 
+/**
+ * @deprecated RpcWrapperContractsLibrary has been deprecated in favor of ReadWrapperContractsLibrary
+ *
+ */
 export class RpcWrapperContractsLibrary implements RpcClientInterface {
   constructor(private rpc: RpcClientInterface, private contractslibrary: ContractsLibrary) {}
 

--- a/packages/taquito-contracts-library/src/taquito-contracts-library.ts
+++ b/packages/taquito-contracts-library/src/taquito-contracts-library.ts
@@ -7,7 +7,7 @@ import { EntrypointsResponse, ScriptedContracts } from '@taquito/rpc';
 import { Extension, Context } from '@taquito/taquito';
 import { validateAddress, ValidationResult } from '@taquito/utils';
 import { InvalidAddressError, InvalidScriptFormatError } from './errors';
-import { RpcWrapperContractsLibrary } from './rpc-wrapper';
+import { ReadWrapperContractsLibrary } from './read-provider-wrapper';
 
 interface ContractsData {
   [contractAddress: string]: { script: ScriptedContracts; entrypoints: EntrypointsResponse };
@@ -63,7 +63,7 @@ export class ContractsLibrary implements Extension {
 
   configureContext(context: Context) {
     context.registerProviderDecorator((context: Context) => {
-      context.rpc = new RpcWrapperContractsLibrary(context.rpc, this);
+      context.readProvider = new ReadWrapperContractsLibrary(context.readProvider, this);
       return context;
     });
   }

--- a/packages/taquito-contracts-library/test/read-provider-wrapper.spec.ts
+++ b/packages/taquito-contracts-library/test/read-provider-wrapper.spec.ts
@@ -1,0 +1,62 @@
+import { script } from './data/contract-script';
+import { entrypoints } from './data/contract-entrypoints';
+import { ContractsLibrary } from '../src/taquito-contracts-library';
+import { ReadWrapperContractsLibrary } from '../src/read-provider-wrapper';
+
+describe('RpcWrapperContractsLibrary tests', () => {
+  let mockReadProvider: any;
+
+  beforeEach(() => {
+    mockReadProvider = {
+      getScript: jest.fn(),
+      getEntrypoints: jest.fn(),
+    };
+  });
+
+  it('ReadWrapperContractsLibrary is instantiable', () => {
+    expect(
+      new ReadWrapperContractsLibrary(mockReadProvider as any, new ContractsLibrary())
+    ).toBeInstanceOf(ReadWrapperContractsLibrary);
+  });
+
+  it('get script from RPC when contract is not in the library', async (done) => {
+    mockReadProvider.getScript.mockResolvedValue('script-from-rpc');
+    const contractAddress = 'KT1NGV6nvvedwwjMjCsWY6Vfm6p1q5sMMLDY';
+    const readWrapper = new ReadWrapperContractsLibrary(
+      mockReadProvider as any,
+      new ContractsLibrary()
+    );
+    const script = await readWrapper.getScript(contractAddress, 'head');
+    expect(script).toEqual('script-from-rpc');
+    done();
+  });
+
+  it('get entrypoints from RPC when contract is not in the library', async (done) => {
+    mockReadProvider.getEntrypoints.mockResolvedValue('entrypoints-from-http');
+    const contractAddress = 'KT1NGV6nvvedwwjMjCsWY6Vfm6p1q5sMMLDY';
+    const readWrapper = new ReadWrapperContractsLibrary(
+      mockReadProvider as any,
+      new ContractsLibrary()
+    );
+    const entrypoints = await readWrapper.getEntrypoints(contractAddress);
+    expect(entrypoints).toEqual('entrypoints-from-http');
+    done();
+  });
+
+  it('get script and entrypoints from library when contract is in the library', async (done) => {
+    const contractAddress = 'KT1NGV6nvvedwwjMjCsWY6Vfm6p1q5sMMLDY';
+    const contractLib = new ContractsLibrary();
+
+    contractLib.addContract({
+      [contractAddress]: {
+        script,
+        entrypoints,
+      },
+    });
+
+    const readWrapper = new ReadWrapperContractsLibrary(mockReadProvider as any, contractLib);
+    expect(await readWrapper.getScript(contractAddress, 'head')).toEqual(script);
+    expect(await readWrapper.getEntrypoints(contractAddress)).toEqual(entrypoints);
+    done();
+  });
+});

--- a/packages/taquito-signer/test/import-key.spec.ts
+++ b/packages/taquito-signer/test/import-key.spec.ts
@@ -6,21 +6,21 @@ describe('ImportKey', () => {
   let toolkit: TezosToolkit;
 
   const mnemonics = [
-    "shoe",
-    "input",
-    "also",
-    "elephant",
-    "network",
-    "noise",
-    "vocal",
-    "drastic",
-    "worry",
-    "unveil",
-    "tumble",
-    "test",
-    "illegal",
-    "album",
-    "tuna"
+    'shoe',
+    'input',
+    'also',
+    'elephant',
+    'network',
+    'noise',
+    'vocal',
+    'drastic',
+    'worry',
+    'unveil',
+    'tumble',
+    'test',
+    'illegal',
+    'album',
+    'tuna',
   ].join(' ');
 
   beforeEach(() => {
@@ -30,17 +30,20 @@ describe('ImportKey', () => {
       getManagerKey: jest.fn(),
       getStorage: jest.fn(),
       getBlockHeader: jest.fn(),
-      getBlockMetadata: jest.fn(),
       getContract: jest.fn(),
       forgeOperations: jest.fn(),
       injectOperation: jest.fn(),
       preapplyOperations: jest.fn(),
+      getProtocols: jest.fn(),
     };
 
     mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
     mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
     mockRpcClient.preapplyOperations.mockResolvedValue([]);
-    mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getProtocols.mockResolvedValue({
+      protocol: 'test_proto',
+      next_protocol: 'test_proto',
+    });
 
     // Required for operations confirmation polling
     mockRpcClient.getBlock.mockResolvedValue({
@@ -57,7 +60,7 @@ describe('ImportKey', () => {
     toolkit['_options'].rpc = mockRpcClient;
   });
 
-  it('should use InMemorySigner when importKey is called', async done => {
+  it('should use InMemorySigner when importKey is called', async (done) => {
     expect(toolkit.signer).toEqual({});
     await importKey(toolkit, 'p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1');
     expect(toolkit.signer).toBeInstanceOf(InMemorySigner);
@@ -66,16 +69,28 @@ describe('ImportKey', () => {
     done();
   });
 
-  it('should use InMemorySigner and activate faucet account when called with {privateKeyOrEmail, passphrase, mnemonic, secret} parameters', async done => {
+  it('should use InMemorySigner and activate faucet account when called with {privateKeyOrEmail, passphrase, mnemonic, secret} parameters', async (done) => {
     // Mock fake operation hash
-    mockRpcClient.injectOperation.mockResolvedValue('oo6JPEAy8VuMRGaFuMmLNFFGdJgiaKfnmT1CpHJfKP3Ye5ZahiP');
+    mockRpcClient.injectOperation.mockResolvedValue(
+      'oo6JPEAy8VuMRGaFuMmLNFFGdJgiaKfnmT1CpHJfKP3Ye5ZahiP'
+    );
     expect(toolkit.signer).toEqual({});
-    await importKey(toolkit, 'hbgpdcvg.beavuxsa@teztnets.xyz', 'dcsBZzXg7d', mnemonics, '837f402873eff00fa0b0977c08725b1f8d78a94b');
+    await importKey(
+      toolkit,
+      'hbgpdcvg.beavuxsa@teztnets.xyz',
+      'dcsBZzXg7d',
+      mnemonics,
+      '837f402873eff00fa0b0977c08725b1f8d78a94b'
+    );
     expect(toolkit.signer).toBeInstanceOf(InMemorySigner);
     expect(mockRpcClient.forgeOperations).toHaveBeenCalledWith({
       branch: 'test',
       contents: [
-        { kind: 'activate_account', pkh: 'tz1gaD8adax6qAST1a79sj78XfyPs5k9Nj78', secret: '837f402873eff00fa0b0977c08725b1f8d78a94b' },
+        {
+          kind: 'activate_account',
+          pkh: 'tz1gaD8adax6qAST1a79sj78XfyPs5k9Nj78',
+          secret: '837f402873eff00fa0b0977c08725b1f8d78a94b',
+        },
       ],
     });
     expect(mockRpcClient.injectOperation).toHaveBeenCalled();
@@ -83,13 +98,19 @@ describe('ImportKey', () => {
     done();
   });
 
-  it('should use InMemorySigner and skip activate faucet account when called with already activated account', async done => {
+  it('should use InMemorySigner and skip activate faucet account when called with already activated account', async (done) => {
     // Mock RPC error when activation is already done
     mockRpcClient.forgeOperations.mockRejectedValue({ body: 'Invalid activation' });
     // Mock fake operation hash
     mockRpcClient.injectOperation.mockResolvedValue('test');
     expect(toolkit.signer).toEqual({});
-    await importKey(toolkit, 'hbgpdcvg.beavuxsa@teztnets.xyz"', 'dcsBZzXg7d', mnemonics, '837f402873eff00fa0b0977c08725b1f8d78a94b');
+    await importKey(
+      toolkit,
+      'hbgpdcvg.beavuxsa@teztnets.xyz"',
+      'dcsBZzXg7d',
+      mnemonics,
+      '837f402873eff00fa0b0977c08725b1f8d78a94b'
+    );
     expect(toolkit.signer).toBeInstanceOf(InMemorySigner);
     expect(mockRpcClient.injectOperation).not.toHaveBeenCalled();
     expect(await toolkit.signer.publicKeyHash()).toEqual('tz1bg7HTLJxHrDcivFUSTx8TLNsJcty7j9r5');

--- a/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
+++ b/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
@@ -176,7 +176,7 @@ export class Tzip12ContractAbstraction {
   }
 
   private async retrieveTokenMetadataFromBigMap(tokenId: number) {
-    const bigmapTokenMetadataId = this.findTokenMetadataBigMap();
+    const bigmapTokenMetadataId = await this.findTokenMetadataBigMap();
     let pairNatMap;
     try {
       pairNatMap = await this.context.contract.getBigMapKeyByID<any>(
@@ -202,9 +202,9 @@ export class Tzip12ContractAbstraction {
     );
   }
 
-  private findTokenMetadataBigMap(): BigMapId {
+  private async findTokenMetadataBigMap(): Promise<BigMapId> {
     const tokenMetadataBigMapId = this.contractAbstraction.schema.FindFirstInTopLevelPair<BigMapId>(
-      this.contractAbstraction.script.storage,
+      await this.context.readProvider.getStorage(this.contractAbstraction.address, 'head'),
       tokenMetadataBigMapType
     );
     if (!tokenMetadataBigMapId) {

--- a/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
@@ -18,6 +18,9 @@ describe('Tzip12 contract abstraction test', () => {
   let mockRpcContractProvider: {
     getBigMapKeyByID: jest.Mock<any, any>;
   };
+  let mockReadProvider: {
+    getStorage: jest.Mock<any, any>;
+  };
 
   beforeEach(() => {
     mockMetadataProvider = {
@@ -36,26 +39,26 @@ describe('Tzip12 contract abstraction test', () => {
     mockRpcContractProvider = {
       getBigMapKeyByID: jest.fn(),
     };
+    mockReadProvider = {
+      getStorage: jest.fn(),
+    };
     mockContractAbstraction.address = 'test';
     mockContractAbstraction['schema'] = mockSchema;
-    mockContractAbstraction['script'] = {
-      script: {
-        code: [],
-        storage: {
-          prim: 'Pair',
-          args: [
-            {
-              int: '20350',
-            },
-            [],
-          ],
+    mockReadProvider.getStorage.mockResolvedValue({
+      prim: 'Pair',
+      args: [
+        {
+          int: '20350',
         },
-      },
-    };
+        [],
+      ],
+    });
+
+    mockContext['metadataProvider'] = mockMetadataProvider;
+    mockContext['readProvider'] = mockReadProvider;
+    mockContext['contract'] = mockRpcContractProvider;
     tzip12Abs = new Tzip12ContractAbstraction(mockContractAbstraction, mockContext);
     tzip12Abs['_tzip16ContractAbstraction'] = mockTzip16ContractAbstraction;
-    mockContext['metadataProvider'] = mockMetadataProvider;
-    mockContext['contract'] = mockRpcContractProvider;
   });
 
   it('Test 1 for getContractMetadata(): Should return the `Tzip-016` contract metadata', async (done) => {

--- a/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
+++ b/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
@@ -29,11 +29,12 @@ export class TezosStorageHandler implements Handler {
     if (!parsedTezosStorageUri) {
       throw new InvalidUri(`tezos-storage:${location}`);
     }
-    const storage: any = await context.rpc.getNormalizedScript(
-      parsedTezosStorageUri.contractAddress || contractAbstraction.address
+    const script = await context.readProvider.getScript(
+      parsedTezosStorageUri.contractAddress || contractAbstraction.address,
+      'head'
     );
-    const bigMapId = Schema.fromRPCResponse({ script: storage }).FindFirstInTopLevelPair<BigMapId>(
-      storage.storage,
+    const bigMapId = Schema.fromRPCResponse({ script }).FindFirstInTopLevelPair<BigMapId>(
+      script.storage,
       typeOfValueToFind
     );
 

--- a/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
+++ b/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
@@ -42,9 +42,9 @@ export class Tzip16ContractAbstraction {
     this._metadataProvider = context.metadataProvider;
   }
 
-  private findMetadataBigMap(): BigMapAbstraction {
+  private async findMetadataBigMap(): Promise<BigMapAbstraction> {
     const metadataBigMapId = this.constractAbstraction.schema.FindFirstInTopLevelPair<BigMapId>(
-      this.constractAbstraction.script.storage,
+      await this.context.readProvider.getStorage(this.constractAbstraction.address, 'head'),
       metadataBigMapType
     );
 
@@ -60,7 +60,7 @@ export class Tzip16ContractAbstraction {
   }
 
   private async getUriOrFail() {
-    const metadataBigMap = this.findMetadataBigMap();
+    const metadataBigMap = await this.findMetadataBigMap();
     const uri = await metadataBigMap.get<string>('');
     if (!uri) {
       throw new UriNotFound();
@@ -119,6 +119,7 @@ export class Tzip16ContractAbstraction {
         const metadataView = this._viewFactory.getView(
           viewName,
           this.context.rpc,
+          this.context.readProvider,
           this.constractAbstraction,
           viewImplementation
         );

--- a/packages/taquito-tzip16/src/viewKind/viewFactory.ts
+++ b/packages/taquito-tzip16/src/viewKind/viewFactory.ts
@@ -1,44 +1,48 @@
 import { RpcClientInterface } from '@taquito/rpc';
-import { ContractAbstraction, ContractProvider, Wallet } from '@taquito/taquito';
+import { ContractAbstraction, ContractProvider, Wallet, TzReadProvider } from '@taquito/taquito';
 import { ViewImplementation, ViewImplementationType } from '../metadata-interface';
 import { MichelsonStorageView } from './michelson-storage-view';
 
 export class ViewFactory {
-    getView(
-        viewName: string,
-        rpc: RpcClientInterface,
-        contract: ContractAbstraction<ContractProvider | Wallet>,
-        viewImplementation: ViewImplementation
-    ) {
-        if (this.isMichelsonStorageView(viewImplementation)) {
-            const viewValues = viewImplementation[ViewImplementationType.MICHELSON_STORAGE];
-            if (!viewValues.returnType || !viewValues.code) {
-                console.warn(
-                    `${viewName} is missing mandatory code or returnType property therefore it will be skipped.`
-                );
-                return;
-            }
-            return () => {
-                const view = new MichelsonStorageView(
-                    viewName,
-                    contract,
-                    rpc,
-                    viewValues.returnType as any,
-                    viewValues.code as any,
-                    viewValues.parameter as any
-                );
-                return view;
-            };
-        }
+  getView(
+    viewName: string,
+    rpc: RpcClientInterface,
+    readProvider: TzReadProvider,
+    contract: ContractAbstraction<ContractProvider | Wallet>,
+    viewImplementation: ViewImplementation
+  ) {
+    if (this.isMichelsonStorageView(viewImplementation)) {
+      const viewValues = viewImplementation[ViewImplementationType.MICHELSON_STORAGE];
+      if (!viewValues.returnType || !viewValues.code) {
+        console.warn(
+          `${viewName} is missing mandatory code or returnType property therefore it will be skipped.`
+        );
+        return;
+      }
+      return () => {
+        const view = new MichelsonStorageView(
+          viewName,
+          contract,
+          rpc,
+          readProvider,
+          viewValues.returnType as any,
+          viewValues.code as any,
+          viewValues.parameter as any
+        );
+        return view;
+      };
     }
+  }
 
-    getImplementationType(viewImplementation: ViewImplementation) {
-        return Object.keys(viewImplementation)[0];
-    }
+  getImplementationType(viewImplementation: ViewImplementation) {
+    return Object.keys(viewImplementation)[0];
+  }
 
-    private isMichelsonStorageView(
-        viewImplementation: ViewImplementation
-    ): viewImplementation is { [ViewImplementationType.MICHELSON_STORAGE]: any } {
-        return this.getImplementationType(viewImplementation) === ViewImplementationType.MICHELSON_STORAGE;
-    }
+  private isMichelsonStorageView(
+    viewImplementation: ViewImplementation
+  ): viewImplementation is { [ViewImplementationType.MICHELSON_STORAGE]: any } {
+    return (
+      this.getImplementationType(viewImplementation) === ViewImplementationType.MICHELSON_STORAGE
+    );
+  }
 }

--- a/packages/taquito-tzip16/test/handlers/tezos-storage-handler.spec.ts
+++ b/packages/taquito-tzip16/test/handlers/tezos-storage-handler.spec.ts
@@ -54,11 +54,11 @@ describe('Parse Tezos storage URI test', () => {
 
 describe('Tzip16 tezos storage handler test', () => {
   const mockContractAbstraction: any = {};
-  let mockRpcClient: {
-    getNormalizedScript: jest.Mock<any, any>;
+  let mockReadProvider: {
+    getScript: jest.Mock<any, any>;
   };
   let mockContext: {
-    rpc: any;
+    readProvider: any;
     contract: any;
   };
   let mockContractProvider: {
@@ -68,20 +68,17 @@ describe('Tzip16 tezos storage handler test', () => {
   const tezosStorageHandler = new TezosStorageHandler();
 
   beforeEach(() => {
-    mockRpcClient = {
-      getNormalizedScript: jest.fn(),
+    mockReadProvider = {
+      getScript: jest.fn(),
     };
     mockContractProvider = {
       getBigMapKeyByID: jest.fn(),
     };
     mockContext = {
-      rpc: mockRpcClient,
+      readProvider: mockReadProvider,
       contract: mockContractProvider,
     };
-  });
-
-  it('Should succesfully find the metadata', async (done) => {
-    mockRpcClient.getNormalizedScript.mockResolvedValue({
+    mockReadProvider.getScript.mockResolvedValue({
       code: [
         {
           prim: 'storage',
@@ -103,6 +100,9 @@ describe('Tzip16 tezos storage handler test', () => {
       ],
       storage: { prim: 'Pair', args: [{ int: '32527' }, []] },
     });
+  });
+
+  it('Should succesfully find the metadata', async (done) => {
     mockContractProvider.getBigMapKeyByID.mockResolvedValue(
       '7b226e616d65223a2274657374222c226465736372697074696f6e223a2241206d657461646174612074657374222c2276657273696f6e223a22302e31222c226c6963656e7365223a224d4954222c22617574686f7273223a5b225461717569746f203c68747470733a2f2f74657a6f737461717569746f2e696f2f3e225d2c22686f6d6570616765223a2268747470733a2f2f74657a6f737461717569746f2e696f2f227d'
     );
@@ -125,29 +125,6 @@ describe('Tzip16 tezos storage handler test', () => {
   });
 
   it('Should fail with InvalidUri when the URI is invalid', async (done) => {
-    mockRpcClient.getNormalizedScript.mockResolvedValue({
-      code: [
-        {
-          prim: 'storage',
-          args: [
-            {
-              prim: 'pair',
-              args: [
-                {
-                  prim: 'big_map',
-                  args: [{ prim: 'string' }, { prim: 'bytes' }],
-                  annots: ['%metadata'],
-                },
-                {},
-              ],
-            },
-          ],
-        },
-        { prim: 'code', args: [] },
-      ],
-      storage: { prim: 'Pair', args: [{ int: '32527' }, []] },
-    });
-
     const tzip16Uri = {
       sha256hash: undefined,
       protocol: 'tezos-storage',
@@ -166,7 +143,7 @@ describe('Tzip16 tezos storage handler test', () => {
   });
 
   it('Should fail with BigMapMetadataNotFound when there is no big map %metadata in the storage', async (done) => {
-    mockRpcClient.getNormalizedScript.mockResolvedValue({
+    mockReadProvider.getScript.mockResolvedValue({
       code: [{ prim: 'storage', args: [{ prim: 'pair', args: [{}, {}] }] }],
       storage: { prim: 'Pair', args: [] },
     });
@@ -185,28 +162,6 @@ describe('Tzip16 tezos storage handler test', () => {
   });
 
   it('Should fail with MetadataNotFound when the path extracted from the URI is not a key of the big map %metadata', async (done) => {
-    mockRpcClient.getNormalizedScript.mockResolvedValue({
-      code: [
-        {
-          prim: 'storage',
-          args: [
-            {
-              prim: 'pair',
-              args: [
-                {
-                  prim: 'big_map',
-                  args: [{ prim: 'string' }, { prim: 'bytes' }],
-                  annots: ['%metadata'],
-                },
-                {},
-              ],
-            },
-          ],
-        },
-        { prim: 'code', args: [] },
-      ],
-      storage: { prim: 'Pair', args: [{ int: '32527' }, []] },
-    });
     mockContractProvider.getBigMapKeyByID.mockResolvedValue(undefined);
 
     const tzip16Uri = {
@@ -227,28 +182,6 @@ describe('Tzip16 tezos storage handler test', () => {
   });
 
   it('Should fail with InvalidMetadataType when metadata type is not bytes', async (done) => {
-    mockRpcClient.getNormalizedScript.mockResolvedValue({
-      code: [
-        {
-          prim: 'storage',
-          args: [
-            {
-              prim: 'pair',
-              args: [
-                {
-                  prim: 'big_map',
-                  args: [{ prim: 'string' }, { prim: 'bytes' }],
-                  annots: ['%metadata'],
-                },
-                {},
-              ],
-            },
-          ],
-        },
-        { prim: 'code', args: [] },
-      ],
-      storage: { prim: 'Pair', args: [{ int: '32527' }, []] },
-    });
     mockContractProvider.getBigMapKeyByID.mockResolvedValue('NOT-BYTES');
 
     const tzip16Uri = {

--- a/packages/taquito-tzip16/test/tzip16-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip16/test/tzip16-contract-abstraction.spec.ts
@@ -15,6 +15,10 @@ describe('Tzip16 contract abstraction test', () => {
     getBigMapKeyByID: jest.Mock<any, any>;
   };
 
+  let mockReadProvider: {
+    getStorage: jest.Mock<any, any>;
+  };
+
   beforeEach(() => {
     mockMetadataProvider = {
       provideMetadata: jest.fn(),
@@ -28,6 +32,10 @@ describe('Tzip16 contract abstraction test', () => {
       getBigMapKeyByID: jest.fn(),
     };
 
+    mockReadProvider = {
+      getStorage: jest.fn(),
+    };
+
     mockMetadataProvider.provideMetadata.mockResolvedValue({
       uri: 'https://test',
       metadata: { name: 'Taquito test' },
@@ -35,22 +43,18 @@ describe('Tzip16 contract abstraction test', () => {
 
     mockContext['metadataProvider'] = mockMetadataProvider;
     mockContext['contract'] = mockRpcContractProvider;
+    mockContext['readProvider'] = mockReadProvider;
 
     mockContractAbstraction['schema'] = mockSchema;
-    mockContractAbstraction['script'] = {
-      script: {
-        code: [],
-        storage: {
-          prim: 'Pair',
-          args: [
-            {
-              int: '20350',
-            },
-            [],
-          ],
+    mockReadProvider.getStorage.mockResolvedValue({
+      prim: 'Pair',
+      args: [
+        {
+          int: '20350',
         },
-      },
-    };
+        [],
+      ],
+    });
   });
 
   it('Should get the metadata', async (done) => {

--- a/packages/taquito-tzip16/test/viewKind/michelson-storage-view.spec.ts
+++ b/packages/taquito-tzip16/test/viewKind/michelson-storage-view.spec.ts
@@ -1,9 +1,11 @@
+import { Context, RpcReadAdapter } from '@taquito/taquito';
 import { ForbiddenInstructionInViewCode, NoParameterExpectedError } from '../../src/tzip16-errors';
 import { MichelsonStorageView } from '../../src/viewKind/michelson-storage-view';
 
 describe('MichelsonStorageView test', () => {
   const mockContractAbstraction: any = {};
   let mockRpcClient: any;
+  let mockReadProvider: any;
 
   beforeEach(() => {
     mockRpcClient = {
@@ -11,6 +13,8 @@ describe('MichelsonStorageView test', () => {
       getBalance: jest.fn(),
       getChainId: jest.fn(),
       runCode: jest.fn(),
+      getStorage: jest.fn(),
+      getBlockHeader: jest.fn(),
     };
 
     mockContractAbstraction.address = 'KT1test';
@@ -47,6 +51,14 @@ describe('MichelsonStorageView test', () => {
     });
     mockRpcClient.getBalance.mockResolvedValue('0');
     mockRpcClient.getChainId.mockResolvedValue('NetTest');
+    mockRpcClient.getBlockHeader.mockResolvedValue({ timestamp: '2021-01-06T05:14:43Z' });
+    mockRpcClient.getStorage.mockResolvedValue({
+      prim: 'Pair',
+      args: [{ int: '7' }, { int: '38671' }],
+    });
+
+    const context = new Context(mockRpcClient as any);
+    mockReadProvider = new RpcReadAdapter(context);
   });
 
   it('Should succesfully execute a view that get the balance of the contrat', async (done) => {
@@ -59,6 +71,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] },
       [
         { prim: 'DROP', args: [], annots: [] },
@@ -77,6 +90,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -103,6 +117,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -128,6 +143,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -149,6 +165,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -170,6 +187,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -191,6 +209,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -214,6 +233,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -239,6 +259,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -261,6 +282,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -292,6 +314,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -318,6 +341,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -359,6 +383,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -405,6 +430,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       viewCode
     );
@@ -444,6 +470,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       [{ prim: 'CAR', args: [], annots: [] }] // code
     );
@@ -459,6 +486,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       [{ prim: 'CAR', args: [], annots: [] }] // code
     );
@@ -474,6 +502,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       [{ prim: 'CAR', args: [], annots: [] }], // code
       { args: [], prim: 'unit', annots: [] }
@@ -490,6 +519,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       [{ prim: 'CAR', args: [], annots: [] }], // code
       { args: [], prim: 'unit', annots: [] }
@@ -506,6 +536,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       [{ prim: 'CAR', args: [], annots: [] }], // code
       { args: [], prim: 'unit', annots: [] }
@@ -524,6 +555,7 @@ describe('MichelsonStorageView test', () => {
       'test',
       mockContractAbstraction,
       mockRpcClient,
+      mockReadProvider,
       { prim: 'mutez', args: [], annots: [] }, // returnType
       [{ prim: 'CAR', args: [], annots: [] }] // code
     );

--- a/packages/taquito/src/contract/contract-methods/contract-method-factory.ts
+++ b/packages/taquito/src/contract/contract-methods/contract-method-factory.ts
@@ -5,6 +5,7 @@ import { ContractMethod } from './contract-method-flat-param';
 import { ParameterSchema, ViewSchema } from '@taquito/michelson-encoder';
 import { RpcClientInterface, MichelsonV1Expression } from '@taquito/rpc';
 import { OnChainView } from './contract-on-chain-view';
+import { TzReadProvider } from '../../read-provider/interface';
 
 export class ContractMethodFactory<T extends ContractProvider | Wallet> {
   constructor(private provider: T, private contractAddress: string) {}
@@ -47,17 +48,17 @@ export class ContractMethodFactory<T extends ContractProvider | Wallet> {
 
   createContractViewObjectParam(
     rpc: RpcClientInterface,
+    readProvider: TzReadProvider,
     smartContractViewSchema: ViewSchema,
     contractStorageType: MichelsonV1Expression,
-    contractStorageValue: MichelsonV1Expression,
     viewArgs: any
   ) {
     return new OnChainView(
       rpc,
+      readProvider,
       this.contractAddress,
       smartContractViewSchema,
       contractStorageType,
-      contractStorageValue,
       viewArgs
     );
   }

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -47,9 +47,7 @@ export abstract class OperationEmitter {
   }
 
   protected async isAccountRevealRequired(publicKeyHash: string) {
-    const manager = await this.rpc.getManagerKey(publicKeyHash);
-    const haveManager = manager && typeof manager === 'object' ? !!manager.key : !!manager;
-    return !haveManager;
+    return !(await this.context.readProvider.isAccountRevealed(publicKeyHash, 'head'));
   }
 
   protected isRevealRequiredForOpType(op: RPCOperation[] | ParamsWithKind[]) {
@@ -70,8 +68,8 @@ export abstract class OperationEmitter {
     const counters: { [key: string]: number } = {};
     let ops: RPCOperation[] = [];
 
-    const blockHeaderPromise = this.rpc.getBlockHeader({ block: 'head~2' });
-    const blockMetaPromise = this.rpc.getBlockMetadata();
+    const blockHashPromise = this.context.readProvider.getBlockHash('head~2');
+    const blockProtoPromise = this.context.readProvider.getNextProtocol('head');
 
     if (Array.isArray(operation)) {
       ops = [...operation];
@@ -85,27 +83,16 @@ export abstract class OperationEmitter {
 
     for (let i = 0; i < ops.length; i++) {
       if (isOpRequireReveal(ops[i]) || ops[i].kind === 'reveal') {
-        const { counter } = await this.rpc.getContract(publicKeyHash);
-        counterPromise = Promise.resolve(counter);
+        counterPromise = this.context.readProvider.getCounter(publicKeyHash, 'head');
         break;
       }
     }
 
-    const [header, metadata, headCounter] = await Promise.all([
-      blockHeaderPromise,
-      blockMetaPromise,
+    const [hash, protocol, headCounter] = await Promise.all([
+      blockHashPromise,
+      blockProtoPromise,
       counterPromise,
     ]);
-
-    if (!header) {
-      throw new Error('Unable to fetch latest block header');
-    }
-
-    if (!metadata) {
-      throw new Error('Unable to fetch latest metadata');
-    }
-
-    const head = header;
 
     const counter = parseInt(headCounter || '0', 10);
     if (!counters[publicKeyHash] || counters[publicKeyHash] < counter) {
@@ -179,13 +166,11 @@ export abstract class OperationEmitter {
         }
       });
 
-    const branch = head.hash;
     const contents = constructOps(ops);
-    const protocol = metadata.next_protocol;
 
     return {
       opOb: {
-        branch,
+        branch: hash,
         contents,
         protocol,
       },

--- a/packages/taquito/src/parser/michel-codec-parser.ts
+++ b/packages/taquito/src/parser/michel-codec-parser.ts
@@ -10,7 +10,7 @@ export class MichelCodecParser implements ParserProvider {
   constructor(private context: Context) {}
 
   private async getNextProto(): Promise<ProtocolID> {
-    const { next_protocol } = await this.context.rpc.getBlockMetadata();
+    const next_protocol = await this.context.readProvider.getNextProtocol('head');
     return next_protocol as ProtocolID;
   }
 

--- a/packages/taquito/src/tz/rpc-tz-provider.ts
+++ b/packages/taquito/src/tz/rpc-tz-provider.ts
@@ -5,7 +5,13 @@ import { Operation } from '../operations/operations';
 import { RPCActivateOperation } from '../operations/types';
 import { TzProvider } from './interface';
 import { OpKind } from '@taquito/rpc';
-import { validateAddress, ValidationResult, validateKeyHash, InvalidAddressError, InvalidKeyHashError } from '@taquito/utils';
+import {
+  validateAddress,
+  ValidationResult,
+  validateKeyHash,
+  InvalidAddressError,
+  InvalidKeyHashError,
+} from '@taquito/utils';
 
 export class RpcTzProvider extends OperationEmitter implements TzProvider {
   constructor(context: Context) {
@@ -16,14 +22,14 @@ export class RpcTzProvider extends OperationEmitter implements TzProvider {
     if (validateAddress(address) !== ValidationResult.VALID) {
       throw new InvalidAddressError(`Invalid address: ${address}`);
     }
-    return this.rpc.getBalance(address);
+    return this.context.readProvider.getBalance(address, 'head');
   }
 
   async getDelegate(address: string): Promise<string | null> {
     if (validateAddress(address) !== ValidationResult.VALID) {
       throw new InvalidAddressError(`Invalid address: ${address}`);
     }
-    return this.rpc.getDelegate(address);
+    return this.context.readProvider.getDelegate(address, 'head');
   }
 
   async activate(pkh: string, secret: string) {

--- a/packages/taquito/test/batch/rpc-batch-provider.spec.ts
+++ b/packages/taquito/test/batch/rpc-batch-provider.spec.ts
@@ -1,354 +1,363 @@
-import { OperationBatch } from "../../src/batch/rpc-batch-provider";
-import { Context } from "../../src/context";
-import { Estimate } from "../../src/contract/estimate";
-import { OpKind, ParamsWithKind } from "../../src/operations/types";
+import { OperationBatch } from '../../src/batch/rpc-batch-provider';
+import { Context } from '../../src/context';
+import { Estimate } from '../../src/contract/estimate';
+import { OpKind, ParamsWithKind } from '../../src/operations/types';
 
 /**
  * OperationBatch test
  */
 describe('OperationBatch test', () => {
-    let mockRpcClient: {
-        getScript: jest.Mock<any, any>;
-        getStorage: jest.Mock<any, any>;
-        getBigMapExpr: jest.Mock<any, any>;
-        getBigMapKey: jest.Mock<any, any>;
-        getBlockHeader: jest.Mock<any, any>;
-        getEntrypoints: jest.Mock<any, any>;
-        getManagerKey: jest.Mock<any, any>;
-        getBlock: jest.Mock<any, any>;
-        getContract: jest.Mock<any, any>;
-        getBlockMetadata: jest.Mock<any, any>;
-        forgeOperations: jest.Mock<any, any>;
-        injectOperation: jest.Mock<any, any>;
-        packData: jest.Mock<any, any>;
-        preapplyOperations: jest.Mock<any, any>;
-        getChainId: jest.Mock<any, any>;
-        getSaplingDiffById: jest.Mock<any, any>;
+  let mockRpcClient: {
+    getScript: jest.Mock<any, any>;
+    getStorage: jest.Mock<any, any>;
+    getBigMapExpr: jest.Mock<any, any>;
+    getBigMapKey: jest.Mock<any, any>;
+    getBlockHeader: jest.Mock<any, any>;
+    getEntrypoints: jest.Mock<any, any>;
+    getManagerKey: jest.Mock<any, any>;
+    getBlock: jest.Mock<any, any>;
+    getContract: jest.Mock<any, any>;
+    getBlockMetadata: jest.Mock<any, any>;
+    forgeOperations: jest.Mock<any, any>;
+    injectOperation: jest.Mock<any, any>;
+    packData: jest.Mock<any, any>;
+    preapplyOperations: jest.Mock<any, any>;
+    getChainId: jest.Mock<any, any>;
+    getSaplingDiffById: jest.Mock<any, any>;
+    getProtocols: jest.Mock<any, any>;
+  };
+
+  let mockSigner: {
+    publicKeyHash: jest.Mock<any, any>;
+    publicKey: jest.Mock<any, any>;
+    sign: jest.Mock<any, any>;
+  };
+
+  let mockEstimate: {
+    originate: jest.Mock<any, any>;
+    transfer: jest.Mock<any, any>;
+    setDelegate: jest.Mock<any, any>;
+    registerDelegate: jest.Mock<any, any>;
+    batch: jest.Mock<any, any>;
+    reveal: jest.Mock<any, any>;
+    registerGlobalConstant: jest.Mock<any, any>;
+  };
+
+  beforeEach(() => {
+    mockRpcClient = {
+      getBigMapExpr: jest.fn(),
+      getEntrypoints: jest.fn(),
+      getBlock: jest.fn(),
+      getScript: jest.fn(),
+      getManagerKey: jest.fn(),
+      getStorage: jest.fn(),
+      getBigMapKey: jest.fn(),
+      getBlockHeader: jest.fn(),
+      getBlockMetadata: jest.fn(),
+      getContract: jest.fn(),
+      forgeOperations: jest.fn(),
+      injectOperation: jest.fn(),
+      packData: jest.fn(),
+      preapplyOperations: jest.fn(),
+      getChainId: jest.fn(),
+      getSaplingDiffById: jest.fn(),
+      getProtocols: jest.fn(),
     };
 
-    let mockSigner: {
-        publicKeyHash: jest.Mock<any, any>;
-        publicKey: jest.Mock<any, any>;
-        sign: jest.Mock<any, any>;
+    mockSigner = {
+      publicKeyHash: jest.fn(),
+      publicKey: jest.fn(),
+      sign: jest.fn(),
     };
 
-    let mockEstimate: {
-        originate: jest.Mock<any, any>;
-        transfer: jest.Mock<any, any>;
-        setDelegate: jest.Mock<any, any>;
-        registerDelegate: jest.Mock<any, any>;
-        batch: jest.Mock<any, any>;
-        reveal: jest.Mock<any, any>;
-        registerGlobalConstant: jest.Mock<any, any>;
+    mockEstimate = {
+      originate: jest.fn(),
+      transfer: jest.fn(),
+      registerDelegate: jest.fn(),
+      setDelegate: jest.fn(),
+      batch: jest.fn(),
+      reveal: jest.fn(),
+      registerGlobalConstant: jest.fn(),
     };
 
-    beforeEach(() => {
-        mockRpcClient = {
-            getBigMapExpr: jest.fn(),
-            getEntrypoints: jest.fn(),
-            getBlock: jest.fn(),
-            getScript: jest.fn(),
-            getManagerKey: jest.fn(),
-            getStorage: jest.fn(),
-            getBigMapKey: jest.fn(),
-            getBlockHeader: jest.fn(),
-            getBlockMetadata: jest.fn(),
-            getContract: jest.fn(),
-            forgeOperations: jest.fn(),
-            injectOperation: jest.fn(),
-            packData: jest.fn(),
-            preapplyOperations: jest.fn(),
-            getChainId: jest.fn(),
-            getSaplingDiffById: jest.fn()
-        };
+    // Required for operations confirmation polling
+    mockRpcClient.getBlock.mockResolvedValue({
+      operations: [[], [], [], []],
+      header: {
+        level: 0,
+      },
+    });
 
-        mockSigner = {
-            publicKeyHash: jest.fn(),
-            publicKey: jest.fn(),
-            sign: jest.fn(),
-        };
+    mockRpcClient.getContract.mockResolvedValue({ counter: 123456 });
+    mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+    mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getProtocols.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getManagerKey.mockResolvedValue('test');
+    mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
+    mockSigner.publicKey.mockResolvedValue('test_pub_key');
+    mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
+    mockRpcClient.preapplyOperations.mockResolvedValue([]);
+    mockRpcClient.getChainId.mockResolvedValue('chain-id');
+    mockRpcClient.injectOperation.mockResolvedValue(
+      'onwtjK2Q32ndjF9zbEPPtmifdBq5qB59wjMP2oCH22mARjyKnGP'
+    );
+  });
 
-        mockEstimate = {
-            originate: jest.fn(),
-            transfer: jest.fn(),
-            registerDelegate: jest.fn(),
-            setDelegate: jest.fn(),
-            batch: jest.fn(),
-            reveal: jest.fn(),
-            registerGlobalConstant: jest.fn()
-        };
+  describe('withRegisterGlobalConstant', () => {
+    it('should produce a batch operation which contains a registerGlobalConstant operation', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
 
-        // Required for operations confirmation polling
-        mockRpcClient.getBlock.mockResolvedValue({
-            operations: [[], [], [], []],
-            header: {
-                level: 0,
+      const operationBatch = new OperationBatch(
+        new Context(mockRpcClient as any, mockSigner as any),
+        mockEstimate as any
+      );
+
+      const batchOp = await operationBatch
+        .withRegisterGlobalConstant({ value: { int: '2' } })
+        .send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { int: '2' },
+              counter: '123457',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
             },
-        });
-
-        mockRpcClient.getContract.mockResolvedValue({ counter: 123456 });
-        mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
-        mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
-        mockRpcClient.getManagerKey.mockResolvedValue('test');
-        mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
-        mockSigner.publicKey.mockResolvedValue('test_pub_key');
-        mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
-        mockRpcClient.preapplyOperations.mockResolvedValue([]);
-        mockRpcClient.getChainId.mockResolvedValue('chain-id');
-        mockRpcClient.injectOperation.mockResolvedValue('onwtjK2Q32ndjF9zbEPPtmifdBq5qB59wjMP2oCH22mARjyKnGP')
-
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
     });
 
-    describe('withRegisterGlobalConstant', () => {
-        it('should produce a batch operation which contains a registerGlobalConstant operation', async done => {
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimate]);
+    it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const operationBatch = new OperationBatch(
+        new Context(mockRpcClient as any, mockSigner as any),
+        mockEstimate as any
+      );
 
-            const batchOp = await operationBatch.withRegisterGlobalConstant({ value: { int: '2' } }).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { int: '2' },
-                            counter: '123457',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+      const batchOp = await operationBatch
+        .withRegisterGlobalConstant({
+          value: { int: '2' },
+          fee: 500,
+          gasLimit: 1400,
+          storageLimit: 100,
+        })
+        .send();
 
-        it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async done => {
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimate]);
-
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
-
-            const batchOp = await operationBatch.withRegisterGlobalConstant({
-                value: { int: '2' },
-                fee: 500,
-                gasLimit: 1400,
-                storageLimit: 100
-            }).send();
-
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { int: '2' },
-                            counter: '123457',
-                            fee: '500',
-                            gas_limit: '1400',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '100',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
-
-        it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async done => {
-            mockRpcClient.getManagerKey.mockResolvedValue(null);
-            const estimateReveal = new Estimate(1000000, 0, 64, 250);
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
-
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
-
-            const batchOp = await operationBatch.withRegisterGlobalConstant({ value: { int: '2' } }).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            counter: '123457',
-                            fee: '374',
-                            gas_limit: '1100',
-                            kind: 'reveal',
-                            public_key: 'test_pub_key',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '0',
-                        },
-                        {
-                            value: { int: '2' },
-                            counter: '123458',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { int: '2' },
+              counter: '123457',
+              fee: '500',
+              gas_limit: '1400',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '100',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
     });
 
-    describe('with', () => {
-        it('should produce a batch operation which contains a registerGlobalConstant operation', async done => {
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimate]);
+    it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async (done) => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      const estimateReveal = new Estimate(1000000, 0, 64, 250);
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const operationBatch = new OperationBatch(
+        new Context(mockRpcClient as any, mockSigner as any),
+        mockEstimate as any
+      );
 
-            const opToBatch: ParamsWithKind[] = [
-                {
-                    kind: OpKind.REGISTER_GLOBAL_CONSTANT,
-                    value: { string: 'test' },
-                },
-            ];
+      const batchOp = await operationBatch
+        .withRegisterGlobalConstant({ value: { int: '2' } })
+        .send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              counter: '123457',
+              fee: '374',
+              gas_limit: '1100',
+              kind: 'reveal',
+              public_key: 'test_pub_key',
+              source: 'test_pub_key_hash',
+              storage_limit: '0',
+            },
+            {
+              value: { int: '2' },
+              counter: '123458',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
+  });
 
-            const batchOp = await operationBatch.with(opToBatch).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { string: 'test' },
-                            counter: '123457',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+  describe('with', () => {
+    it('should produce a batch operation which contains a registerGlobalConstant operation', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
 
-        it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async done => {
+      const operationBatch = new OperationBatch(
+        new Context(mockRpcClient as any, mockSigner as any),
+        mockEstimate as any
+      );
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: { string: 'test' },
+        },
+      ];
 
-            const opToBatch: ParamsWithKind[] = [
-                {
-                    kind: OpKind.REGISTER_GLOBAL_CONSTANT,
-                    value: { string: 'test' },
-                    fee: 500,
-                    gasLimit: 1400,
-                    storageLimit: 100
-                },
-            ];
+      const batchOp = await operationBatch.with(opToBatch).send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { string: 'test' },
+              counter: '123457',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
 
-            const batchOp = await operationBatch.with(opToBatch).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { string: 'test' },
-                            counter: '123457',
-                            fee: '500',
-                            gas_limit: '1400',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '100',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+    it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async (done) => {
+      const operationBatch = new OperationBatch(
+        new Context(mockRpcClient as any, mockSigner as any),
+        mockEstimate as any
+      );
 
-        it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async done => {
-            mockRpcClient.getManagerKey.mockResolvedValue(null);
-            const estimateReveal = new Estimate(1000000, 0, 64, 250);
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: { string: 'test' },
+          fee: 500,
+          gasLimit: 1400,
+          storageLimit: 100,
+        },
+      ];
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const batchOp = await operationBatch.with(opToBatch).send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { string: 'test' },
+              counter: '123457',
+              fee: '500',
+              gas_limit: '1400',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '100',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
 
-            const opToBatch: ParamsWithKind[] = [
-                {
-                    kind: OpKind.REGISTER_GLOBAL_CONSTANT,
-                    value: { string: 'test' },
-                },
-            ];
+    it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async (done) => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      const estimateReveal = new Estimate(1000000, 0, 64, 250);
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
 
-            const batchOp = await operationBatch.with(opToBatch).send();
+      const operationBatch = new OperationBatch(
+        new Context(mockRpcClient as any, mockSigner as any),
+        mockEstimate as any
+      );
 
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            counter: '123457',
-                            fee: '374',
-                            gas_limit: '1100',
-                            kind: 'reveal',
-                            public_key: 'test_pub_key',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '0',
-                        },
-                        {
-                            value: { string: "test" },
-                            counter: '123458',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
-    })
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: { string: 'test' },
+        },
+      ];
+
+      const batchOp = await operationBatch.with(opToBatch).send();
+
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              counter: '123457',
+              fee: '374',
+              gas_limit: '1100',
+              kind: 'reveal',
+              public_key: 'test_pub_key',
+              source: 'test_pub_key_hash',
+              storage_limit: '0',
+            },
+            {
+              value: { string: 'test' },
+              counter: '123458',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
+  });
 });

--- a/packages/taquito/test/contract/contract-abstraction-composer.spec.ts
+++ b/packages/taquito/test/contract/contract-abstraction-composer.spec.ts
@@ -27,7 +27,7 @@ describe('Contract abstraction composer test', () => {
     mockRpcClient = {
       getNormalizedScript: jest.fn(),
       getEntrypoints: jest.fn(),
-      getBlockHeader: jest.fn(),
+      getChainId: jest.fn(),
     };
 
     mockRpcClient.getNormalizedScript.mockResolvedValue(script);
@@ -36,14 +36,17 @@ describe('Contract abstraction composer test', () => {
         mint: { prim: 'pair', args: [{ prim: 'key' }, { prim: 'nat' }] },
       },
     });
-    mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+    mockRpcClient.getChainId.mockResolvedValue('test');
 
     toolkit = new TezosToolkit('url');
     toolkit['_context'].rpc = mockRpcClient;
   });
 
   it('Should add a helloWorld method on the contract abstraction', async (done) => {
-    const result = await toolkit.contract.at('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D', composeContractAbstractionTest);
+    const result = await toolkit.contract.at(
+      'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+      composeContractAbstractionTest
+    );
     expect(result.constractAbstractionTest().helloWorld()).toEqual('Hello World!');
     done();
   });

--- a/packages/taquito/test/contract/contractAbstraction.spec.ts
+++ b/packages/taquito/test/contract/contractAbstraction.spec.ts
@@ -12,18 +12,18 @@ import { OnChainView } from '../../src/contract/contract-methods/contract-on-cha
 describe('ContractAbstraction test', () => {
   let rpcContractProvider: RpcContractProvider;
   let mockRpcClient: {};
+  let mockReadProvider: {};
   let mockSigner: {};
   let mockEstimate: {};
 
   beforeEach(() => {
     mockRpcClient = {};
+    mockReadProvider = {};
     mockSigner = {};
     mockEstimate = {};
-    rpcContractProvider = new RpcContractProvider(
-      // deepcode ignore no-any: any is good enough
-      new Context(mockRpcClient as any, mockSigner as any),
-      mockEstimate as any
-    );
+    const context = new Context(mockRpcClient as any, mockSigner as any);
+    context.readProvider = mockReadProvider as any;
+    rpcContractProvider = new RpcContractProvider(context, mockEstimate as any);
   });
 
   describe('Calling the `toTansferParams` method on a `ContractMethod` and a `ContractMethodObject` should return the same value', () => {
@@ -38,7 +38,8 @@ describe('ContractAbstraction test', () => {
         rpcContractProvider,
         entrypointsGenericMultisig,
         'chain_test',
-        mockRpcClient as any
+        mockRpcClient as any,
+        mockReadProvider as any
       );
 
       // Calling the smart contract main method using flat arguments
@@ -168,7 +169,8 @@ describe('ContractAbstraction test', () => {
         rpcContractProvider,
         entrypointsGenericMultisig,
         'chain_test',
-        mockRpcClient as any
+        mockRpcClient as any,
+        mockReadProvider as any
       );
 
       // Calling the smart contract main method using flat arguments
@@ -300,7 +302,8 @@ describe('ContractAbstraction test', () => {
         rpcContractProvider,
         { entrypoints: {} },
         'chain_test',
-        mockRpcClient as any
+        mockRpcClient as any,
+        mockReadProvider as any
       );
 
       const method0 = contratcAbs.methods[0](
@@ -376,7 +379,8 @@ describe('ContractAbstraction test', () => {
         rpcContractProvider,
         { entrypoints: {} },
         'chain_test',
-        mockRpcClient as any
+        mockRpcClient as any,
+        mockReadProvider as any
       );
 
       const method2 = contratcAbs.methods[2]('tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', '1');
@@ -468,7 +472,8 @@ describe('ContractAbstraction test', () => {
         rpcContractProvider,
         { entrypoints: {} },
         'chain_test',
-        mockRpcClient as any
+        mockRpcClient as any,
+        mockReadProvider as any
       );
 
       expect(Object.keys(contratcAbs.contractViews).length).toEqual(2);

--- a/packages/taquito/test/contract/contractView.spec.ts
+++ b/packages/taquito/test/contract/contractView.spec.ts
@@ -10,7 +10,7 @@ describe('ContractView test', () => {
     getNormalizedScript: jest.Mock<any, any>;
     getStorage: jest.Mock<any, any>;
     getEntrypoints: jest.Mock<any, any>;
-    getBlockHeader: jest.Mock<any, any>;
+    getChainId: jest.Mock<any, any>;
   };
 
   let mockSigner: {
@@ -31,7 +31,7 @@ describe('ContractView test', () => {
       getEntrypoints: jest.fn(),
       getNormalizedScript: jest.fn(),
       getStorage: jest.fn(),
-      getBlockHeader: jest.fn(),
+      getChainId: jest.fn(),
     };
 
     mockSigner = {
@@ -52,24 +52,7 @@ describe('ContractView test', () => {
       mockEstimate as any
     );
 
-    mockRpcClient.getBlockHeader.mockResolvedValue({
-      protocol: 'PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb',
-      chain_id: 'NetXjD3HPJJjmcd',
-      hash: 'BMCnvCbzC9v4HxTXWpUpaA7hooFVkQGfg16zMgzeb3eUNVB58S1',
-      level: 847136,
-      proto: 2,
-      predecessor: 'BLqnKLAfqAf5pjoVMkj4VztdmmksSu3fx3q2eRTwTRL2CGvgws2',
-      timestamp: '2020-11-04T18:39:20Z',
-      validation_pass: 4,
-      operations_hash: 'LLoZpwx6pGPmWYdSns1WHJ9GL4UFxGdjn9nWL3KFvXNKa2ioHuXSb',
-      fitness: ['01', '00000000000ced1f'],
-      context: 'CoVmCTMPFiauJwp59yFm45K3LCKNJeeSzhBggF6nVJgrrnPTxyTV',
-      priority: 0,
-      proof_of_work_nonce: '7073f75508b30400',
-      seed_nonce_hash: 'nceUd4hqZULXQPyioXpWBsv2qVEAf77wP52impoDVPF6rgG1X1R48',
-      signature:
-        'siguQC9rv8ZRoH7jsxQPDiQN37GPKccxsVaqgRSDuTsfbjX4NcHgx9MS1CEfQYK7PgSxfjokia6ZRpdGJnde1y3BPjpKeftf',
-    });
+    mockRpcClient.getChainId.mockResolvedValue('NetXjD3HPJJjmcd');
     mockRpcClient.getNormalizedScript.mockResolvedValue({
       code: tokenCode,
       storage: tokenInit,

--- a/packages/taquito/test/contract/data-lambda-view-class.ts
+++ b/packages/taquito/test/contract/data-lambda-view-class.ts
@@ -1,1110 +1,1034 @@
 export const script = {
-    code: [
+  code: [
+    {
+      prim: 'parameter',
+      args: [
         {
-            prim: "parameter",
-            args: [
-                {
-                    prim: "or",
-                    args: [
-                        {
-                            prim: "or",
-                            args: [
-                                {
-                                    prim: "or",
-                                    args: [
-                                        {
-                                            prim: "pair",
-                                            args: [{ prim: "address" }, { prim: "nat" }],
-                                            annots: ["%approve"],
-                                        },
-                                        {
-                                            prim: "pair",
-                                            args: [
-                                                {
-                                                    prim: "pair",
-                                                    args: [{ prim: "address" }, { prim: "address" }],
-                                                },
-                                                { prim: "contract", args: [{ prim: "nat" }] },
-                                            ],
-                                            annots: ["%getAllowance"],
-                                        },
-                                    ],
-                                },
-                                {
-                                    prim: "or",
-                                    args: [
-                                        {
-                                            prim: "pair",
-                                            args: [
-                                                { prim: "address" },
-                                                { prim: "contract", args: [{ prim: "nat" }] },
-                                            ],
-                                            annots: ["%getBalance"],
-                                        },
-                                        {
-                                            prim: "pair",
-                                            args: [
-                                                { prim: "unit" },
-                                                { prim: "contract", args: [{ prim: "nat" }] },
-                                            ],
-                                            annots: ["%getTotalSupply"],
-                                        },
-                                    ],
-                                },
-                            ],
-                        },
-                        {
-                            prim: "or",
-                            args: [
-                                { prim: "nat", annots: ["%mint"] },
-                                {
-                                    prim: "pair",
-                                    args: [
-                                        {
-                                            prim: "pair",
-                                            args: [{ prim: "address" }, { prim: "address" }],
-                                        },
-                                        { prim: "nat" },
-                                    ],
-                                    annots: ["%transfer"],
-                                },
-                            ],
-                        },
-                    ],
-                },
-            ],
-        },
-        {
-            prim: "storage",
-            args: [
-                {
-                    prim: "pair",
-                    args: [
-                        {
-                            prim: "pair",
-                            args: [
-                                {
-                                    prim: "big_map",
-                                    args: [
-                                        { prim: "address" },
-                                        {
-                                            prim: "pair",
-                                            args: [
-                                                {
-                                                    prim: "map",
-                                                    args: [{ prim: "address" }, { prim: "nat" }],
-                                                    annots: ["%allowances"],
-                                                },
-                                                { prim: "nat", annots: ["%balance"] },
-                                            ],
-                                        },
-                                    ],
-                                    annots: ["%ledger"],
-                                },
-                                { prim: "address", annots: ["%owner"] },
-                            ],
-                        },
-                        { prim: "nat", annots: ["%totalSupply"] },
-                    ],
-                },
-            ],
-        },
-        {
-            prim: "code",
-            args: [
-                [
-                    { prim: "DUP" },
-                    { prim: "CDR" },
-                    { prim: "PUSH", args: [{ prim: "mutez" }, { int: "0" }] },
-                    { prim: "AMOUNT" },
-                    { prim: "COMPARE" },
-                    { prim: "NEQ" },
-                    {
-                        prim: "IF",
-                        args: [
-                            [
-                                { prim: "DROP", args: [{ int: "2" }] },
-                                {
-                                    prim: "PUSH",
-                                    args: [
-                                        { prim: "string" },
-                                        { string: "This contract do not accept token" },
-                                    ],
-                                },
-                                { prim: "FAILWITH" },
-                            ],
-                            [
-                                { prim: "SWAP" },
-                                { prim: "CAR" },
-                                {
-                                    prim: "IF_LEFT",
-                                    args: [
-                                        [
-                                            {
-                                                prim: "IF_LEFT",
-                                                args: [
-                                                    [
-                                                        {
-                                                            prim: "IF_LEFT",
-                                                            args: [
-                                                                [
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "3" }] },
-                                                                    { prim: "SENDER" },
-                                                                    { prim: "COMPARE" },
-                                                                    { prim: "EQ" },
-                                                                    {
-                                                                        prim: "IF",
-                                                                        args: [
-                                                                            [
-                                                                                { prim: "DROP", args: [{ int: "3" }] },
-                                                                                {
-                                                                                    prim: "PUSH",
-                                                                                    args: [
-                                                                                        { prim: "string" },
-                                                                                        { string: "SameOwnerAndSpender" },
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "FAILWITH" },
-                                                                            ],
-                                                                            [
-                                                                                { prim: "DUP" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "SENDER" },
-                                                                                { prim: "GET" },
-                                                                                {
-                                                                                    prim: "IF_NONE",
-                                                                                    args: [
-                                                                                        [
-                                                                                            {
-                                                                                                prim: "PUSH",
-                                                                                                args: [
-                                                                                                    { prim: "string" },
-                                                                                                    { string: "NoAccount" },
-                                                                                                ],
-                                                                                            },
-                                                                                            { prim: "FAILWITH" },
-                                                                                        ],
-                                                                                        [],
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "DIG", args: [{ int: "4" }] },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DUG", args: [{ int: "5" }] },
-                                                                                { prim: "GET" },
-                                                                                {
-                                                                                    prim: "IF_NONE",
-                                                                                    args: [
-                                                                                        [
-                                                                                            { prim: "DUP" },
-                                                                                            { prim: "CAR" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "3" }],
-                                                                                            },
-                                                                                            { prim: "SOME" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "4" }],
-                                                                                            },
-                                                                                            { prim: "UPDATE" },
-                                                                                        ],
-                                                                                        [
-                                                                                            {
-                                                                                                prim: "PUSH",
-                                                                                                args: [
-                                                                                                    { prim: "nat" },
-                                                                                                    { int: "0" },
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "4" }],
-                                                                                            },
-                                                                                            { prim: "DUP" },
-                                                                                            {
-                                                                                                prim: "DUG",
-                                                                                                args: [{ int: "5" }],
-                                                                                            },
-                                                                                            { prim: "COMPARE" },
-                                                                                            { prim: "GT" },
-                                                                                            {
-                                                                                                prim: "PUSH",
-                                                                                                args: [
-                                                                                                    { prim: "nat" },
-                                                                                                    { int: "0" },
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "2" }],
-                                                                                            },
-                                                                                            { prim: "COMPARE" },
-                                                                                            { prim: "GT" },
-                                                                                            { prim: "AND" },
-                                                                                            {
-                                                                                                prim: "IF",
-                                                                                                args: [
-                                                                                                    [
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "DROP" },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "DROP" },
-                                                                                                        {
-                                                                                                            prim: "PUSH",
-                                                                                                            args: [
-                                                                                                                { prim: "string" },
-                                                                                                                {
-                                                                                                                    string:
-                                                                                                                        "UnsafeAllowanceChange",
-                                                                                                                },
-                                                                                                            ],
-                                                                                                        },
-                                                                                                        { prim: "FAILWITH" },
-                                                                                                    ],
-                                                                                                    [
-                                                                                                        { prim: "DUP" },
-                                                                                                        { prim: "CAR" },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "3" }],
-                                                                                                        },
-                                                                                                        { prim: "SOME" },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "4" }],
-                                                                                                        },
-                                                                                                        { prim: "UPDATE" },
-                                                                                                    ],
-                                                                                                ],
-                                                                                            },
-                                                                                        ],
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "DIG", args: [{ int: "2" }] },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "DIG", args: [{ int: "3" }] },
-                                                                                { prim: "DIG", args: [{ int: "3" }] },
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "CDR" },
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "PAIR" },
-                                                                                { prim: "SOME" },
-                                                                                { prim: "SENDER" },
-                                                                                { prim: "UPDATE" },
-                                                                                {
-                                                                                    prim: "DIP",
-                                                                                    args: [
-                                                                                        [
-                                                                                            { prim: "DUP" },
-                                                                                            { prim: "CDR" },
-                                                                                            { prim: "SWAP" },
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "CDR" },
-                                                                                        ],
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "PAIR" },
-                                                                                { prim: "PAIR" },
-                                                                            ],
-                                                                        ],
-                                                                    },
-                                                                    {
-                                                                        prim: "NIL",
-                                                                        args: [{ prim: "operation" }],
-                                                                    },
-                                                                    { prim: "PAIR" },
-                                                                ],
-                                                                [
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "3" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "3" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "DIG", args: [{ int: "3" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "GET" },
-                                                                    {
-                                                                        prim: "IF_NONE",
-                                                                        args: [
-                                                                            [
-                                                                                {
-                                                                                    prim: "PUSH",
-                                                                                    args: [
-                                                                                        { prim: "string" },
-                                                                                        { string: "NoAccount" },
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "FAILWITH" },
-                                                                            ],
-                                                                            [],
-                                                                        ],
-                                                                    },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "GET" },
-                                                                    {
-                                                                        prim: "IF_NONE",
-                                                                        args: [
-                                                                            [
-                                                                                {
-                                                                                    prim: "PUSH",
-                                                                                    args: [
-                                                                                        { prim: "string" },
-                                                                                        { string: "NoAccount" },
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "FAILWITH" },
-                                                                            ],
-                                                                            [],
-                                                                        ],
-                                                                    },
-                                                                    {
-                                                                        prim: "NIL",
-                                                                        args: [{ prim: "operation" }],
-                                                                    },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "CAR" },
-                                                                    {
-                                                                        prim: "PUSH",
-                                                                        args: [{ prim: "mutez" }, { int: "0" }],
-                                                                    },
-                                                                    { prim: "DIG", args: [{ int: "3" }] },
-                                                                    { prim: "TRANSFER_TOKENS" },
-                                                                    { prim: "CONS" },
-                                                                    { prim: "PAIR" },
-                                                                ],
-                                                            ],
-                                                        },
-                                                    ],
-                                                    [
-                                                        {
-                                                            prim: "IF_LEFT",
-                                                            args: [
-                                                                [
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "GET" },
-                                                                    {
-                                                                        prim: "IF_NONE",
-                                                                        args: [
-                                                                            [
-                                                                                {
-                                                                                    prim: "PUSH",
-                                                                                    args: [
-                                                                                        { prim: "string" },
-                                                                                        { string: "NoAccount" },
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "FAILWITH" },
-                                                                            ],
-                                                                            [],
-                                                                        ],
-                                                                    },
-                                                                    {
-                                                                        prim: "NIL",
-                                                                        args: [{ prim: "operation" }],
-                                                                    },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CDR" },
-                                                                    {
-                                                                        prim: "PUSH",
-                                                                        args: [{ prim: "mutez" }, { int: "0" }],
-                                                                    },
-                                                                    { prim: "DIG", args: [{ int: "3" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "TRANSFER_TOKENS" },
-                                                                    { prim: "CONS" },
-                                                                    { prim: "PAIR" },
-                                                                ],
-                                                                [
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "PAIR" },
-                                                                    {
-                                                                        prim: "NIL",
-                                                                        args: [{ prim: "operation" }],
-                                                                    },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    {
-                                                                        prim: "PUSH",
-                                                                        args: [{ prim: "mutez" }, { int: "0" }],
-                                                                    },
-                                                                    { prim: "DIG", args: [{ int: "3" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "TRANSFER_TOKENS" },
-                                                                    { prim: "CONS" },
-                                                                    { prim: "PAIR" },
-                                                                ],
-                                                            ],
-                                                        },
-                                                    ],
-                                                ],
-                                            },
-                                        ],
-                                        [
-                                            {
-                                                prim: "IF_LEFT",
-                                                args: [
-                                                    [
-                                                        { prim: "SWAP" },
-                                                        { prim: "DUP" },
-                                                        { prim: "CAR" },
-                                                        { prim: "CDR" },
-                                                        { prim: "SENDER" },
-                                                        { prim: "COMPARE" },
-                                                        { prim: "NEQ" },
-                                                        {
-                                                            prim: "IF",
-                                                            args: [
-                                                                [
-                                                                    { prim: "DROP", args: [{ int: "2" }] },
-                                                                    {
-                                                                        prim: "PUSH",
-                                                                        args: [
-                                                                            { prim: "string" },
-                                                                            { string: "UnauthorizedAccess" },
-                                                                        ],
-                                                                    },
-                                                                    { prim: "FAILWITH" },
-                                                                ],
-                                                                [
-                                                                    { prim: "DUP" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "GET" },
-                                                                    {
-                                                                        prim: "IF_NONE",
-                                                                        args: [
-                                                                            [
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DUG", args: [{ int: "2" }] },
-                                                                                {
-                                                                                    prim: "EMPTY_MAP",
-                                                                                    args: [
-                                                                                        { prim: "address" },
-                                                                                        { prim: "nat" },
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "PAIR" },
-                                                                            ],
-                                                                            [
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DIG", args: [{ int: "3" }] },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DUG", args: [{ int: "4" }] },
-                                                                                { prim: "DIG", args: [{ int: "2" }] },
-                                                                                { prim: "CDR" },
-                                                                                { prim: "ADD" },
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "PAIR" },
-                                                                            ],
-                                                                        ],
-                                                                    },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "3" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "SOME" },
-                                                                    { prim: "DIG", args: [{ int: "3" }] },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "4" }] },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "UPDATE" },
-                                                                    {
-                                                                        prim: "DIP",
-                                                                        args: [
-                                                                            [
-                                                                                { prim: "DUP" },
-                                                                                { prim: "CDR" },
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "CDR" },
-                                                                            ],
-                                                                        ],
-                                                                    },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "DUG", args: [{ int: "2" }] },
-                                                                    { prim: "CDR" },
-                                                                    { prim: "ADD" },
-                                                                    { prim: "SWAP" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "PAIR" },
-                                                                ],
-                                                            ],
-                                                        },
-                                                        { prim: "NIL", args: [{ prim: "operation" }] },
-                                                        { prim: "PAIR" },
-                                                    ],
-                                                    [
-                                                        { prim: "DUP" },
-                                                        { prim: "DUG", args: [{ int: "2" }] },
-                                                        { prim: "CDR" },
-                                                        { prim: "PAIR" },
-                                                        { prim: "SWAP" },
-                                                        { prim: "DUP" },
-                                                        { prim: "DUG", args: [{ int: "2" }] },
-                                                        { prim: "CAR" },
-                                                        { prim: "CDR" },
-                                                        { prim: "DIG", args: [{ int: "2" }] },
-                                                        { prim: "CAR" },
-                                                        { prim: "CAR" },
-                                                        { prim: "PAIR" },
-                                                        { prim: "PAIR" },
-                                                        { prim: "DUP" },
-                                                        { prim: "CAR" },
-                                                        { prim: "CAR" },
-                                                        { prim: "SWAP" },
-                                                        { prim: "DUP" },
-                                                        { prim: "DUG", args: [{ int: "2" }] },
-                                                        { prim: "CAR" },
-                                                        { prim: "CDR" },
-                                                        { prim: "DIG", args: [{ int: "2" }] },
-                                                        { prim: "DUP" },
-                                                        { prim: "DUG", args: [{ int: "3" }] },
-                                                        { prim: "CDR" },
-                                                        { prim: "CAR" },
-                                                        { prim: "DIG", args: [{ int: "3" }] },
-                                                        { prim: "CDR" },
-                                                        { prim: "CDR" },
-                                                        { prim: "DIG", args: [{ int: "2" }] },
-                                                        { prim: "DUP" },
-                                                        { prim: "DUG", args: [{ int: "3" }] },
-                                                        { prim: "DIG", args: [{ int: "4" }] },
-                                                        { prim: "DUP" },
-                                                        { prim: "DUG", args: [{ int: "5" }] },
-                                                        { prim: "COMPARE" },
-                                                        { prim: "EQ" },
-                                                        {
-                                                            prim: "IF",
-                                                            args: [
-                                                                [
-                                                                    { prim: "DROP", args: [{ int: "4" }] },
-                                                                    {
-                                                                        prim: "PUSH",
-                                                                        args: [
-                                                                            { prim: "string" },
-                                                                            { string: "SameOriginAndDestination" },
-                                                                        ],
-                                                                    },
-                                                                    { prim: "FAILWITH" },
-                                                                ],
-                                                                [
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DIG", args: [{ int: "2" }] },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "3" }] },
-                                                                    { prim: "DIG", args: [{ int: "5" }] },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "DUG", args: [{ int: "6" }] },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "PAIR" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "CAR" },
-                                                                    { prim: "DUP" },
-                                                                    { prim: "SENDER" },
-                                                                    { prim: "COMPARE" },
-                                                                    { prim: "NEQ" },
-                                                                    {
-                                                                        prim: "IF",
-                                                                        args: [
-                                                                            [
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DUG", args: [{ int: "2" }] },
-                                                                                { prim: "CDR" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "SWAP" },
-                                                                                { prim: "GET" },
-                                                                                {
-                                                                                    prim: "IF_NONE",
-                                                                                    args: [
-                                                                                        [
-                                                                                            { prim: "DROP" },
-                                                                                            {
-                                                                                                prim: "PUSH",
-                                                                                                args: [
-                                                                                                    { prim: "bool" },
-                                                                                                    { prim: "False" },
-                                                                                                ],
-                                                                                            },
-                                                                                        ],
-                                                                                        [
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "SENDER" },
-                                                                                            { prim: "GET" },
-                                                                                            {
-                                                                                                prim: "IF_NONE",
-                                                                                                args: [
-                                                                                                    [
-                                                                                                        { prim: "DROP" },
-                                                                                                        {
-                                                                                                            prim: "PUSH",
-                                                                                                            args: [
-                                                                                                                { prim: "bool" },
-                                                                                                                { prim: "False" },
-                                                                                                            ],
-                                                                                                        },
-                                                                                                    ],
-                                                                                                    [
-                                                                                                        { prim: "SWAP" },
-                                                                                                        { prim: "CAR" },
-                                                                                                        { prim: "CDR" },
-                                                                                                        { prim: "SWAP" },
-                                                                                                        { prim: "COMPARE" },
-                                                                                                        { prim: "GE" },
-                                                                                                    ],
-                                                                                                ],
-                                                                                            },
-                                                                                        ],
-                                                                                    ],
-                                                                                },
-                                                                            ],
-                                                                            [
-                                                                                { prim: "DROP", args: [{ int: "2" }] },
-                                                                                {
-                                                                                    prim: "PUSH",
-                                                                                    args: [
-                                                                                        { prim: "bool" },
-                                                                                        { prim: "True" },
-                                                                                    ],
-                                                                                },
-                                                                            ],
-                                                                        ],
-                                                                    },
-                                                                    { prim: "NOT" },
-                                                                    {
-                                                                        prim: "IF",
-                                                                        args: [
-                                                                            [
-                                                                                { prim: "DROP", args: [{ int: "4" }] },
-                                                                                {
-                                                                                    prim: "PUSH",
-                                                                                    args: [
-                                                                                        { prim: "string" },
-                                                                                        { string: "NotEnoughAllowance" },
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "FAILWITH" },
-                                                                            ],
-                                                                            [
-                                                                                { prim: "DUP" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "CAR" },
-                                                                                { prim: "DIG", args: [{ int: "4" }] },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DUG", args: [{ int: "5" }] },
-                                                                                { prim: "GET" },
-                                                                                {
-                                                                                    prim: "IF_NONE",
-                                                                                    args: [
-                                                                                        [
-                                                                                            {
-                                                                                                prim: "PUSH",
-                                                                                                args: [
-                                                                                                    { prim: "string" },
-                                                                                                    { string: "NoAccount" },
-                                                                                                ],
-                                                                                            },
-                                                                                            { prim: "FAILWITH" },
-                                                                                        ],
-                                                                                        [],
-                                                                                    ],
-                                                                                },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "CDR" },
-                                                                                { prim: "DIG", args: [{ int: "3" }] },
-                                                                                { prim: "DUP" },
-                                                                                { prim: "DUG", args: [{ int: "4" }] },
-                                                                                { prim: "COMPARE" },
-                                                                                { prim: "GT" },
-                                                                                {
-                                                                                    prim: "IF",
-                                                                                    args: [
-                                                                                        [
-                                                                                            {
-                                                                                                prim: "DROP",
-                                                                                                args: [{ int: "5" }],
-                                                                                            },
-                                                                                            {
-                                                                                                prim: "PUSH",
-                                                                                                args: [
-                                                                                                    { prim: "string" },
-                                                                                                    {
-                                                                                                        string: "NotEnoughBalance",
-                                                                                                    },
-                                                                                                ],
-                                                                                            },
-                                                                                            { prim: "FAILWITH" },
-                                                                                        ],
-                                                                                        [
-                                                                                            { prim: "DUP" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "3" }],
-                                                                                            },
-                                                                                            { prim: "DUP" },
-                                                                                            {
-                                                                                                prim: "DUG",
-                                                                                                args: [{ int: "4" }],
-                                                                                            },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "2" }],
-                                                                                            },
-                                                                                            { prim: "CDR" },
-                                                                                            { prim: "SUB" },
-                                                                                            { prim: "ABS" },
-                                                                                            { prim: "SWAP" },
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "PAIR" },
-                                                                                            { prim: "SWAP" },
-                                                                                            { prim: "DUP" },
-                                                                                            {
-                                                                                                prim: "DUG",
-                                                                                                args: [{ int: "2" }],
-                                                                                            },
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "CAR" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "4" }],
-                                                                                            },
-                                                                                            { prim: "DUP" },
-                                                                                            {
-                                                                                                prim: "DUG",
-                                                                                                args: [{ int: "5" }],
-                                                                                            },
-                                                                                            { prim: "GET" },
-                                                                                            {
-                                                                                                prim: "IF_NONE",
-                                                                                                args: [
-                                                                                                    [
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "DUP" },
-                                                                                                        {
-                                                                                                            prim: "DUG",
-                                                                                                            args: [{ int: "3" }],
-                                                                                                        },
-                                                                                                        {
-                                                                                                            prim: "EMPTY_MAP",
-                                                                                                            args: [
-                                                                                                                { prim: "address" },
-                                                                                                                { prim: "nat" },
-                                                                                                            ],
-                                                                                                        },
-                                                                                                        { prim: "PAIR" },
-                                                                                                    ],
-                                                                                                    [
-                                                                                                        { prim: "DUP" },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "4" }],
-                                                                                                        },
-                                                                                                        { prim: "DUP" },
-                                                                                                        {
-                                                                                                            prim: "DUG",
-                                                                                                            args: [{ int: "5" }],
-                                                                                                        },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "CDR" },
-                                                                                                        { prim: "ADD" },
-                                                                                                        { prim: "SWAP" },
-                                                                                                        { prim: "CAR" },
-                                                                                                        { prim: "PAIR" },
-                                                                                                    ],
-                                                                                                ],
-                                                                                            },
-                                                                                            { prim: "SWAP" },
-                                                                                            { prim: "DUP" },
-                                                                                            {
-                                                                                                prim: "DUG",
-                                                                                                args: [{ int: "2" }],
-                                                                                            },
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "SENDER" },
-                                                                                            { prim: "GET" },
-                                                                                            {
-                                                                                                prim: "IF_NONE",
-                                                                                                args: [
-                                                                                                    [
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "3" }],
-                                                                                                        },
-                                                                                                        { prim: "DROP" },
-                                                                                                        { prim: "SWAP" },
-                                                                                                        { prim: "DUP" },
-                                                                                                        {
-                                                                                                            prim: "DUG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "CAR" },
-                                                                                                    ],
-                                                                                                    [
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "DUP" },
-                                                                                                        {
-                                                                                                            prim: "DUG",
-                                                                                                            args: [{ int: "3" }],
-                                                                                                        },
-                                                                                                        { prim: "CAR" },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "5" }],
-                                                                                                        },
-                                                                                                        {
-                                                                                                            prim: "DIG",
-                                                                                                            args: [{ int: "2" }],
-                                                                                                        },
-                                                                                                        { prim: "SUB" },
-                                                                                                        { prim: "ABS" },
-                                                                                                        { prim: "SOME" },
-                                                                                                        { prim: "SENDER" },
-                                                                                                        { prim: "UPDATE" },
-                                                                                                    ],
-                                                                                                ],
-                                                                                            },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "3" }],
-                                                                                            },
-                                                                                            { prim: "DUP" },
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "CAR" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "4" }],
-                                                                                            },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "3" }],
-                                                                                            },
-                                                                                            { prim: "SWAP" },
-                                                                                            { prim: "CDR" },
-                                                                                            { prim: "SWAP" },
-                                                                                            { prim: "PAIR" },
-                                                                                            { prim: "SOME" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "5" }],
-                                                                                            },
-                                                                                            { prim: "UPDATE" },
-                                                                                            {
-                                                                                                prim: "DIP",
-                                                                                                args: [
-                                                                                                    [
-                                                                                                        { prim: "DUP" },
-                                                                                                        { prim: "CDR" },
-                                                                                                        { prim: "SWAP" },
-                                                                                                        { prim: "CAR" },
-                                                                                                        { prim: "CDR" },
-                                                                                                    ],
-                                                                                                ],
-                                                                                            },
-                                                                                            { prim: "PAIR" },
-                                                                                            { prim: "PAIR" },
-                                                                                            { prim: "DUP" },
-                                                                                            { prim: "CAR" },
-                                                                                            { prim: "CAR" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "2" }],
-                                                                                            },
-                                                                                            { prim: "SOME" },
-                                                                                            {
-                                                                                                prim: "DIG",
-                                                                                                args: [{ int: "3" }],
-                                                                                            },
-                                                                                            { prim: "UPDATE" },
-                                                                                            {
-                                                                                                prim: "DIP",
-                                                                                                args: [
-                                                                                                    [
-                                                                                                        { prim: "DUP" },
-                                                                                                        { prim: "CDR" },
-                                                                                                        { prim: "SWAP" },
-                                                                                                        { prim: "CAR" },
-                                                                                                        { prim: "CDR" },
-                                                                                                    ],
-                                                                                                ],
-                                                                                            },
-                                                                                            { prim: "PAIR" },
-                                                                                            { prim: "PAIR" },
-                                                                                        ],
-                                                                                    ],
-                                                                                },
-                                                                            ],
-                                                                        ],
-                                                                    },
-                                                                ],
-                                                            ],
-                                                        },
-                                                        { prim: "NIL", args: [{ prim: "operation" }] },
-                                                        { prim: "PAIR" },
-                                                    ],
-                                                ],
-                                            },
-                                        ],
-                                    ],
-                                },
-                            ],
-                        ],
-                    },
-                ],
-            ],
-        },
-    ],
-    storage: {
-        prim: "Pair",
-        args: [
+          prim: 'or',
+          args: [
             {
-                prim: "Pair",
-                args: [
-                    { int: "26692" },
-                    { bytes: "0002c51358175f2d67a257bc6a70394ea6ce2f98f68e" },
-                ],
+              prim: 'or',
+              args: [
+                {
+                  prim: 'or',
+                  args: [
+                    {
+                      prim: 'pair',
+                      args: [{ prim: 'address' }, { prim: 'nat' }],
+                      annots: ['%approve'],
+                    },
+                    {
+                      prim: 'pair',
+                      args: [
+                        {
+                          prim: 'pair',
+                          args: [{ prim: 'address' }, { prim: 'address' }],
+                        },
+                        { prim: 'contract', args: [{ prim: 'nat' }] },
+                      ],
+                      annots: ['%getAllowance'],
+                    },
+                  ],
+                },
+                {
+                  prim: 'or',
+                  args: [
+                    {
+                      prim: 'pair',
+                      args: [{ prim: 'address' }, { prim: 'contract', args: [{ prim: 'nat' }] }],
+                      annots: ['%getBalance'],
+                    },
+                    {
+                      prim: 'pair',
+                      args: [{ prim: 'unit' }, { prim: 'contract', args: [{ prim: 'nat' }] }],
+                      annots: ['%getTotalSupply'],
+                    },
+                  ],
+                },
+              ],
             },
-            { int: "100" },
-        ],
+            {
+              prim: 'or',
+              args: [
+                { prim: 'nat', annots: ['%mint'] },
+                {
+                  prim: 'pair',
+                  args: [
+                    {
+                      prim: 'pair',
+                      args: [{ prim: 'address' }, { prim: 'address' }],
+                    },
+                    { prim: 'nat' },
+                  ],
+                  annots: ['%transfer'],
+                },
+              ],
+            },
+          ],
+        },
+      ],
     },
+    {
+      prim: 'storage',
+      args: [
+        {
+          prim: 'pair',
+          args: [
+            {
+              prim: 'pair',
+              args: [
+                {
+                  prim: 'big_map',
+                  args: [
+                    { prim: 'address' },
+                    {
+                      prim: 'pair',
+                      args: [
+                        {
+                          prim: 'map',
+                          args: [{ prim: 'address' }, { prim: 'nat' }],
+                          annots: ['%allowances'],
+                        },
+                        { prim: 'nat', annots: ['%balance'] },
+                      ],
+                    },
+                  ],
+                  annots: ['%ledger'],
+                },
+                { prim: 'address', annots: ['%owner'] },
+              ],
+            },
+            { prim: 'nat', annots: ['%totalSupply'] },
+          ],
+        },
+      ],
+    },
+    {
+      prim: 'code',
+      args: [
+        [
+          { prim: 'DUP' },
+          { prim: 'CDR' },
+          { prim: 'PUSH', args: [{ prim: 'mutez' }, { int: '0' }] },
+          { prim: 'AMOUNT' },
+          { prim: 'COMPARE' },
+          { prim: 'NEQ' },
+          {
+            prim: 'IF',
+            args: [
+              [
+                { prim: 'DROP', args: [{ int: '2' }] },
+                {
+                  prim: 'PUSH',
+                  args: [{ prim: 'string' }, { string: 'This contract do not accept token' }],
+                },
+                { prim: 'FAILWITH' },
+              ],
+              [
+                { prim: 'SWAP' },
+                { prim: 'CAR' },
+                {
+                  prim: 'IF_LEFT',
+                  args: [
+                    [
+                      {
+                        prim: 'IF_LEFT',
+                        args: [
+                          [
+                            {
+                              prim: 'IF_LEFT',
+                              args: [
+                                [
+                                  { prim: 'PAIR' },
+                                  { prim: 'DUP' },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '3' }] },
+                                  { prim: 'SENDER' },
+                                  { prim: 'COMPARE' },
+                                  { prim: 'EQ' },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        { prim: 'DROP', args: [{ int: '3' }] },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            { prim: 'string' },
+                                            { string: 'SameOwnerAndSpender' },
+                                          ],
+                                        },
+                                        { prim: 'FAILWITH' },
+                                      ],
+                                      [
+                                        { prim: 'DUP' },
+                                        { prim: 'CAR' },
+                                        { prim: 'CAR' },
+                                        { prim: 'SENDER' },
+                                        { prim: 'GET' },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [{ prim: 'string' }, { string: 'NoAccount' }],
+                                              },
+                                              { prim: 'FAILWITH' },
+                                            ],
+                                            [],
+                                          ],
+                                        },
+                                        { prim: 'DUP' },
+                                        { prim: 'CAR' },
+                                        { prim: 'DIG', args: [{ int: '4' }] },
+                                        { prim: 'DUP' },
+                                        { prim: 'DUG', args: [{ int: '5' }] },
+                                        { prim: 'GET' },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              { prim: 'DUP' },
+                                              { prim: 'CAR' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '3' }],
+                                              },
+                                              { prim: 'SOME' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '4' }],
+                                              },
+                                              { prim: 'UPDATE' },
+                                            ],
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [{ prim: 'nat' }, { int: '0' }],
+                                              },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '4' }],
+                                              },
+                                              { prim: 'DUP' },
+                                              {
+                                                prim: 'DUG',
+                                                args: [{ int: '5' }],
+                                              },
+                                              { prim: 'COMPARE' },
+                                              { prim: 'GT' },
+                                              {
+                                                prim: 'PUSH',
+                                                args: [{ prim: 'nat' }, { int: '0' }],
+                                              },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '2' }],
+                                              },
+                                              { prim: 'COMPARE' },
+                                              { prim: 'GT' },
+                                              { prim: 'AND' },
+                                              {
+                                                prim: 'IF',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'DROP' },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'DROP' },
+                                                    {
+                                                      prim: 'PUSH',
+                                                      args: [
+                                                        { prim: 'string' },
+                                                        {
+                                                          string: 'UnsafeAllowanceChange',
+                                                        },
+                                                      ],
+                                                    },
+                                                    { prim: 'FAILWITH' },
+                                                  ],
+                                                  [
+                                                    { prim: 'DUP' },
+                                                    { prim: 'CAR' },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '3' }],
+                                                    },
+                                                    { prim: 'SOME' },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '4' }],
+                                                    },
+                                                    { prim: 'UPDATE' },
+                                                  ],
+                                                ],
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        { prim: 'DIG', args: [{ int: '2' }] },
+                                        { prim: 'DUP' },
+                                        { prim: 'CAR' },
+                                        { prim: 'CAR' },
+                                        { prim: 'DIG', args: [{ int: '3' }] },
+                                        { prim: 'DIG', args: [{ int: '3' }] },
+                                        { prim: 'SWAP' },
+                                        { prim: 'CDR' },
+                                        { prim: 'SWAP' },
+                                        { prim: 'PAIR' },
+                                        { prim: 'SOME' },
+                                        { prim: 'SENDER' },
+                                        { prim: 'UPDATE' },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              { prim: 'DUP' },
+                                              { prim: 'CDR' },
+                                              { prim: 'SWAP' },
+                                              { prim: 'CAR' },
+                                              { prim: 'CDR' },
+                                            ],
+                                          ],
+                                        },
+                                        { prim: 'PAIR' },
+                                        { prim: 'PAIR' },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'NIL',
+                                    args: [{ prim: 'operation' }],
+                                  },
+                                  { prim: 'PAIR' },
+                                ],
+                                [
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '3' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'PAIR' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '3' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'DIG', args: [{ int: '3' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'PAIR' },
+                                  { prim: 'PAIR' },
+                                  { prim: 'DUP' },
+                                  { prim: 'CDR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'GET' },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'PUSH',
+                                          args: [{ prim: 'string' }, { string: 'NoAccount' }],
+                                        },
+                                        { prim: 'FAILWITH' },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  { prim: 'CAR' },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'GET' },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'PUSH',
+                                          args: [{ prim: 'string' }, { string: 'NoAccount' }],
+                                        },
+                                        { prim: 'FAILWITH' },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'NIL',
+                                    args: [{ prim: 'operation' }],
+                                  },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'CAR' },
+                                  {
+                                    prim: 'PUSH',
+                                    args: [{ prim: 'mutez' }, { int: '0' }],
+                                  },
+                                  { prim: 'DIG', args: [{ int: '3' }] },
+                                  { prim: 'TRANSFER_TOKENS' },
+                                  { prim: 'CONS' },
+                                  { prim: 'PAIR' },
+                                ],
+                              ],
+                            },
+                          ],
+                          [
+                            {
+                              prim: 'IF_LEFT',
+                              args: [
+                                [
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'PAIR' },
+                                  { prim: 'DUP' },
+                                  { prim: 'CDR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'GET' },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'PUSH',
+                                          args: [{ prim: 'string' }, { string: 'NoAccount' }],
+                                        },
+                                        { prim: 'FAILWITH' },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'NIL',
+                                    args: [{ prim: 'operation' }],
+                                  },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CDR' },
+                                  {
+                                    prim: 'PUSH',
+                                    args: [{ prim: 'mutez' }, { int: '0' }],
+                                  },
+                                  { prim: 'DIG', args: [{ int: '3' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'TRANSFER_TOKENS' },
+                                  { prim: 'CONS' },
+                                  { prim: 'PAIR' },
+                                ],
+                                [
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'PAIR' },
+                                  {
+                                    prim: 'NIL',
+                                    args: [{ prim: 'operation' }],
+                                  },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  {
+                                    prim: 'PUSH',
+                                    args: [{ prim: 'mutez' }, { int: '0' }],
+                                  },
+                                  { prim: 'DIG', args: [{ int: '3' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'TRANSFER_TOKENS' },
+                                  { prim: 'CONS' },
+                                  { prim: 'PAIR' },
+                                ],
+                              ],
+                            },
+                          ],
+                        ],
+                      },
+                    ],
+                    [
+                      {
+                        prim: 'IF_LEFT',
+                        args: [
+                          [
+                            { prim: 'SWAP' },
+                            { prim: 'DUP' },
+                            { prim: 'CAR' },
+                            { prim: 'CDR' },
+                            { prim: 'SENDER' },
+                            { prim: 'COMPARE' },
+                            { prim: 'NEQ' },
+                            {
+                              prim: 'IF',
+                              args: [
+                                [
+                                  { prim: 'DROP', args: [{ int: '2' }] },
+                                  {
+                                    prim: 'PUSH',
+                                    args: [{ prim: 'string' }, { string: 'UnauthorizedAccess' }],
+                                  },
+                                  { prim: 'FAILWITH' },
+                                ],
+                                [
+                                  { prim: 'DUP' },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'GET' },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        { prim: 'SWAP' },
+                                        { prim: 'DUP' },
+                                        { prim: 'DUG', args: [{ int: '2' }] },
+                                        {
+                                          prim: 'EMPTY_MAP',
+                                          args: [{ prim: 'address' }, { prim: 'nat' }],
+                                        },
+                                        { prim: 'PAIR' },
+                                      ],
+                                      [
+                                        { prim: 'DUP' },
+                                        { prim: 'DIG', args: [{ int: '3' }] },
+                                        { prim: 'DUP' },
+                                        { prim: 'DUG', args: [{ int: '4' }] },
+                                        { prim: 'DIG', args: [{ int: '2' }] },
+                                        { prim: 'CDR' },
+                                        { prim: 'ADD' },
+                                        { prim: 'SWAP' },
+                                        { prim: 'CAR' },
+                                        { prim: 'PAIR' },
+                                      ],
+                                    ],
+                                  },
+                                  { prim: 'SWAP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '3' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'SOME' },
+                                  { prim: 'DIG', args: [{ int: '3' }] },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '4' }] },
+                                  { prim: 'CAR' },
+                                  { prim: 'CDR' },
+                                  { prim: 'UPDATE' },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        { prim: 'DUP' },
+                                        { prim: 'CDR' },
+                                        { prim: 'SWAP' },
+                                        { prim: 'CAR' },
+                                        { prim: 'CDR' },
+                                      ],
+                                    ],
+                                  },
+                                  { prim: 'PAIR' },
+                                  { prim: 'PAIR' },
+                                  { prim: 'DUG', args: [{ int: '2' }] },
+                                  { prim: 'CDR' },
+                                  { prim: 'ADD' },
+                                  { prim: 'SWAP' },
+                                  { prim: 'CAR' },
+                                  { prim: 'PAIR' },
+                                ],
+                              ],
+                            },
+                            { prim: 'NIL', args: [{ prim: 'operation' }] },
+                            { prim: 'PAIR' },
+                          ],
+                          [
+                            { prim: 'DUP' },
+                            { prim: 'DUG', args: [{ int: '2' }] },
+                            { prim: 'CDR' },
+                            { prim: 'PAIR' },
+                            { prim: 'SWAP' },
+                            { prim: 'DUP' },
+                            { prim: 'DUG', args: [{ int: '2' }] },
+                            { prim: 'CAR' },
+                            { prim: 'CDR' },
+                            { prim: 'DIG', args: [{ int: '2' }] },
+                            { prim: 'CAR' },
+                            { prim: 'CAR' },
+                            { prim: 'PAIR' },
+                            { prim: 'PAIR' },
+                            { prim: 'DUP' },
+                            { prim: 'CAR' },
+                            { prim: 'CAR' },
+                            { prim: 'SWAP' },
+                            { prim: 'DUP' },
+                            { prim: 'DUG', args: [{ int: '2' }] },
+                            { prim: 'CAR' },
+                            { prim: 'CDR' },
+                            { prim: 'DIG', args: [{ int: '2' }] },
+                            { prim: 'DUP' },
+                            { prim: 'DUG', args: [{ int: '3' }] },
+                            { prim: 'CDR' },
+                            { prim: 'CAR' },
+                            { prim: 'DIG', args: [{ int: '3' }] },
+                            { prim: 'CDR' },
+                            { prim: 'CDR' },
+                            { prim: 'DIG', args: [{ int: '2' }] },
+                            { prim: 'DUP' },
+                            { prim: 'DUG', args: [{ int: '3' }] },
+                            { prim: 'DIG', args: [{ int: '4' }] },
+                            { prim: 'DUP' },
+                            { prim: 'DUG', args: [{ int: '5' }] },
+                            { prim: 'COMPARE' },
+                            { prim: 'EQ' },
+                            {
+                              prim: 'IF',
+                              args: [
+                                [
+                                  { prim: 'DROP', args: [{ int: '4' }] },
+                                  {
+                                    prim: 'PUSH',
+                                    args: [
+                                      { prim: 'string' },
+                                      { string: 'SameOriginAndDestination' },
+                                    ],
+                                  },
+                                  { prim: 'FAILWITH' },
+                                ],
+                                [
+                                  { prim: 'DUP' },
+                                  { prim: 'DIG', args: [{ int: '2' }] },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '3' }] },
+                                  { prim: 'DIG', args: [{ int: '5' }] },
+                                  { prim: 'DUP' },
+                                  { prim: 'DUG', args: [{ int: '6' }] },
+                                  { prim: 'PAIR' },
+                                  { prim: 'PAIR' },
+                                  { prim: 'DUP' },
+                                  { prim: 'CAR' },
+                                  { prim: 'CAR' },
+                                  { prim: 'DUP' },
+                                  { prim: 'SENDER' },
+                                  { prim: 'COMPARE' },
+                                  { prim: 'NEQ' },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        { prim: 'SWAP' },
+                                        { prim: 'DUP' },
+                                        { prim: 'DUG', args: [{ int: '2' }] },
+                                        { prim: 'CDR' },
+                                        { prim: 'CAR' },
+                                        { prim: 'CAR' },
+                                        { prim: 'SWAP' },
+                                        { prim: 'GET' },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              { prim: 'DROP' },
+                                              {
+                                                prim: 'PUSH',
+                                                args: [{ prim: 'bool' }, { prim: 'False' }],
+                                              },
+                                            ],
+                                            [
+                                              { prim: 'CAR' },
+                                              { prim: 'SENDER' },
+                                              { prim: 'GET' },
+                                              {
+                                                prim: 'IF_NONE',
+                                                args: [
+                                                  [
+                                                    { prim: 'DROP' },
+                                                    {
+                                                      prim: 'PUSH',
+                                                      args: [{ prim: 'bool' }, { prim: 'False' }],
+                                                    },
+                                                  ],
+                                                  [
+                                                    { prim: 'SWAP' },
+                                                    { prim: 'CAR' },
+                                                    { prim: 'CDR' },
+                                                    { prim: 'SWAP' },
+                                                    { prim: 'COMPARE' },
+                                                    { prim: 'GE' },
+                                                  ],
+                                                ],
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                      [
+                                        { prim: 'DROP', args: [{ int: '2' }] },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [{ prim: 'bool' }, { prim: 'True' }],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  { prim: 'NOT' },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        { prim: 'DROP', args: [{ int: '4' }] },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            { prim: 'string' },
+                                            { string: 'NotEnoughAllowance' },
+                                          ],
+                                        },
+                                        { prim: 'FAILWITH' },
+                                      ],
+                                      [
+                                        { prim: 'DUP' },
+                                        { prim: 'CAR' },
+                                        { prim: 'CAR' },
+                                        { prim: 'DIG', args: [{ int: '4' }] },
+                                        { prim: 'DUP' },
+                                        { prim: 'DUG', args: [{ int: '5' }] },
+                                        { prim: 'GET' },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [{ prim: 'string' }, { string: 'NoAccount' }],
+                                              },
+                                              { prim: 'FAILWITH' },
+                                            ],
+                                            [],
+                                          ],
+                                        },
+                                        { prim: 'DUP' },
+                                        { prim: 'CDR' },
+                                        { prim: 'DIG', args: [{ int: '3' }] },
+                                        { prim: 'DUP' },
+                                        { prim: 'DUG', args: [{ int: '4' }] },
+                                        { prim: 'COMPARE' },
+                                        { prim: 'GT' },
+                                        {
+                                          prim: 'IF',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                                args: [{ int: '5' }],
+                                              },
+                                              {
+                                                prim: 'PUSH',
+                                                args: [
+                                                  { prim: 'string' },
+                                                  {
+                                                    string: 'NotEnoughBalance',
+                                                  },
+                                                ],
+                                              },
+                                              { prim: 'FAILWITH' },
+                                            ],
+                                            [
+                                              { prim: 'DUP' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '3' }],
+                                              },
+                                              { prim: 'DUP' },
+                                              {
+                                                prim: 'DUG',
+                                                args: [{ int: '4' }],
+                                              },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '2' }],
+                                              },
+                                              { prim: 'CDR' },
+                                              { prim: 'SUB' },
+                                              { prim: 'ABS' },
+                                              { prim: 'SWAP' },
+                                              { prim: 'CAR' },
+                                              { prim: 'PAIR' },
+                                              { prim: 'SWAP' },
+                                              { prim: 'DUP' },
+                                              {
+                                                prim: 'DUG',
+                                                args: [{ int: '2' }],
+                                              },
+                                              { prim: 'CAR' },
+                                              { prim: 'CAR' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '4' }],
+                                              },
+                                              { prim: 'DUP' },
+                                              {
+                                                prim: 'DUG',
+                                                args: [{ int: '5' }],
+                                              },
+                                              { prim: 'GET' },
+                                              {
+                                                prim: 'IF_NONE',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'DUP' },
+                                                    {
+                                                      prim: 'DUG',
+                                                      args: [{ int: '3' }],
+                                                    },
+                                                    {
+                                                      prim: 'EMPTY_MAP',
+                                                      args: [{ prim: 'address' }, { prim: 'nat' }],
+                                                    },
+                                                    { prim: 'PAIR' },
+                                                  ],
+                                                  [
+                                                    { prim: 'DUP' },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '4' }],
+                                                    },
+                                                    { prim: 'DUP' },
+                                                    {
+                                                      prim: 'DUG',
+                                                      args: [{ int: '5' }],
+                                                    },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'CDR' },
+                                                    { prim: 'ADD' },
+                                                    { prim: 'SWAP' },
+                                                    { prim: 'CAR' },
+                                                    { prim: 'PAIR' },
+                                                  ],
+                                                ],
+                                              },
+                                              { prim: 'SWAP' },
+                                              { prim: 'DUP' },
+                                              {
+                                                prim: 'DUG',
+                                                args: [{ int: '2' }],
+                                              },
+                                              { prim: 'CAR' },
+                                              { prim: 'SENDER' },
+                                              { prim: 'GET' },
+                                              {
+                                                prim: 'IF_NONE',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '3' }],
+                                                    },
+                                                    { prim: 'DROP' },
+                                                    { prim: 'SWAP' },
+                                                    { prim: 'DUP' },
+                                                    {
+                                                      prim: 'DUG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'CAR' },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'DUP' },
+                                                    {
+                                                      prim: 'DUG',
+                                                      args: [{ int: '3' }],
+                                                    },
+                                                    { prim: 'CAR' },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '5' }],
+                                                    },
+                                                    {
+                                                      prim: 'DIG',
+                                                      args: [{ int: '2' }],
+                                                    },
+                                                    { prim: 'SUB' },
+                                                    { prim: 'ABS' },
+                                                    { prim: 'SOME' },
+                                                    { prim: 'SENDER' },
+                                                    { prim: 'UPDATE' },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '3' }],
+                                              },
+                                              { prim: 'DUP' },
+                                              { prim: 'CAR' },
+                                              { prim: 'CAR' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '4' }],
+                                              },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '3' }],
+                                              },
+                                              { prim: 'SWAP' },
+                                              { prim: 'CDR' },
+                                              { prim: 'SWAP' },
+                                              { prim: 'PAIR' },
+                                              { prim: 'SOME' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '5' }],
+                                              },
+                                              { prim: 'UPDATE' },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    { prim: 'DUP' },
+                                                    { prim: 'CDR' },
+                                                    { prim: 'SWAP' },
+                                                    { prim: 'CAR' },
+                                                    { prim: 'CDR' },
+                                                  ],
+                                                ],
+                                              },
+                                              { prim: 'PAIR' },
+                                              { prim: 'PAIR' },
+                                              { prim: 'DUP' },
+                                              { prim: 'CAR' },
+                                              { prim: 'CAR' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '2' }],
+                                              },
+                                              { prim: 'SOME' },
+                                              {
+                                                prim: 'DIG',
+                                                args: [{ int: '3' }],
+                                              },
+                                              { prim: 'UPDATE' },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    { prim: 'DUP' },
+                                                    { prim: 'CDR' },
+                                                    { prim: 'SWAP' },
+                                                    { prim: 'CAR' },
+                                                    { prim: 'CDR' },
+                                                  ],
+                                                ],
+                                              },
+                                              { prim: 'PAIR' },
+                                              { prim: 'PAIR' },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                ],
+                              ],
+                            },
+                            { prim: 'NIL', args: [{ prim: 'operation' }] },
+                            { prim: 'PAIR' },
+                          ],
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+      ],
+    },
+  ],
+  storage: {
+    prim: 'Pair',
+    args: [
+      {
+        prim: 'Pair',
+        args: [{ int: '26692' }, { bytes: '0002c51358175f2d67a257bc6a70394ea6ce2f98f68e' }],
+      },
+      { int: '100' },
+    ],
+  },
 };
 
 export const entrypoints = {
-    entrypoints: {
-        transfer: {
-            prim: "pair",
-            args: [
-                { prim: "pair", args: [{ prim: "address" }, { prim: "address" }] },
-                { prim: "nat" },
-            ],
-        },
-        mint: { prim: "nat" },
-        getTotalSupply: {
-            prim: "pair",
-            args: [{ prim: "unit" }, { prim: "contract", args: [{ prim: "nat" }] }],
-        },
-        getBalance: {
-            prim: "pair",
-            args: [
-                { prim: "address" },
-                { prim: "contract", args: [{ prim: "nat" }] },
-            ],
-        },
-        getAllowance: {
-            prim: "pair",
-            args: [
-                { prim: "pair", args: [{ prim: "address" }, { prim: "address" }] },
-                { prim: "contract", args: [{ prim: "nat" }] },
-            ],
-        },
-        approve: { prim: "pair", args: [{ prim: "address" }, { prim: "nat" }] },
+  entrypoints: {
+    transfer: {
+      prim: 'pair',
+      args: [{ prim: 'pair', args: [{ prim: 'address' }, { prim: 'address' }] }, { prim: 'nat' }],
     },
-};
-
-export const header = {
-    protocol: "PsCARTHAGazKbHtnKfLzQg3kms52kSRpgnDY982a9oYsSXRLQEb",
-    chain_id: "NetXjD3HPJJjmcd",
-    hash: "BL2bVSxJtt1XUZK5p2R6XSSkLy7y5rfByvWk1Vt17zHnEdwjAh5",
-    level: 864873,
-    proto: 2,
-    predecessor: "BMXFGwQPhbW7mNmDFfL4aboBKGnpM9BtALvgL2uRKEB7gvZTQnV",
-    timestamp: "2020-11-12T23:27:07Z",
-    validation_pass: 4,
-    operations_hash: "LLoZaGpo4BWE3Fq6GJpnkmJb79P3madTQGciGmd2HVtrjHZN6RVyX",
-    fitness: ["01", "00000000000d3268"],
-    context: "CoUncrujoZK2VvM6D8pM3c7PZkcgiESyqrErXsu5XL9gAT79AKKx",
-    priority: 1,
-    proof_of_work_nonce: "6b9f3bc3443c0100",
-    signature:
-        "sigeQYoNwa6g6KKjrqEGY9R9YLHqMNHXTHmddpu4qb8Ucm4z1rzBGt8aT2NQerpzLh2YBVp8psRdbeqS4itD3UbYSDwfYT3Z",
+    mint: { prim: 'nat' },
+    getTotalSupply: {
+      prim: 'pair',
+      args: [{ prim: 'unit' }, { prim: 'contract', args: [{ prim: 'nat' }] }],
+    },
+    getBalance: {
+      prim: 'pair',
+      args: [{ prim: 'address' }, { prim: 'contract', args: [{ prim: 'nat' }] }],
+    },
+    getAllowance: {
+      prim: 'pair',
+      args: [
+        { prim: 'pair', args: [{ prim: 'address' }, { prim: 'address' }] },
+        { prim: 'contract', args: [{ prim: 'nat' }] },
+      ],
+    },
+    approve: { prim: 'pair', args: [{ prim: 'address' }, { prim: 'nat' }] },
+  },
 };

--- a/packages/taquito/test/contract/lambda-view-class.spec.ts
+++ b/packages/taquito/test/contract/lambda-view-class.spec.ts
@@ -1,6 +1,6 @@
 import LambdaView from '../../src/contract/lambda-view';
 import { TezosToolkit } from '../../src/taquito';
-import { entrypoints, header, script } from './data-lambda-view-class';
+import { entrypoints, script } from './data-lambda-view-class';
 
 describe('LambdaView test', () => {
   let mockRpcClientView: any;
@@ -11,19 +11,19 @@ describe('LambdaView test', () => {
   beforeEach(() => {
     mockRpcClientView = {
       getNormalizedScript: jest.fn(),
-      getBlockHeader: jest.fn(),
+      getChainId: jest.fn(),
       getEntrypoints: jest.fn(),
     };
 
     mockRpcClientView.getNormalizedScript.mockResolvedValue(script);
-    mockRpcClientView.getBlockHeader.mockResolvedValue(header);
+    mockRpcClientView.getChainId.mockResolvedValue('NetXjD3HPJJjmcd');
 
     toolkitView = new TezosToolkit('url');
     toolkitView['_context'].rpc = mockRpcClientView;
 
     mockRpcClientLambda = {
       getNormalizedScript: jest.fn(),
-      getBlockHeader: jest.fn(),
+      getChainId: jest.fn(),
       getEntrypoints: jest.fn(),
     };
 
@@ -52,7 +52,7 @@ describe('LambdaView test', () => {
       ],
       storage: { prim: 'Unit' },
     });
-    mockRpcClientLambda.getBlockHeader.mockResolvedValue(header);
+    mockRpcClientLambda.getChainId.mockResolvedValue('NetXjD3HPJJjmcd');
     mockRpcClientLambda.getEntrypoints.mockResolvedValue({ entrypoints: {} });
 
     toolkitLambda = new TezosToolkit('url');

--- a/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
@@ -38,6 +38,7 @@ describe('RPCEstimateProvider test', () => {
     preapplyOperations: jest.Mock<any, any>;
     getChainId: jest.Mock<any, any>;
     getConstants: jest.Mock<any, any>;
+    getProtocols: jest.Mock<any, any>;
   };
 
   let mockSigner: {
@@ -62,6 +63,7 @@ describe('RPCEstimateProvider test', () => {
       preapplyOperations: jest.fn(),
       getChainId: jest.fn(),
       getConstants: jest.fn(),
+      getProtocols: jest.fn(),
     };
 
     mockSigner = {
@@ -83,6 +85,7 @@ describe('RPCEstimateProvider test', () => {
     mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
     mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
     mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getProtocols.mockResolvedValue({ next_protocol: 'test_proto' });
     mockRpcClient.forgeOperations.mockResolvedValue('1234');
     mockRpcClient.preapplyOperations.mockResolvedValue([]);
     mockRpcClient.getChainId.mockResolvedValue('chain-id');
@@ -524,10 +527,11 @@ describe('RPCEstimateProvider test', () => {
         { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
         { kind: OpKind.TRANSACTION, to: 'tz3hRZUScFCcEVhdDjXWoyekbgd1Gatga6mp', amount: 2 },
         {
-          kind: OpKind.REGISTER_GLOBAL_CONSTANT, value: {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: {
             prim: 'Pair',
-            args: [{ int: '998' }, { int: '999' }]
-          }
+            args: [{ int: '998' }, { int: '999' }],
+          },
         },
       ]);
       expect(estimate.length).toEqual(3);
@@ -589,10 +593,11 @@ describe('RPCEstimateProvider test', () => {
       });
       const estimate = await estimateProvider.batch([
         {
-          kind: OpKind.REGISTER_GLOBAL_CONSTANT, value: {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: {
             prim: 'Pair',
-            args: [{ int: '998' }, { int: '999' }]
-          }
+            args: [{ int: '998' }, { int: '999' }],
+          },
         },
         { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
         { kind: OpKind.TRANSACTION, to: 'tz3hRZUScFCcEVhdDjXWoyekbgd1Gatga6mp', amount: 2 },
@@ -609,8 +614,8 @@ describe('RPCEstimateProvider test', () => {
         storageLimit: 73,
         suggestedFeeMutez: 408,
       });
-      expect(estimate[2].suggestedFeeMutez).toEqual(385)
-      expect(estimate[3].suggestedFeeMutez).toEqual(385)
+      expect(estimate[2].suggestedFeeMutez).toEqual(385);
+      expect(estimate[3].suggestedFeeMutez).toEqual(385);
       expect(estimate[2]).toMatchObject({
         gasLimit: 1100,
         storageLimit: 0,
@@ -736,9 +741,9 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.runOperation.mockResolvedValue(registerGlobalConstantNoReveal);
       const estimate = await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
-        }
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
+        },
       });
       expect(estimate).toMatchObject({
         gasLimit: 1330,
@@ -753,9 +758,9 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.runOperation.mockResolvedValue(registerGlobalConstantWithReveal);
       const estimate = await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
-        }
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
+        },
       });
       expect(estimate).toMatchObject({
         gasLimit: 1330,
@@ -770,8 +775,8 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getBalance.mockResolvedValue(new BigNumber('1100'));
       await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
         },
         storageLimit: 200,
       });
@@ -796,8 +801,8 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getBalance.mockResolvedValue(new BigNumber('10000000000'));
       await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
         },
         gasLimit: 200,
       });
@@ -822,8 +827,8 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getBalance.mockResolvedValue(new BigNumber('10000000000'));
       await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
         },
         fee: 10000,
       });
@@ -846,16 +851,18 @@ describe('RPCEstimateProvider test', () => {
     it('should return parsed error from RPC result', async (done) => {
       mockRpcClient.runOperation.mockResolvedValue(registerGlobalConstantWithError);
 
-      await expect(estimateProvider.registerGlobalConstant({
-        value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
-        }
-      })).rejects.toMatchObject({
-        errors:
-          [{
+      await expect(
+        estimateProvider.registerGlobalConstant({
+          value: {
+            prim: 'Pair',
+            args: [{ int: '998' }, { int: '999' }],
+          },
+        })
+      ).rejects.toMatchObject({
+        errors: [
+          {
             kind: 'branch',
-            id: 'proto.011-PtHangzH.Expression_already_registered'
+            id: 'proto.011-PtHangzH.Expression_already_registered',
           },
           {
             kind: 'permanent',
@@ -863,13 +870,14 @@ describe('RPCEstimateProvider test', () => {
             existing_key: [
               'global_constant',
               'f4b54fa94f3255df3ab6a95d0112964d825642706d42de848b3c507ff4602c4a',
-              'len'
-            ]
-          }],
+              'len',
+            ],
+          },
+        ],
         name: 'TezosOperationError',
         id: 'proto.011-PtHangzH.context.storage_error',
         kind: 'permanent',
-        message: '(permanent) proto.011-PtHangzH.context.storage_error'
+        message: '(permanent) proto.011-PtHangzH.context.storage_error',
       });
       done();
     });

--- a/packages/taquito/test/parser/michel-codec-parser.spec.ts
+++ b/packages/taquito/test/parser/michel-codec-parser.spec.ts
@@ -3,13 +3,13 @@ import { Context, MichelCodecParser, Protocols, InvalidCodeParameter } from '../
 
 describe('MichelCodec parser', () => {
   const mockRpcClient = {
-    getBlockMetadata: jest.fn(),
+    getProtocols: jest.fn(),
   };
   const mockGlobalConstantsProvider = {
     getGlobalConstantByHash: jest.fn(),
   };
 
-  mockRpcClient.getBlockMetadata.mockResolvedValue({
+  mockRpcClient.getProtocols.mockResolvedValue({
     next_protocol: 'PtEdo2ZkT9oKpimTah6x2embF25oss54njMuPzkJTEi5RqfdZFA',
   });
 
@@ -18,7 +18,7 @@ describe('MichelCodec parser', () => {
   });
 
   describe('getNextProto', () => {
-    it('calls getBlockMetadata from the rpc client', async (done) => {
+    it('calls getProtocols from the rpc client', async (done) => {
       const parser = new MichelCodecParser(new Context(mockRpcClient as any));
       const result = await parser['getNextProto']();
       expect(result).toStrictEqual(Protocols.PtEdo2Zk);

--- a/packages/taquito/test/tz/rpc-tz-provider.spec.ts
+++ b/packages/taquito/test/tz/rpc-tz-provider.spec.ts
@@ -8,7 +8,7 @@ describe('RpcTzProvider test', () => {
   });
 
   describe('getBalance', () => {
-    it('calls get balance from the rpc client', async done => {
+    it('calls get balance from the rpc client', async (done) => {
       const mockRpcClient = {
         getBalance: jest.fn(),
       };
@@ -19,13 +19,15 @@ describe('RpcTzProvider test', () => {
       const result = await provider.getBalance('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
       expect(result).toBeInstanceOf(BigNumber);
       expect(result.toString()).toStrictEqual('10000');
-      expect(mockRpcClient.getBalance.mock.calls[0][0]).toEqual('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
+      expect(mockRpcClient.getBalance.mock.calls[0][0]).toEqual(
+        'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'
+      );
       done();
     });
   });
 
   describe('getDelegate', () => {
-    it('calls get delegate from the rpc client', async done => {
+    it('calls get delegate from the rpc client', async (done) => {
       const mockRpcClient = {
         getDelegate: jest.fn(),
       };
@@ -35,7 +37,9 @@ describe('RpcTzProvider test', () => {
       const provider = new RpcTzProvider(new Context(mockRpcClient as any));
       const result = await provider.getDelegate('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
       expect(result).toStrictEqual('KT1G393LjojNshvMdf68XQD24Hwjn7xarzNe');
-      expect(mockRpcClient.getDelegate.mock.calls[0][0]).toEqual('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
+      expect(mockRpcClient.getDelegate.mock.calls[0][0]).toEqual(
+        'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'
+      );
       done();
     });
   });
@@ -46,14 +50,14 @@ describe('RpcTzProvider test', () => {
       publicKey: jest.Mock<any, any>;
       sign: jest.Mock<any, any>;
     };
-    it('should produce a activate_account operation', async done => {
+    it('should produce a activate_account operation', async (done) => {
       const mockRpcClient = {
         getBlock: jest.fn(),
         getScript: jest.fn(),
         getManagerKey: jest.fn(),
         getStorage: jest.fn(),
         getBlockHeader: jest.fn(),
-        getBlockMetadata: jest.fn(),
+        getProtocols: jest.fn(),
         getContract: jest.fn(),
         forgeOperations: jest.fn(),
         injectOperation: jest.fn(),
@@ -75,11 +79,15 @@ describe('RpcTzProvider test', () => {
 
       mockRpcClient.getManagerKey.mockResolvedValue('test');
       mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
-      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw' });
+      mockRpcClient.getBlockHeader.mockResolvedValue({
+        hash: 'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw',
+      });
       mockRpcClient.preapplyOperations.mockResolvedValue([]);
-      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockRpcClient.getProtocols.mockResolvedValue({ next_protocol: 'test_proto' });
       mockRpcClient.forgeOperations.mockResolvedValue('test');
-      mockRpcClient.injectOperation.mockResolvedValue('ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj');
+      mockRpcClient.injectOperation.mockResolvedValue(
+        'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj'
+      );
 
       const provider = new RpcTzProvider(new Context(mockRpcClient as any, mockSigner as any));
       const result = await provider.activate('tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m', '123');

--- a/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
+++ b/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
@@ -27,7 +27,7 @@ describe('Contract abstraction composer test', () => {
     mockRpcClient = {
       getNormalizedScript: jest.fn(),
       getEntrypoints: jest.fn(),
-      getBlockHeader: jest.fn(),
+      getChainId: jest.fn(),
     };
 
     mockRpcClient.getNormalizedScript.mockResolvedValue(script);
@@ -36,14 +36,17 @@ describe('Contract abstraction composer test', () => {
         mint: { prim: 'pair', args: [{ prim: 'key' }, { prim: 'nat' }] },
       },
     });
-    mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+    mockRpcClient.getChainId.mockResolvedValue('test');
 
     toolkit = new TezosToolkit('url');
     toolkit['_context'].rpc = mockRpcClient;
   });
 
   it('Should add a helloWorld method on the contract abstraction', async (done) => {
-    const result = await toolkit.wallet.at('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D', composeContractAbstractionTest);
+    const result = await toolkit.wallet.at(
+      'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+      composeContractAbstractionTest
+    );
     expect(result.constractAbstractionTest().helloWorld()).toEqual('Hello World!');
     done();
   });


### PR DESCRIPTION
Codebase changes to read data from configured `ReadProvider` instead of `RPC`.

By default, the `ReadProvider` is set to an instance of `RpcReadAdapter` which reads data from the `RPC` node as before. We provide the ability to configure the `ReadProvider` on the `TezosToolkit` so that data can be read from an indexer rather than from the RPC.

#1389

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
