### PR TITLE
feat(rpcclient): support for new properties RpcClient

### DIFF
--- a/integration-tests/rpc-nodes.spec.ts
+++ b/integration-tests/rpc-nodes.spec.ts
@@ -17,7 +17,6 @@ CONFIGS().forEach(
     rpc,
   }) => {
     const Tezos = lib;
-    const skipIthacanet = protocol === Protocols.Psithaca2 ? test.skip : test;
 
     beforeEach(async (done) => {
       await setup();
@@ -140,8 +139,7 @@ CONFIGS().forEach(
           done();
         });
 
-        //pending https://github.com/ecadlabs/taquito/issues/1255
-        skipIthacanet(`Fetches information about a delegate from RPC`, async (done) => {
+        it(`Fetches information about a delegate from RPC`, async (done) => {
           const delegates = await rpcClient.getDelegates(knownBaker);
           expect(delegates).toBeDefined();
           done();

--- a/packages/taquito-contracts-library/src/rpc-wrapper.ts
+++ b/packages/taquito-contracts-library/src/rpc-wrapper.ts
@@ -163,11 +163,6 @@ export class RpcWrapperContractsLibrary implements RpcClientInterface {
   async getBallots({ block }: RPCOptions = defaultRPCOptions): Promise<BallotsResponse> {
     return this.rpc.getBallots({ block });
   }
-  async getCurrentPeriodKind({
-    block,
-  }: RPCOptions = defaultRPCOptions): Promise<PeriodKindResponse> {
-    return this.rpc.getCurrentPeriodKind({ block });
-  }
   async getCurrentProposal({
     block,
   }: RPCOptions = defaultRPCOptions): Promise<CurrentProposalResponse> {
@@ -217,11 +212,17 @@ export class RpcWrapperContractsLibrary implements RpcClientInterface {
   ): Promise<RunCodeResult> {
     return this.rpc.runCode(code, { block });
   }
-  async runView({ unparsing_mode = 'Readable', ...rest }: RPCRunViewParam, { block }: RPCOptions = defaultRPCOptions): Promise<RunViewResult> {
-    return this.rpc.runView({
-      unparsing_mode,
-      ...rest
-    }, { block });
+  async runView(
+    { unparsing_mode = 'Readable', ...rest }: RPCRunViewParam,
+    { block }: RPCOptions = defaultRPCOptions
+  ): Promise<RunViewResult> {
+    return this.rpc.runView(
+      {
+        unparsing_mode,
+        ...rest,
+      },
+      { block }
+    );
   }
   async getChainId(): Promise<string> {
     return this.rpc.getChainId();

--- a/packages/taquito-rpc/src/opkind.ts
+++ b/packages/taquito-rpc/src/opkind.ts
@@ -5,6 +5,9 @@ export enum OpKind {
   TRANSACTION = 'transaction',
   ACTIVATION = 'activate_account',
   ENDORSEMENT = 'endorsement',
+  PREENDORSEMENT = 'preendorsement',
+  SET_DEPOSITS_LIMIT = 'set_deposits_limit',
+  DOUBLE_PREENDORSEMENT_EVIDENCE = 'double_preendorsement_evidence',
   ENDORSEMENT_WITH_SLOT = 'endorsement_with_slot',
   SEED_NONCE_REVELATION = 'seed_nonce_revelation',
   DOUBLE_ENDORSEMENT_EVIDENCE = 'double_endorsement_evidence',
@@ -12,5 +15,5 @@ export enum OpKind {
   PROPOSALS = 'proposals',
   BALLOT = 'ballot',
   FAILING_NOOP = 'failing_noop',
-  REGISTER_GLOBAL_CONSTANT = 'register_global_constant'
+  REGISTER_GLOBAL_CONSTANT = 'register_global_constant',
 }

--- a/packages/taquito-rpc/src/rpc-client-interface.ts
+++ b/packages/taquito-rpc/src/rpc-client-interface.ts
@@ -80,7 +80,6 @@ export interface RpcClientInterface {
   ): Promise<EndorsingRightsResponse>;
   getBallotList(options?: RPCOptions): Promise<BallotListResponse>;
   getBallots(options?: RPCOptions): Promise<BallotsResponse>;
-  getCurrentPeriodKind(options?: RPCOptions): Promise<PeriodKindResponse>;
   getCurrentProposal(options?: RPCOptions): Promise<CurrentProposalResponse>;
   getCurrentQuorum(options?: RPCOptions): Promise<CurrentQuorumResponse>;
   getVotesListings(options?: RPCOptions): Promise<VotesListingsResponse>;

--- a/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
+++ b/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
@@ -597,29 +597,6 @@ export class RpcClientCache implements RpcClientInterface {
    *
    * @param options contains generic configuration for rpc calls
    *
-   * @description Current period kind.
-   *
-   * @deprecated Deprecated in favor of getCurrentPeriod
-   *
-   * @see https://tezos.gitlab.io/api/rpc.html#get-block-id-votes-current-period-kind
-   */
-  async getCurrentPeriodKind({
-    block,
-  }: RPCOptions = defaultRPCOptions): Promise<PeriodKindResponse> {
-    const key = this.formatCacheKey(this.rpcClient.getRpcUrl(), 'getCurrentPeriodKind', [block]);
-    if (this.has(key)) {
-      return this.get(key);
-    } else {
-      const response = this.rpcClient.getCurrentPeriodKind({ block });
-      this.put(key, response);
-      return response;
-    }
-  }
-
-  /**
-   *
-   * @param options contains generic configuration for rpc calls
-   *
    * @description Current proposal under evaluation.
    *
    * @see https://tezos.gitlab.io/api/rpc.html#get-block-id-votes-current-proposal
@@ -807,11 +784,17 @@ export class RpcClientCache implements RpcClientInterface {
    * @description Simulate a call to a view following the TZIP-4 standard. See https://gitlab.com/tzip/tzip/-/blob/master/proposals/tzip-4/tzip-4.md#view-entrypoints.
    *
    */
-   async runView({ unparsing_mode = 'Readable', ...rest }: RPCRunViewParam, { block }: RPCOptions = defaultRPCOptions): Promise<RunViewResult> {
-    return this.rpcClient.runView({
-      unparsing_mode,
-      ...rest
-    }, { block });
+  async runView(
+    { unparsing_mode = 'Readable', ...rest }: RPCRunViewParam,
+    { block }: RPCOptions = defaultRPCOptions
+  ): Promise<RunViewResult> {
+    return this.rpcClient.runView(
+      {
+        unparsing_mode,
+        ...rest,
+      },
+      { block }
+    );
   }
 
   async getChainId() {

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -12,9 +12,13 @@ export type DelegateResponse = string | null;
 export type OperationHash = string;
 
 export interface DelegatesResponse {
-  balance: BigNumber;
-  frozen_balance: BigNumber;
-  frozen_balance_by_cycle: Frozenbalancebycycle[];
+  balance?: BigNumber;
+  full_balance?: BigNumber;
+  current_frozen_deposits?: BigNumber;
+  frozen_deposits?: BigNumber;
+  frozen_balance?: BigNumber;
+  frozen_balance_by_cycle?: Frozenbalancebycycle[];
+  frozen_deposits_limit?: BigNumber;
   staking_balance: BigNumber;
   delegated_contracts: string[];
   delegated_balance: BigNumber;
@@ -45,9 +49,12 @@ export interface BlockFullHeader {
   operations_hash: string;
   fitness: string[];
   context: string;
+  payload_hash?: string;
+  payload_round?: number;
   priority: number;
   proof_of_work_nonce: string;
   seed_nonce_hash?: string;
+  liquidity_baking_escape_vote?: boolean;
   signature: string;
 }
 
@@ -55,7 +62,18 @@ export type InlinedEndorsementKindEnum = OpKind.ENDORSEMENT;
 
 export interface InlinedEndorsementContents {
   kind: InlinedEndorsementKindEnum;
+  slot?: number;
+  round?: number;
+  block_payload_hash?: string;
   level: number;
+}
+
+export interface InlinedPreEndorsementContents {
+  kind: OpKind.PREENDORSEMENT;
+  slot: number;
+  level: number;
+  round: number;
+  block_payload_hash: string;
 }
 
 export interface InlinedEndorsement {
@@ -64,11 +82,44 @@ export interface InlinedEndorsement {
   signature?: string;
 }
 
+export interface InlinedPreEndorsement {
+  branch: string;
+  operations: InlinedPreEndorsementContents;
+  signature?: string;
+}
+
 export type OperationContentsBallotEnum = 'nay' | 'yay' | 'pass';
 
 export interface OperationContentsEndorsement {
   kind: OpKind.ENDORSEMENT;
   level: number;
+  slot?: number;
+  round?: number;
+  block_payload_hash?: string;
+}
+
+export interface OperationContentsPreEndorsement {
+  kind: OpKind.PREENDORSEMENT;
+  slot: number;
+  level: number;
+  round: number;
+  block_payload_hash: string;
+}
+
+export interface OperationContentsDoublePreEndorsement {
+  kind: OpKind.DOUBLE_PREENDORSEMENT_EVIDENCE;
+  op1: InlinedPreEndorsement;
+  op2: InlinedPreEndorsement;
+}
+
+export interface OperationContentsSetDepositsLimit {
+  kind: OpKind.SET_DEPOSITS_LIMIT;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  limit?: string;
 }
 
 export interface OperationContentsEndorsementWithSlot {
@@ -178,6 +229,8 @@ export interface OperationContentsRegisterGlobalConstant {
 
 export type OperationContents =
   | OperationContentsEndorsement
+  | OperationContentsPreEndorsement
+  | OperationContentsDoublePreEndorsement
   | OperationContentsRevelation
   | OperationContentsDoubleEndorsement
   | OperationContentsDoubleBaking
@@ -190,12 +243,20 @@ export type OperationContents =
   | OperationContentsDelegation
   | OperationContentsEndorsementWithSlot
   | OperationContentsFailingNoop
-  | OperationContentsRegisterGlobalConstant;
+  | OperationContentsRegisterGlobalConstant
+  | OperationContentsSetDepositsLimit;
 
 export interface OperationContentsAndResultMetadataExtended {
   balance_updates: OperationMetadataBalanceUpdates[];
   delegate: string;
-  slots: number[];
+  slots?: number[];
+  endorsement_power?: number;
+}
+
+export interface OperationContentsAndResultMetadataPreEndorsement {
+  balance_updates: OperationMetadataBalanceUpdates[];
+  delegate: string;
+  preendorsement_power: number;
 }
 
 export interface OperationContentsAndResultMetadataReveal {
@@ -222,16 +283,40 @@ export interface OperationContentsAndResultMetadataRegisterGlobalConstant {
   internal_operation_results?: InternalOperationResult[];
 }
 
+export interface OperationContentsAndResultMetadataSetDepositsLimit {
+  balance_updates: OperationMetadataBalanceUpdates[];
+  operation_result: OperationResultSetDepositsLimit;
+  internal_operation_results?: InternalOperationResult[];
+}
+
 export interface OperationContentsAndResultMetadata {
   balance_updates: OperationMetadataBalanceUpdates[];
 }
 
 export interface OperationContentsAndResultEndorsement {
   kind: OpKind.ENDORSEMENT;
+  block_payload_hash?: string;
   level: number;
+  round?: number;
+  slot?: number;
   metadata: OperationContentsAndResultMetadataExtended;
 }
 
+export interface OperationContentsAndResultPreEndorsement {
+  kind: OpKind.PREENDORSEMENT;
+  slot: number;
+  level: number;
+  round: number;
+  block_payload_hash: string;
+  metadata: OperationContentsAndResultMetadataPreEndorsement;
+}
+
+export interface OperationContentsAndResultDoublePreEndorsement {
+  kind: OpKind.DOUBLE_PREENDORSEMENT_EVIDENCE;
+  op1: InlinedPreEndorsement;
+  op2: InlinedPreEndorsement;
+  metadata: OperationContentsAndResultMetadata;
+}
 export interface OperationContentsAndResultEndorsementWithSlot {
   kind: OpKind.ENDORSEMENT_WITH_SLOT;
   endorsement: InlinedEndorsement;
@@ -329,8 +414,21 @@ export interface OperationContentsAndResultRegisterGlobalConstant {
   metadata: OperationContentsAndResultMetadataRegisterGlobalConstant;
 }
 
+export interface OperationContentsAndResultSetDepositsLimit {
+  kind: OpKind.SET_DEPOSITS_LIMIT;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  limit?: string;
+  metadata: OperationContentsAndResultMetadataSetDepositsLimit;
+}
+
 export type OperationContentsAndResult =
   | OperationContentsAndResultEndorsement
+  | OperationContentsAndResultPreEndorsement
+  | OperationContentsAndResultDoublePreEndorsement
   | OperationContentsAndResultRevelation
   | OperationContentsAndResultDoubleEndorsement
   | OperationContentsAndResultDoubleBaking
@@ -342,7 +440,8 @@ export type OperationContentsAndResult =
   | OperationContentsAndResultOrigination
   | OperationContentsAndResultDelegation
   | OperationContentsAndResultEndorsementWithSlot
-  | OperationContentsAndResultRegisterGlobalConstant;
+  | OperationContentsAndResultRegisterGlobalConstant
+  | OperationContentsAndResultSetDepositsLimit;
 
 export interface OperationEntry {
   protocol: string;
@@ -366,7 +465,15 @@ export type BakingRightsArgumentsDelegate = string | string[];
 export type BakingRightsArgumentsCycle = number | number[];
 export type BakingRightsArgumentsLevel = number | number[];
 
-export interface BakingRightsQueryArguments {
+export type BakingRightsQueryArguments =
+  | BakingRightsQueryArgumentsProto12
+  | BakingRightsQueryArgumentsBase;
+
+export interface BakingRightsQueryArgumentsProto12
+  extends Omit<BakingRightsQueryArgumentsBase, 'max_priority'> {
+  max_round?: string;
+}
+export interface BakingRightsQueryArgumentsBase {
   level?: BakingRightsArgumentsLevel;
   cycle?: BakingRightsArgumentsCycle;
   delegate?: BakingRightsArgumentsDelegate;
@@ -377,7 +484,8 @@ export interface BakingRightsQueryArguments {
 export interface BakingRightsResponseItem {
   level: number;
   delegate: string;
-  priority: number;
+  priority?: number;
+  round?: number;
   estimated_time?: Date;
 }
 
@@ -393,10 +501,16 @@ export interface EndorsingRightsQueryArguments {
   delegate?: EndorsingRightsArgumentsDelegate;
 }
 
+export interface EndorsingRightsResponseItemDelegates {
+  delegate: string;
+  first_slot: number;
+  endorsing_power: number;
+}
 export interface EndorsingRightsResponseItem {
   level: number;
-  delegate: string;
-  slots: number[];
+  delegate?: string;
+  delegates?: EndorsingRightsResponseItemDelegates[];
+  slots?: number[];
   estimated_time?: Date;
 }
 
@@ -442,23 +556,6 @@ export type ProposalsResponseItem = [string, number];
 
 export type ProposalsResponse = ProposalsResponseItem[];
 
-export interface RawBlockHeaderResponse {
-  protocol: string;
-  chain_id: string;
-  hash: string;
-  level: number;
-  proto: number;
-  predecessor: string;
-  timestamp: string;
-  validation_pass: number;
-  operations_hash: string;
-  fitness: string[];
-  context: string;
-  priority: number;
-  proof_of_work_nonce: string;
-  signature: string;
-}
-
 export interface BlockHeaderResponse {
   protocol: string;
   chain_id: string;
@@ -471,8 +568,11 @@ export interface BlockHeaderResponse {
   operations_hash: string;
   fitness: string[];
   context: string;
-  priority: number;
+  payload_hash?: string;
+  payload_round?: number;
+  priority?: number;
   proof_of_work_nonce: string;
+  liquidity_baking_escape_vote?: boolean;
   signature: string;
 }
 
@@ -508,8 +608,8 @@ export type ForgeOperationsParams = Pick<OperationObject, 'branch' | 'contents'>
 
 export type TimeStampMixed = Date | string;
 
-export type BalanceUpdateKindEnum = 'contract' | 'freezer';
-export type BalanceUpdateCategoryEnum = 'rewards' | 'fees' | 'deposits';
+export type BalanceUpdateKindEnum = MetadataBalanceUpdatesKindEnum;
+export type BalanceUpdateCategoryEnum = MetadataBalanceUpdatesCategoryEnum;
 
 export interface MichelsonV1ExpressionBase {
   int?: string;
@@ -557,7 +657,8 @@ export type InternalOperationResultKindEnum =
   | OpKind.TRANSACTION
   | OpKind.ORIGINATION
   | OpKind.DELEGATION
-  | OpKind.REGISTER_GLOBAL_CONSTANT;
+  | OpKind.REGISTER_GLOBAL_CONSTANT
+  | OpKind.SET_DEPOSITS_LIMIT;
 
 export type SuccessfulManagerOperationResultKindEnum =
   | OpKind.REVEAL
@@ -570,9 +671,17 @@ export type InternalOperationResultEnum =
   | OperationResultTransaction
   | OperationResultDelegation
   | OperationResultOrigination
-  | OperationResultRegisterGlobalConstant;
+  | OperationResultRegisterGlobalConstant
+  | OperationResultSetDepositsLimit;
 
 export interface OperationResultDelegation {
+  status: OperationResultStatusEnum;
+  consumed_gas?: string;
+  errors?: TezosGenericOperationError[];
+  consumed_milligas?: string;
+}
+
+export interface OperationResultSetDepositsLimit {
   status: OperationResultStatusEnum;
   consumed_gas?: string;
   errors?: TezosGenericOperationError[];
@@ -646,6 +755,7 @@ export interface InternalOperationResult {
   delegate?: string;
   script?: ScriptedContracts;
   value?: MichelsonV1Expression;
+  limit?: string;
   result: InternalOperationResultEnum;
 }
 
@@ -662,15 +772,49 @@ export interface SuccessfulManagerOperationResult {
   lazy_storage_diff?: LazyStorageDiff[];
 }
 
-export type MetadataBalanceUpdatesKindEnum = 'contract' | 'freezer';
-export type MetadataBalanceUpdatesCategoryEnum = 'rewards' | 'fees' | 'deposits';
-export type MetadataBalanceUpdatesOriginEnum = 'block' | 'migration' | 'subsidy';
+export type MetadataBalanceUpdatesKindEnum =
+  | 'contract'
+  | 'freezer'
+  | 'accumulator'
+  | 'burned'
+  | 'commitment'
+  | 'minted';
+
+export enum METADATA_BALANCE_UPDATES_CATEGORY {
+  BAKING_REWARDS = 'baking rewards',
+  REWARDS = 'rewards',
+  FEES = 'fees',
+  DEPOSITS = 'deposits',
+  LEGACY_REWARDS = 'legacy_rewards',
+  LEGACY_FEES = 'legacy_fees',
+  LEGACY_DEPOSITS = 'legacy_deposits',
+  BLOCK_FEES = 'block fees',
+  NONCE_REVELATION_REWARDS = 'nonce revelation rewards',
+  DOUBLE_SIGNING_EVIDENCE_REWARDS = 'double signing evidence rewards',
+  ENDORSING_REWARDS = 'endorsing rewards',
+  BAKING_BONUSES = 'baking bonuses',
+  STORAGE_FEES = 'storage fees',
+  PUNISHMENTS = 'punishments',
+  LOST_ENDORSING_REWARDS = 'lost endorsing rewards',
+  SUBSIDY = 'subsidy',
+  BURNED = 'burned',
+  COMMITMENT = 'commitment',
+  BOOTSTRAP = 'bootstrap',
+  INVOICE = 'invoice',
+  MINTED = 'minted',
+}
+export type MetadataBalanceUpdatesCategoryEnum = METADATA_BALANCE_UPDATES_CATEGORY;
+
+export type MetadataBalanceUpdatesOriginEnum = 'block' | 'migration' | 'subsidy' | 'simulation';
 
 export interface OperationMetadataBalanceUpdates {
   kind: MetadataBalanceUpdatesKindEnum;
   category?: MetadataBalanceUpdatesCategoryEnum;
   contract?: string;
   delegate?: string;
+  participation?: boolean;
+  revelation?: boolean;
+  committer?: string;
   cycle?: number;
   change: string;
   origin?: MetadataBalanceUpdatesOriginEnum;
@@ -917,6 +1061,7 @@ export interface BlockMetadata {
   max_operation_data_length: number;
   max_block_header_length: number;
   max_operation_list_length: MaxOperationListLength[];
+  proposer?: string;
   baker: string;
   level?: Level;
   level_info?: LevelInfo;
@@ -952,6 +1097,7 @@ export type RunCodeResult = {
   storage: MichelsonV1Expression;
   operations: InternalOperationResult[];
   big_map_diff?: ContractBigMapDiff;
+  lazy_storage_diff?: LazyStorageDiff;
 };
 
 export type RPCRunViewParam = {
@@ -989,7 +1135,7 @@ export interface OperationContentsAndResultOrigination {
 
 export interface VotingPeriodResult {
   index: number;
-  kind: string;
+  kind: PeriodKindResponse;
   start_position: number;
 }
 

--- a/packages/taquito-rpc/test/data/rpc-responses.ts
+++ b/packages/taquito-rpc/test/data/rpc-responses.ts
@@ -2484,3 +2484,930 @@ export const protocols = {
   protocol: 'PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx',
   next_protocol: 'PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx',
 };
+
+export const delegatesIthacanetSample = {
+  full_balance: '1198951292321',
+  current_frozen_deposits: '120167343864',
+  frozen_deposits: '120167343864',
+  staking_balance: '1203308804406',
+  delegated_contracts: ['tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD'],
+  delegated_balance: '4357512085',
+  deactivated: false,
+  grace_period: 37,
+  voting_power: 199,
+};
+
+export const blockIthacanetSample = {
+  protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+  chain_id: 'NetXnHfVqm9iesp',
+  hash: 'BMGdK16iMkm4YmgAneYuvd7B4R5S8nYQKFfKzXCKMHP1FqS5hXQ',
+  header: {
+    level: 135596,
+    proto: 2,
+    predecessor: 'BLgx6Cr7DYwXEexuz828mBUqCKotCXo8PRAN55A9wovUrYWvao8',
+    timestamp: '2022-02-24T01:09:20Z',
+    validation_pass: 4,
+    operations_hash: 'LLoaKP1SEeTE1ziKFRHipDYihitAoTHhEZbiartSvehqMPvu7v661',
+    fitness: ['02', '000211ac', '', 'ffffffff', '00000000'],
+    context: 'CoVkVfBsmMSCeTLcBesUe4TdhDhvZxhm8SN48Rky5B3aD8U92hY9',
+    payload_hash: 'vh28CE8X2KKMvt5S4aGzPdMq5FpcfVRSoeyU3D3TUdVyk9zucR31',
+    payload_round: 0,
+    proof_of_work_nonce: '409a3f3f250d0100',
+    liquidity_baking_escape_vote: false,
+    signature:
+      'sigtWPWubCNXDfaH7NZQcei2hzBbHKQtw56z2WRvrmyPNBLRYP2cNAycFob1Dr8MBbbCGtCUny2BaEbzBa4kVEadMNrGp6Mk',
+  },
+  metadata: {
+    protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+    next_protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+    test_chain_status: {
+      status: 'not_running',
+    },
+    max_operations_ttl: 120,
+    max_operation_data_length: 32768,
+    max_block_header_length: 289,
+    max_operation_list_length: [
+      {
+        max_size: 4194304,
+        max_op: 2048,
+      },
+      {
+        max_size: 32768,
+      },
+      {
+        max_size: 135168,
+        max_op: 132,
+      },
+      {
+        max_size: 524288,
+      },
+    ],
+    proposer: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+    baker: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+    level_info: {
+      level: 135596,
+      level_position: 135595,
+      cycle: 33,
+      cycle_position: 427,
+      expected_commitment: false,
+    },
+    voting_period_info: {
+      voting_period: {
+        index: 6,
+        kind: 'proposal',
+        start_position: 122880,
+      },
+      position: 12715,
+      remaining: 7764,
+    },
+    nonce_hash: null,
+    consumed_gas: '1000000',
+    deactivated: [],
+    balance_updates: [
+      {
+        kind: 'accumulator',
+        category: 'block fees',
+        change: '-1500',
+        origin: 'block',
+      },
+      {
+        kind: 'minted',
+        category: 'baking rewards',
+        change: '-5000000',
+        origin: 'block',
+      },
+      {
+        kind: 'contract',
+        contract: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+        change: '5001500',
+        origin: 'block',
+      },
+      {
+        kind: 'minted',
+        category: 'baking bonuses',
+        change: '-4217424',
+        origin: 'block',
+      },
+      {
+        kind: 'contract',
+        contract: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+        change: '4217424',
+        origin: 'block',
+      },
+    ],
+    liquidity_baking_escape_ema: 119624,
+    implicit_operations_results: [
+      {
+        kind: 'transaction',
+        storage: [
+          {
+            int: '1',
+          },
+          {
+            int: '338987500100',
+          },
+          {
+            int: '100',
+          },
+          {
+            bytes: '01e927f00ef734dfc85919635e9afc9166c83ef9fc00',
+          },
+          {
+            bytes: '0115eb0104481a6d7921160bc982c5e0a561cd8a3a00',
+          },
+        ],
+        balance_updates: [
+          {
+            kind: 'minted',
+            category: 'subsidy',
+            change: '-2500000',
+            origin: 'subsidy',
+          },
+          {
+            kind: 'contract',
+            contract: 'KT1TxqZ8QtKvLu3V3JH7Gx58n7Co8pgtpQU5',
+            change: '2500000',
+            origin: 'subsidy',
+          },
+        ],
+        consumed_gas: '225',
+        consumed_milligas: '224023',
+        storage_size: '4632',
+      },
+    ],
+  },
+  operations: [
+    [
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooqwt58nxiSHAsmwaBDux3LoEkNE9p14v1TXtnB4CfEaobgHuZ2',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 0,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1iZ9LkpAhN8X1L6RpBtfy3wxpEWzFrXz8j',
+              endorsement_power: 206,
+            },
+          },
+        ],
+        signature:
+          'sigT3AuNgusteshSqt2J5aha7iSsYAXsYVGAr62RNZkrd1Gp6JjY59CtD33a4zyv57ZwV7J5JvWRD7uZrwaE6NSzmP61SGkb',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opZP7VfVcdqY5ivF5tyFYr48SR4wj74wrc4hQHyQWLv5azBZtiN',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 1,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1RuHDSj9P7mNNhfKxsyLGRDahTX5QD1DdP',
+              endorsement_power: 121,
+            },
+          },
+        ],
+        signature:
+          'sigdipDBAxcvLShbKRHNkBoSxxFUr2bTnoVsaM3df8zZhmNex1SefwfNmBJQPePvXSyePWMHSxQiDxpCDkzppEEade6eaSjh',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onxcESouatMhSqYxmtQPtM99df28TYavNR2izyJtULDG29eq5FY',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 2,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1RJ74UepJA9tigjoEeUEFajowzVB3QQaVx',
+              endorsement_power: 257,
+            },
+          },
+        ],
+        signature:
+          'sigeNkH2F3rFUha9Qr1kunmoTHMsWcDKtjh6owGkmBu1xJW7VWfFvgGJtz3qvi2a7npnTfLzVPKroAQwTc8XjY3rMNwDZuUr',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'op2gAd6kzpWPViXxC5QhH62HhtRjjthf2QT78C9vC7epL9V5sxo',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 3,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
+              endorsement_power: 1227,
+            },
+          },
+        ],
+        signature:
+          'sigVwJmrALwEdqetE3Z6EDJyGpett54p4A68xKSpvZMnS2aJZa6Dqr6hiQFroEaV97VsZdVoBZZK1pn7o5CvwZ6BuHG89v7j',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'oorGPbxDrdFc8aZfa7BSLm2v2x3DEWdnThvvq6sxwv2Xbra74A9',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 4,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1XMiZwHpHZ8a1AfwRWKfzLskJgZNyV8PHs',
+              endorsement_power: 139,
+            },
+          },
+        ],
+        signature:
+          'sigRz9Ev7mwTiRtVdBegKCGHLqWz3JSt8HwwmmPoTNYEHyijovj62MRHQBAuaKVi6c7rwoP2451v1ejKB1diHYvgQ2L9iVBj',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opLpk7KV13f8ZkjZrf15PW6gjaiBAeJeWgz3xsgcHv538afebPR',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 5,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1XGwK6kkiJaq2ZEJYcWEj5Tc8bcV6pNHqV',
+              endorsement_power: 48,
+            },
+          },
+        ],
+        signature:
+          'sigXSUhDQmNG4PuQR6Eaz5ffDsL3upXZ1QwsSd7Q4LTTkkucbsYTqorgpY9dh28XtcTFkxi6cGYN2cUUPvDaMXZxX4nJ4Zg2',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'op55vJPHBNdwmAztCGSEezNgUBMLrLa19F7FXGt4mXmYBJ2rz6i',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 7,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1cg5EqC3WdZgRSvGJeW328S4KQNrT4jvyv',
+              endorsement_power: 264,
+            },
+          },
+        ],
+        signature:
+          'sigWtL6YhYswrxoBxACy7P8dwrcWW4syiTeeggTL5sLyS1PdQUYaTMVgvTzWmdX5LdpC4JSB5o3xxF941ac3nbnFtzXgwMYc',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onxq8YLBdsL8AJy81MXrsSMKdBKFnLk7GVqAUxjjoCLFt6D8HMN',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 8,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1NGS7FEGGfEFp5XRVkHBqVqSQ8VuumF9j3',
+              endorsement_power: 33,
+            },
+          },
+        ],
+        signature:
+          'sigpDY5wQs7Rxo7sFTcJUkxzXeBMvbnseLZaLAT5JB95iGS9ndwdQF1WYLSdAYDhwiXKuZpcGDFLHipHYizpQh8qQFg8xrYU',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onqHgJw1HWxoHucpim35NQ2t4V4sPzJmPTPhru4cxuBJuMjQzwh',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 10,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1TGKSrZrBpND3PELJ43nVdyadoeiM1WMzb',
+              endorsement_power: 164,
+            },
+          },
+        ],
+        signature:
+          'sigUfJLBuU6HnaCVRDvFG6YELjMy3YmoMwj8ohgaYt9mTQUbK28AkfxjDcck72e3LsL6KGBZZjmSWDwwU6DtJanM5orRTubY',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooCYNg4ZMQWt3yzfyrDbmK6dtyMuwYr6spj2eCCoJf76iZeP3mP',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 12,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1MeT8NACB8Q4uV9dPQ3YxXBmYgapbxQxQ5',
+              endorsement_power: 782,
+            },
+          },
+        ],
+        signature:
+          'sigWwS6Cqc32rrngX136d2KKfp9SgBDdosgA2HoALEk62tRMjU6LJSa6m6SDnrKitAZrXTtD9VguMCc61X8oUuYyYt5nT1CF',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opDt75d4MTscbTgXzcJVrKD25QPofMpkTzofCAeRZgskLYwbJX5',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 13,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1dqPQn5HXNJ7yjcqBx2w6sozjPXTV1kpfh',
+              endorsement_power: 156,
+            },
+          },
+        ],
+        signature:
+          'sigijCvAxjub2QdmhNT4wQkppQDYrKAxt7MN1v9iwRszcR3bMkKK6VfACHpy7RkQ4VvN3caPMJf6rhnLRdgpAqpQrAwj6KBT',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'oohJgzphmFhuqPzhhSgMThmeuUQNmpqbwUMjc2tPCGryQTFDCQ8',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 17,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1foXHgRzdYdaLgX6XhpZGxbBv42LZ6ubvE',
+              endorsement_power: 237,
+            },
+          },
+        ],
+        signature:
+          'sigQkUSHt6izTh7TNn3GTtELiL6rypCYUYHFPU65FXWojV6xhsL7jDkJipxSLvpPhshK8d7EebWSe2PhFrtqgUWBbuGibNtm',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooQnVunqu4u6KVD65kKfruyh4fUDLD8ahqmvg3tWQbo1WX6yreK',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 18,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1NiaviJwtMbpEcNqSP6neeoBYj8Brb3QPv',
+              endorsement_power: 240,
+            },
+          },
+        ],
+        signature:
+          'sigqVDESVHH7tkjtyuM63TsL28C3HSjmesdGJn7ALFKVQHn1Ciw23PhAXeeR3iS9LtVihM7LQy4hqjZhZqCWnP5BmoPgXSFr',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooUzJx1JK2uMnSxzwTzN7VCaaGropVm32w1CMXc25fLwBvNoSiF',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 20,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1LQ32syCNyGj6FdAuJfko42Wep87iYZk8k',
+              endorsement_power: 159,
+            },
+          },
+        ],
+        signature:
+          'sigTcHdNzSGKd3WoKTcwFYvZXseN3oya2eNnRWvnh3yjDoqjB4mJedUrvVPHb3XphnejGhmqscWQeqo8qz5SMJGFvSLsaU5R',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onfyPPCxtU937rMKNtkXV978ckQSnTqgM9VMEsB18ha9QXHZbyw',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 28,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1funU3PjPsuXvmtXMgnAckY1s4pNT6V7WJ',
+              endorsement_power: 152,
+            },
+          },
+        ],
+        signature:
+          'sigfiyUP39iz8GGq6opn5eMiUqGCJ1vRWF8r92ByyeL7zhGe7b21WEKREYNmAPfhcWFWHm9rFRB5uav4LMFd2V6NCwkQtsaF',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooosvu7cCgZZG9E8SYgrNBFBJcVtTnrhhuoEuckNGzsEi5ug8uk',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 29,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz3Q67aMz7gSMiQRcW729sXSfuMtkyAHYfqc',
+              endorsement_power: 158,
+            },
+          },
+        ],
+        signature:
+          'sigqFLE4Q2uZ6yMo8QWjrsbzVKV4bWNWbppP5ZhLDsvL83HbzJQG2ABHbCALrqXNrZR1znRcvAaB7JYEHDScw9tqWVN2VpKt',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooT5Fy1ZkamhGPBKSE6uFhQicoaZJNBC4AsoWo9F9v7W6AVRvpv',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 33,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1cXeGHP8Urj2pQRwpAkCdPGbCdqFUPsQwU',
+              endorsement_power: 163,
+            },
+          },
+        ],
+        signature:
+          'sigvGuQyTgdreAChYGAjUYR76pQSKKTq7ed4vFuzSGe6sZyiSa1uXS8wRDqH5nXTugTKs6S7sSDps4UsT6SRuTXQFN5iDekk',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onway6W9qLwef1ejbEFPtKiU6wzjubKfj6YorREHtiaZhNQuRuD',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 35,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1ituzNz9MGaMSL9dVDN7jE5SArCEWNmZbS',
+              endorsement_power: 161,
+            },
+          },
+        ],
+        signature:
+          'sigN9vEVaZerpXewKGoDUhXqDoyw69jawRuewDAf55z839E4JSaW3KDGX3AZHN5vRxPxiQLTUmvnUCTxK73fQL63aJ8CMiLF',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'op2tvcwvEN8vDoBQdHinKCpJpq5xr8uhXjESfNpQg4dUYKXv3RC',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 43,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1hm7NuCGNSKZQLQSawjUnehJcX8yCBcCAq',
+              endorsement_power: 162,
+            },
+          },
+        ],
+        signature:
+          'sigmCvUw4dFVcru7Vpa4yiQKh8M5zX4EPXNwg5VTggXDiQmxTeZdwsKggZJwh3CDyiBWvLL7gnnbCK644Kwy59xXpZvQi19h',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onr9HZHYKAgRxrZKgvQWraBGaGAoWGqtEaT8bArT9JzfxisgWTw',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 44,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1Q7YBzLJkw87c2FdwaWuGKyacSDc4QghzQ',
+              endorsement_power: 137,
+            },
+          },
+        ],
+        signature:
+          'sigwKZiwNPK4mw5eEBBGh8TNNGuhuQ2snncTLWuQhMxs9GFxMFRD8GrkLUwsPQV84Qcr6pwbFFPFQx5U6TUBT7ZXU9jovyLY',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opUPRQxsDU1XsppujmWr66YwQLD135vApq6EbVz7mtY58EKCSGq',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 46,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1NFs6yP2sXd5vAAbR43bbDRpV2nahDZope',
+              endorsement_power: 117,
+            },
+          },
+        ],
+        signature:
+          'siggYsKR7C7hMFfUXNv4KvUx9t2djbZxVHeSJQvd5Zcmz8tg5bCZLmXV8rwAeB5bFahuVn5z6iAp8SMXT35peAPc37256pEE',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooM4BoirczR6W8hXEVsYQ8cHerbHbE9in4z5wMS2AhxvP2Ufad4',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 47,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1KkJtLB9pMdLKNpVRNZw9zmysrxKmYcRGU',
+              endorsement_power: 158,
+            },
+          },
+        ],
+        signature:
+          'sigpDri9hyWVNm6VrnS8Kr4yY3bdNXEWwXPmUEMbvJSM6nLEgzHczAN9QQ73WiHv6xJdjdhgUjitkHkyU8tsmEHSpJMGLrTt',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooLKxLjcVBoeB2GJ2QNg6afi4HwUQ2upCfaxWsjT4k1nrtxmL8h',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 48,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1V9CRVyKP3roXsnjcFJP3p9DSXX63KL7iP',
+              endorsement_power: 166,
+            },
+          },
+        ],
+        signature:
+          'sigVjebUbAjkjvw1wyvQ73FyEn9GJfnytuqN9Xd3ghEzaFyacaWEiD7c1ANv67XYDgrquV3GsHF29booHXinSjGjP4cAgcRU',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'oo36GYoDhvBuhb4wqFRRZ2ugLJNkKfHGmcaHhjLCg9SgdiQPJSY',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 54,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1Zt8QQ9aBznYNk5LUBjtME9DuExomw9YRs',
+              endorsement_power: 153,
+            },
+          },
+        ],
+        signature:
+          'sigV2Cfek4NvEY5CvN91nJLfAG2xG7r8hAt3nZQFPNYu5Qtz3TEQbYLxfwbs8UozKvv8bwAzVk35L9VKgcMUkaEZ3NHsYYg1',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'oopWQdrwuxWCBkw7qaVesBLCsGExxuhRuU7FJqQuA9pQcr7nPzw',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 59,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1e841Z7k7XHSoTSyHyBHG2Gijv7DzzjEBb',
+              endorsement_power: 170,
+            },
+          },
+        ],
+        signature:
+          'signyax1oDM1SxWoQir1aMRNXnm1zDnSvLyZnGdPZzh8kqYiK7GqiNb9tP3DUxcLnZeYtiQbWNuBCf6eZzXnXtc7mUhYXAHV',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'oo4t2WvJgwZhAsf5CwcDtKCfSkiaKp9wTNYL7LuAbJ9k3sJvTEg',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 61,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1e42w8ZaGAbM3gucbBy8iRypdbnqUj7oWY',
+              endorsement_power: 74,
+            },
+          },
+        ],
+        signature:
+          'signNkorAErY1hBzFRkzeMTqUy6inFFTd9EmpYPKfFyUGX139DyHtsfUHfumPFHeomLtXZMmGQ5g2vi4R1tveaS9yQvz7aba',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opUy2TmnHxDqjUt3Ht7dCsWyLLNz9sRpA1eC5qZqkhyvHND67pu',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 64,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1QXAAasy8TciwfvDC4a7MWo1tm3K37uN9Y',
+              endorsement_power: 153,
+            },
+          },
+        ],
+        signature:
+          'sigtoch1ijiGuNGW3qHtAngiEDhEqL5T4acdNEGKt4ew2NoPNkxScgshoxttV45NYxKpLNw6J3FQHPRyaT22fGgwbd9ySu3k',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ooArbFfPVgM6mc3RUroxf2qsimXProumPK6XuidgfjosoT2VN34',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 70,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1MvCE9dczhoij2bd4sLL2AfVuMtWfFAoCN',
+              endorsement_power: 137,
+            },
+          },
+        ],
+        signature:
+          'sigb2eh47AatunkNSZPVpsZg9nqGqu8GG2C24Hx4D6SoRJ1sz4jgFPjAhP1rk9BkRJ8GfM3AYyY7PGdFqzod3a6q1Wk4ZRVK',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'ood93Z7NmwMeLSo2dW8tBUBst3p3ogcEmkUrDR9T8coHrVApZzF',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 71,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1PirbogVqfmBT9XCuYJ1KnDx4bnMSYfGru',
+              endorsement_power: 119,
+            },
+          },
+        ],
+        signature:
+          'sigiSzxJ1dSeHujvRtv1VKCAc5V1mu5ftRfyutfgKyjjCLGRrNG73k8jb5nqjiTu9T79L4oKdf1g7AEQMCK6eENWPcaMwfFN',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'onjvGqyScQLdGb5cMPwHbnd9UVmh3MhcUze3P1wGHSXRarfxAwY',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 75,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1edUYGqBtteStneTGDBrQWTFmq9cnEELiW',
+              endorsement_power: 135,
+            },
+          },
+        ],
+        signature:
+          'siggwc4K8yWEU8ttzA8HhQh15zV2fYcyK6nfbuVGVs3G2TbM1nVrJxLiC6sHKqBtBuofiC8pYzDLJxVY9zdCzGqBhyMPCw4M',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opBqy3cLQugeT2xVvKoJUn3yLp79hzuXHc7r5BqSa5HHHFddYgB',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 85,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD',
+              endorsement_power: 139,
+            },
+          },
+        ],
+        signature:
+          'sigoZ5bh1XPA8kHFkBCs4U9Dq6nT9Ng3i9LENKKCHg8k96TP4KVcFmh1iyVTpxSSiM8V21bnZ7W91KsDL2vekru1ACXsU8Yp',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'opCRv7Ewfh3s96PDiVKPC2c4A9oT6nf8FVeQYB2EUEJFT81UTET',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 90,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1SFbdg2jjkixHNU1Jm9f8JA4pYnMXsgATC',
+              endorsement_power: 5,
+            },
+          },
+        ],
+        signature:
+          'sigcmrbc6rZnDpEkR268Pvzz2GPSRi8nWnTthYXt8L6Tg9pB4vzdh4uy8gKYrMQFbJTwRSsyPa31xR5u8FMH9xMAfrWn9r48',
+      },
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'op9TeE362FGyayWVRghVrRxm2FdezqPdqJRM4VTeq5C6ievFDkd',
+        branch: 'BLzJ1MtqtmWwnG6ZdX7LPygJGvaE51eDqX55KVQM4HNHcVbeDKs',
+        contents: [
+          {
+            kind: 'endorsement',
+            slot: 116,
+            level: 135595,
+            round: 0,
+            block_payload_hash: 'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6',
+            metadata: {
+              balance_updates: [],
+              delegate: 'tz1RBECWBXv4tKcuDbxYmBguvdn8wzjrejHg',
+              endorsement_power: 143,
+            },
+          },
+        ],
+        signature:
+          'sigQ5nhdCPRiddmNUYLXCeBk5qs3T6fxMiitKgFJQg5Nuo8sqJTamyJctbF5Gt7MrDZEdiCcmZBj4dEHa9fjDLyCSdgHsL3x',
+      },
+    ],
+    [],
+    [],
+    [
+      {
+        protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+        chain_id: 'NetXnHfVqm9iesp',
+        hash: 'oowvQuTHNxiG8x1TzewhUHtKGLhFPbhiaaHJFKpUnvkv2h3RDsz',
+        branch: 'BLZNxWPKB9CGGZ8bCYvkq7NwHZNHLuCHnueiJz7QFEzUztT4TjP',
+        contents: [
+          {
+            kind: 'set_deposits_limit',
+            source: 'tz2FViF6XzJ4PqD5TTuaAtZScmiwpJBGBpSh',
+            fee: '1500',
+            counter: '146662',
+            gas_limit: '1000',
+            storage_limit: '10000',
+            limit: '3',
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz2FViF6XzJ4PqD5TTuaAtZScmiwpJBGBpSh',
+                  change: '-1500',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '1500',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                consumed_gas: '1000',
+                consumed_milligas: '1000000',
+              },
+            },
+          },
+        ],
+        signature:
+          'sigegUy94SxjpBw2MwKMsqFjEjbeoQu8VdcXciXRryv4KA1hMT2gGKRCKnDFinKHaaWGCZskHzo2Hb6XB1iV6gonUdhBuCuN',
+      },
+    ],
+  ],
+};

--- a/packages/taquito-rpc/test/rpc-cache.spec.ts
+++ b/packages/taquito-rpc/test/rpc-cache.spec.ts
@@ -64,7 +64,6 @@ describe('RpcClientCache test', () => {
       getEndorsingRights: jest.fn(),
       getBallotList: jest.fn(),
       getBallots: jest.fn(),
-      getCurrentPeriodKind: jest.fn(),
       getCurrentProposal: jest.fn(),
       getCurrentQuorum: jest.fn(),
       getVotesListings: jest.fn(),
@@ -98,7 +97,6 @@ describe('RpcClientCache test', () => {
     mockRpcClient.getEndorsingRights.mockReturnValue(endorsingRights);
     mockRpcClient.getBallotList.mockReturnValue(ballotList);
     mockRpcClient.getBallots.mockReturnValue(ballots);
-    mockRpcClient.getCurrentPeriodKind.mockReturnValue(currentPeriodKind);
     mockRpcClient.getCurrentProposal.mockReturnValue(currentProposal);
     mockRpcClient.getCurrentQuorum.mockReturnValue(currentQuorum);
     mockRpcClient.getVotesListings.mockReturnValue(votesListing);
@@ -138,7 +136,6 @@ describe('RpcClientCache test', () => {
     await rpcCache.getEndorsingRights();
     await rpcCache.getBallotList();
     await rpcCache.getBallots();
-    await rpcCache.getCurrentPeriodKind();
     await rpcCache.getCurrentProposal();
     await rpcCache.getCurrentQuorum();
     await rpcCache.getVotesListings();
@@ -199,9 +196,6 @@ describe('RpcClientCache test', () => {
     );
     expect(rpcCache.getAllCachedData()['rpcTest/getBallotList/head/'].response).toEqual(ballotList);
     expect(rpcCache.getAllCachedData()['rpcTest/getBallots/head/'].response).toEqual(ballots);
-    expect(rpcCache.getAllCachedData()['rpcTest/getCurrentPeriodKind/head/'].response).toEqual(
-      currentPeriodKind
-    );
     expect(rpcCache.getAllCachedData()['rpcTest/getCurrentProposal/head/'].response).toEqual(
       currentProposal
     );
@@ -257,7 +251,6 @@ describe('RpcClientCache test', () => {
     await rpcCache.getEndorsingRights({ level: 1111 }, block);
     await rpcCache.getBallotList(block);
     await rpcCache.getBallots(block);
-    await rpcCache.getCurrentPeriodKind(block);
     await rpcCache.getCurrentProposal(block);
     await rpcCache.getCurrentQuorum(block);
     await rpcCache.getVotesListings(block);
@@ -333,9 +326,6 @@ describe('RpcClientCache test', () => {
       ballots
     );
     expect(
-      rpcCache.getAllCachedData()[`rpcTest/getCurrentPeriodKind/${block.block}/`].response
-    ).toEqual(currentPeriodKind);
-    expect(
       rpcCache.getAllCachedData()[`rpcTest/getCurrentProposal/${block.block}/`].response
     ).toEqual(currentProposal);
     expect(
@@ -388,7 +378,6 @@ describe('RpcClientCache test', () => {
     await rpcCache.getEndorsingRights();
     await rpcCache.getBallotList();
     await rpcCache.getBallots();
-    await rpcCache.getCurrentPeriodKind();
     await rpcCache.getCurrentProposal();
     await rpcCache.getCurrentQuorum();
     await rpcCache.getVotesListings();

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { RpcClient } from '../src/taquito-rpc';
+import { OpKind, RpcClient } from '../src/taquito-rpc';
 import BigNumber from 'bignumber.js';
 import {
   LazyStorageDiffBigMap,
@@ -11,7 +11,10 @@ import {
   LazyStorageDiffSaplingState,
   OperationContentsAndResultRegisterGlobalConstant,
   RPCRunViewParam,
+  OperationContentsAndResultSetDepositsLimit,
+  METADATA_BALANCE_UPDATES_CATEGORY,
 } from '../src/types';
+import { blockIthacanetSample, delegatesIthacanetSample } from './data/rpc-responses';
 
 /**
  * RpcClient test
@@ -292,6 +295,25 @@ describe('RpcClient test', () => {
 
       done();
     });
+
+    it('parse the response properly, proto12', async (done) => {
+      httpBackend.createRequest.mockResolvedValue(delegatesIthacanetSample);
+      const response = await client.getDelegates(contractAddress);
+
+      expect(response).toEqual({
+        full_balance: new BigNumber('1198951292321'),
+        current_frozen_deposits: new BigNumber('120167343864'),
+        frozen_deposits: new BigNumber('120167343864'),
+        staking_balance: new BigNumber('1203308804406'),
+        delegated_contracts: ['tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD'],
+        delegated_balance: new BigNumber('4357512085'),
+        deactivated: false,
+        grace_period: 37,
+        voting_power: 199,
+      });
+
+      done();
+    });
   });
 
   describe('getBigMapKey', () => {
@@ -540,30 +562,30 @@ describe('RpcClient test', () => {
           cache_layout: ['100000000', '240000', '2560'],
           michelson_maximum_type_size: 2001,
           preserved_cycles: 3,
-          blocks_per_cycle: 2048,
-          blocks_per_commitment: 64,
-          blocks_per_stake_snapshot: 512,
-          blocks_per_voting_period: 40960,
+          blocks_per_cycle: 4096,
+          blocks_per_commitment: 32,
+          blocks_per_stake_snapshot: 256,
+          blocks_per_voting_period: 20480,
           hard_gas_limit_per_operation: '1040000',
           hard_gas_limit_per_block: '5200000',
-          proof_of_work_threshold: '-1',
-          tokens_per_roll: '8000000000',
+          proof_of_work_threshold: '70368744177663',
+          tokens_per_roll: '6000000000',
           seed_nonce_revelation_tip: '125000',
           origination_size: 257,
-          baking_reward_fixed_portion: '10000000',
-          baking_reward_bonus_per_slot: '4286',
-          endorsing_reward_per_slot: '2857',
+          baking_reward_fixed_portion: '5000000',
+          baking_reward_bonus_per_slot: '2143',
+          endorsing_reward_per_slot: '1428',
           cost_per_byte: '250',
           hard_storage_limit_per_operation: '60000',
           quorum_min: 2000,
           quorum_max: 7000,
           min_proposal_quorum: 500,
           liquidity_baking_subsidy: '2500000',
-          liquidity_baking_sunset_level: 525600,
-          liquidity_baking_escape_ema_threshold: 100000,
+          liquidity_baking_sunset_level: 10000000,
+          liquidity_baking_escape_ema_threshold: 666667,
           max_operations_time_to_live: 120,
-          minimal_block_delay: '30',
-          delay_increment_per_round: '15',
+          minimal_block_delay: '15',
+          delay_increment_per_round: '5',
           consensus_committee_size: 7000,
           consensus_threshold: 4667,
           minimal_participation_ratio: { numerator: 2, denominator: 3 },
@@ -586,13 +608,13 @@ describe('RpcClient test', () => {
         max_operation_data_length: 32768,
         max_proposals_per_delegate: 20,
         preserved_cycles: 3,
-        blocks_per_cycle: 2048,
-        blocks_per_commitment: 64,
-        blocks_per_voting_period: 40960,
+        blocks_per_cycle: 4096,
+        blocks_per_commitment: 32,
+        blocks_per_voting_period: 20480,
         hard_gas_limit_per_operation: new BigNumber(1040000),
         hard_gas_limit_per_block: new BigNumber(5200000),
-        proof_of_work_threshold: new BigNumber(-1),
-        tokens_per_roll: new BigNumber(8000000000),
+        proof_of_work_threshold: new BigNumber(70368744177663),
+        tokens_per_roll: new BigNumber(6000000000),
         seed_nonce_revelation_tip: new BigNumber(125000),
         origination_size: 257,
         cost_per_byte: new BigNumber(250),
@@ -601,20 +623,20 @@ describe('RpcClient test', () => {
         quorum_max: 7000,
         min_proposal_quorum: 500,
         liquidity_baking_subsidy: new BigNumber(2500000),
-        liquidity_baking_sunset_level: 525600,
-        liquidity_baking_escape_ema_threshold: 100000,
+        liquidity_baking_sunset_level: 10000000,
+        liquidity_baking_escape_ema_threshold: 666667,
         max_allowed_global_constants_depth: 10000,
         max_micheline_bytes_limit: 50000,
         max_micheline_node_count: 50000,
         michelson_maximum_type_size: 2001,
         cache_layout: [new BigNumber(100000000), new BigNumber(240000), new BigNumber(2560)],
-        blocks_per_stake_snapshot: 512,
-        baking_reward_fixed_portion: new BigNumber(10000000),
-        baking_reward_bonus_per_slot: new BigNumber(4286),
-        endorsing_reward_per_slot: new BigNumber(2857),
+        blocks_per_stake_snapshot: 256,
+        baking_reward_fixed_portion: new BigNumber(5000000),
+        baking_reward_bonus_per_slot: new BigNumber(2143),
+        endorsing_reward_per_slot: new BigNumber(1428),
         max_operations_time_to_live: 120,
-        minimal_block_delay: new BigNumber(30),
-        delay_increment_per_round: new BigNumber(15),
+        minimal_block_delay: new BigNumber(15),
+        delay_increment_per_round: new BigNumber(5),
         consensus_committee_size: 7000,
         consensus_threshold: 4667,
         minimal_participation_ratio: {
@@ -2269,6 +2291,118 @@ describe('RpcClient test', () => {
 
       done();
     });
+
+    it('should use enum to represent property category in balance_updates, proto 12', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+
+      const response = await client.getBlock();
+
+      // To avoid dealing with the space in the property name returned by the RPC
+      expect(response.metadata.balance_updates[0].category).toBeDefined();
+      expect(response.metadata.balance_updates[0].category).toEqual(
+        METADATA_BALANCE_UPDATES_CATEGORY.BLOCK_FEES
+      );
+      expect(response.metadata.balance_updates[1].category).toBeDefined();
+      expect(response.metadata.balance_updates[1].category).toEqual(
+        METADATA_BALANCE_UPDATES_CATEGORY.BAKING_REWARDS
+      );
+      expect(response.metadata.balance_updates[3].category).toBeDefined();
+      expect(response.metadata.balance_updates[3].category).toEqual(
+        METADATA_BALANCE_UPDATES_CATEGORY.BAKING_BONUSES
+      );
+
+      done();
+    });
+
+    it('should fetch a block and access new properties in header, proto 12', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+
+      const response = await client.getBlock();
+
+      expect(response.header.payload_hash).toBeDefined();
+      expect(response.header.payload_hash).toEqual(
+        'vh28CE8X2KKMvt5S4aGzPdMq5FpcfVRSoeyU3D3TUdVyk9zucR31'
+      );
+      expect(response.header.payload_round).toBeDefined();
+      expect(response.header.payload_round).toEqual(0);
+      expect(response.header.liquidity_baking_escape_vote).toBeDefined();
+      expect(response.header.liquidity_baking_escape_vote).toBeFalsy();
+
+      done();
+    });
+
+    it('should fetch a block and access new properties in metadata, proto 12', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+
+      const response = await client.getBlock();
+
+      expect(response.metadata.proposer).toBeDefined();
+      expect(response.metadata.proposer).toEqual('tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9');
+      expect(response.metadata.balance_updates[0].category).toBeDefined();
+
+      done();
+    });
+
+    it('should access new properties of the operation type endorsement, proto 12', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+
+      const response = await client.getBlock();
+
+      expect(response.operations[0][0].contents[0].kind).toEqual(OpKind.ENDORSEMENT);
+      const contentEndorsement = response.operations[0][0]
+        .contents[0] as OperationContentsAndResultEndorsement;
+      expect(contentEndorsement.slot).toBeDefined();
+      expect(contentEndorsement.slot).toEqual(0);
+      expect(contentEndorsement.round).toBeDefined();
+      expect(contentEndorsement.round).toEqual(0);
+      expect(contentEndorsement.block_payload_hash).toBeDefined();
+      expect(contentEndorsement.block_payload_hash).toEqual(
+        'vh2SkkaBZp19oyMUmTTXy5Q33hKKWZSAzXa7Tz2F6mtyeAgXsHC6'
+      );
+
+      expect(contentEndorsement.metadata.balance_updates).toEqual([]);
+      expect(contentEndorsement.metadata.endorsement_power).toBeDefined();
+      expect(contentEndorsement.metadata.endorsement_power).toEqual(206);
+
+      done();
+    });
+
+    it('should access new properties of the operation type set_deposits_limit, proto 12', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+
+      const response = await client.getBlock();
+
+      expect(response.operations[3][0].contents[0].kind).toEqual(OpKind.SET_DEPOSITS_LIMIT);
+      const content = response.operations[3][0]
+        .contents[0] as OperationContentsAndResultSetDepositsLimit;
+      expect(content.source).toEqual('tz2FViF6XzJ4PqD5TTuaAtZScmiwpJBGBpSh');
+      expect(content.fee).toEqual('1500');
+      expect(content.counter).toEqual('146662');
+      expect(content.gas_limit).toEqual('1000');
+      expect(content.storage_limit).toEqual('10000');
+      expect(content.limit).toBeDefined();
+      expect(content.limit).toEqual('3');
+      expect(content.metadata.balance_updates[0].kind).toEqual('contract');
+      expect(content.metadata.balance_updates[0].contract).toBeDefined();
+      expect(content.metadata.balance_updates[0].contract).toEqual(
+        'tz2FViF6XzJ4PqD5TTuaAtZScmiwpJBGBpSh'
+      );
+      expect(content.metadata.balance_updates[0].change).toBeDefined();
+      expect(content.metadata.balance_updates[0].change).toEqual('-1500');
+      expect(content.metadata.balance_updates[0].origin).toBeDefined();
+      expect(content.metadata.balance_updates[0].origin).toEqual('block');
+      expect(content.metadata.balance_updates[0].category).toBeUndefined();
+      expect(content.metadata.balance_updates[0].delegate).toBeUndefined();
+      expect(content.metadata.balance_updates[0].cycle).toBeUndefined();
+
+      expect(content.metadata.operation_result.status).toEqual('applied');
+      expect(content.metadata.operation_result.consumed_gas).toBeDefined();
+      expect(content.metadata.operation_result.consumed_gas).toEqual('1000');
+      expect(content.metadata.operation_result.consumed_milligas).toBeDefined();
+      expect(content.metadata.operation_result.consumed_milligas).toEqual('1000000');
+
+      done();
+    });
   });
 
   describe('getBakingRights', () => {
@@ -2346,7 +2480,7 @@ describe('RpcClient test', () => {
 
       expect(result[1].delegate).toEqual('tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN');
       expect(result[1].estimated_time).toEqual('2019-08-02T09:42:56Z');
-      expect(result[1].slots.length).toEqual(3);
+      expect(result[1].slots!.length).toEqual(3);
       done();
     });
   });
@@ -2403,21 +2537,6 @@ describe('RpcClient test', () => {
         url: 'root/chains/test/blocks/head/votes/ballots',
       });
       expect(response.yay).toEqual(5943);
-
-      done();
-    });
-  });
-
-  describe('getCurrentPeriodKind', () => {
-    it('query the right url and data', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve('testing_vote'));
-      const response = await client.getCurrentPeriodKind();
-
-      expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
-        method: 'GET',
-        url: 'root/chains/test/blocks/head/votes/current_period_kind',
-      });
-      expect(response).toEqual('testing_vote');
 
       done();
     });
@@ -2551,6 +2670,7 @@ describe('RpcClient test', () => {
     it('query the right url and data', async (done) => {
       const testData = {};
 
+      httpBackend.createRequest.mockResolvedValue({ content: {} });
       await client.runOperation(testData as any);
 
       expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
@@ -2559,6 +2679,48 @@ describe('RpcClient test', () => {
       });
 
       expect(httpBackend.createRequest.mock.calls[0][1]).toEqual(testData);
+
+      done();
+    });
+
+    it('should use enum for property category to avoid space in name', async (done) => {
+      const testData = {};
+
+      httpBackend.createRequest.mockResolvedValue({
+        contents: [
+          {
+            metadata: {
+              balance_updates: [
+                {
+                  category: 'storage fees',
+                  kind: 'burned',
+                  origin: 'block',
+                },
+                {
+                  category: 'block fees',
+                  change: '374',
+                  kind: 'accumulator',
+                  origin: 'block',
+                },
+                {
+                  category: 'legacy_rewards',
+                },
+              ],
+            },
+          },
+        ],
+      });
+      const response = await client.runOperation(testData as any);
+
+      const balanceUpdate =
+        'metadata' in response.contents[0]
+          ? response.contents[0]['metadata']['balance_updates']
+          : [];
+      expect(balanceUpdate[0]['category']).toEqual(METADATA_BALANCE_UPDATES_CATEGORY.STORAGE_FEES);
+      expect(balanceUpdate[1]['category']).toEqual(METADATA_BALANCE_UPDATES_CATEGORY.BLOCK_FEES);
+      expect(balanceUpdate[2]['category']).toEqual(
+        METADATA_BALANCE_UPDATES_CATEGORY.LEGACY_REWARDS
+      );
 
       done();
     });
@@ -2571,24 +2733,24 @@ describe('RpcClient test', () => {
         entrypoint: 'test',
         chain_id: 'test',
         input: {
-          string: 'test'
-        }
+          string: 'test',
+        },
       };
 
       await client.runView(testData);
-      
+
       expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
         method: 'POST',
-        url: 'root/chains/test/blocks/head/helpers/scripts/run_view'
+        url: 'root/chains/test/blocks/head/helpers/scripts/run_view',
       });
       expect(httpBackend.createRequest.mock.calls[0][1]).toEqual({
         contract: 'test',
         entrypoint: 'test',
         chain_id: 'test',
         input: {
-          string: 'test'
+          string: 'test',
         },
-        unparsing_mode: 'Readable'
+        unparsing_mode: 'Readable',
       });
       done();
     });
@@ -2599,21 +2761,21 @@ describe('RpcClient test', () => {
         entrypoint: 'test',
         chain_id: 'test',
         input: {
-          string: 'test'
+          string: 'test',
         },
-        unparsing_mode: 'Optimized'
-      }
+        unparsing_mode: 'Optimized',
+      };
 
       await client.runView(testData);
 
       expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
         method: 'POST',
-        url: 'root/chains/test/blocks/head/helpers/scripts/run_view'
+        url: 'root/chains/test/blocks/head/helpers/scripts/run_view',
       });
       expect(httpBackend.createRequest.mock.calls[0][1]).toEqual(testData);
       done();
-    })
-  })
+    });
+  });
 
   describe('packData', () => {
     it('query the right url and data', async (done) => {

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -1,5 +1,4 @@
 import {
-  BlockHeaderResponse,
   OperationContents,
   OperationContentsAndResult,
   OpKind,


### PR DESCRIPTION
Updated RPC types accordingly for Ithaca protocol. Added types representing the new operations
PREENDORSEMENT, DOUBLE_PREENDORSEMENT_EVIDENCE and SET_DEPOSITS_LIMIT, support new balance updates
kinds, categories and origins

BREAKING CHANGE: Removed the deprecated getCurrentPeriodKind method

re #1255

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
