### PR TITLE
refactor(taquito): pass protocol hash to LocalForger

### DIFF
--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -1,7 +1,6 @@
 import { RpcClient, RpcClientInterface } from '@taquito/rpc';
 import { Protocols } from './constants';
 import { Forger } from '@taquito/local-forging';
-import { RpcForger } from './forger/rpc-forger';
 import { Injector } from './injector/interface';
 import { RpcInjector } from './injector/rpc-injector';
 import { Signer } from './signer/interface';
@@ -22,6 +21,7 @@ import { retry } from 'rxjs/operators';
 import { BehaviorSubject, OperatorFunction } from 'rxjs';
 import { GlobalConstantsProvider } from './global-constants/interface-global-constants-provider';
 import { NoopGlobalConstantsProvider } from './global-constants/noop-global-constants-provider';
+import { TaquitoLocalForger } from './forger/taquito-local-forger';
 
 export interface TaquitoProvider<T, K extends Array<any>> {
   new (context: Context, ...rest: K): T;
@@ -92,7 +92,7 @@ export class Context {
     } else {
       this._rpcClient = this._rpc;
     }
-    this._forger = forger ? forger : new RpcForger(this);
+    this._forger = forger ? forger : new TaquitoLocalForger(this);
     this._injector = injector ? injector : new RpcInjector(this);
     this.operationFactory = new OperationFactory(this);
     this._walletProvider = wallet ? wallet : new LegacyWalletProvider(this);

--- a/packages/taquito/src/forger/taquito-local-forger.ts
+++ b/packages/taquito/src/forger/taquito-local-forger.ts
@@ -1,0 +1,26 @@
+import {
+  LocalForger,
+  Forger,
+  ForgeParams,
+  ForgeResponse,
+  ProtocolsHash,
+} from '@taquito/local-forging';
+import { Protocols } from '../constants';
+import { Context } from '../context';
+
+export class TaquitoLocalForger implements Forger {
+  constructor(private context: Context) {}
+
+  private async getNextProto(): Promise<ProtocolsHash> {
+    if (!this.context.proto) {
+      const { next_protocol } = await this.context.rpc.getBlockMetadata();
+      this.context.proto = next_protocol as Protocols;
+    }
+    return this.context.proto as unknown as ProtocolsHash;
+  }
+
+  async forge({ branch, contents }: ForgeParams): Promise<ForgeResponse> {
+    const forger = new LocalForger(await this.getNextProto());
+    return forger.forge({ branch, contents });
+  }
+}

--- a/packages/taquito/src/parser/michel-codec-parser.ts
+++ b/packages/taquito/src/parser/michel-codec-parser.ts
@@ -5,13 +5,17 @@ import { OriginateParams } from '../operations/types';
 import { InvalidInitParameter, InvalidCodeParameter } from '../contract/errors';
 import { Schema } from '@taquito/michelson-encoder';
 import { MichelsonV1Expression } from '@taquito/rpc';
+import { Protocols } from '../constants';
 
 export class MichelCodecParser implements ParserProvider {
   constructor(private context: Context) {}
 
   private async getNextProto(): Promise<ProtocolID> {
-    const { next_protocol } = await this.context.rpc.getBlockMetadata();
-    return next_protocol as ProtocolID;
+    if (!this.context.proto) {
+      const { next_protocol } = await this.context.rpc.getBlockMetadata();
+      this.context.proto = next_protocol as Protocols;
+    }
+    return this.context.proto as ProtocolID;
   }
 
   async parseScript(src: string): Promise<Expr[] | null> {

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -4,7 +4,7 @@
  */
 
 import { RpcClient, RpcClientInterface } from '@taquito/rpc';
-import { LocalForger, Forger } from '@taquito/local-forging';
+import { Forger } from '@taquito/local-forging';
 import { RPCBatchProvider } from './batch/rpc-batch-provider';
 import { Protocols } from './constants';
 import { ConfigConfirmation, ConfigStreamer, Context, TaquitoProvider } from './context';
@@ -23,6 +23,7 @@ import { TzProvider } from './tz/interface';
 import { VERSION } from './version';
 import { LegacyWalletProvider, Wallet, WalletProvider } from './wallet';
 import { OperationFactory } from './wallet/operation-factory';
+import { TaquitoLocalForger } from './forger/taquito-local-forger';
 
 export { MichelsonMap, UnitValue } from '@taquito/michelson-encoder';
 export { Forger, ForgeParams, ForgeResponse } from '@taquito/local-forging';
@@ -176,10 +177,11 @@ export class TezosToolkit {
 
   /**
    * @description Sets forger provider on the Tezos Taquito instance
+   * The `LocalForger` from `@taquito/local-forging` is set by default.
    *
    * @param options forger to use to interact with the Tezos network
    *
-   * @example Tezos.setForgerProvider(localForger)
+   * @example Tezos.setForgerProvider(this.getFactory(RpcForger)())
    *
    */
   setForgerProvider(forger?: SetProviderOptions['forger']) {
@@ -187,7 +189,7 @@ export class TezosToolkit {
       this._options.forger = forger;
       this._context.forger = forger;
     } else if (this._options.forger === undefined) {
-      const f = new LocalForger();
+      const f = this.getFactory(TaquitoLocalForger)();
       this._options.forger = f;
       this._context.forger = f;
     }
@@ -240,9 +242,14 @@ export class TezosToolkit {
    *
    */
   setPackerProvider(packer?: SetProviderOptions['packer']) {
-    const p = typeof packer === 'undefined' ? this.getFactory(RpcPacker)() : packer;
-    this._options.packer = p;
-    this._context.packer = p;
+    if (!this._options.packer && typeof packer === 'undefined') {
+      const p = this.getFactory(RpcPacker)();
+      this._context.packer = p;
+      this._options.packer = p;
+    } else if (typeof packer !== 'undefined') {
+      this._context.packer = packer;
+      this._options.packer = packer;
+    }
   }
 
   /**
@@ -264,12 +271,14 @@ export class TezosToolkit {
   setGlobalConstantsProvider(
     globalConstantsProvider?: SetProviderOptions['globalConstantsProvider']
   ) {
-    const g =
-      typeof globalConstantsProvider === 'undefined'
-        ? new NoopGlobalConstantsProvider()
-        : globalConstantsProvider;
-    this._options.globalConstantsProvider = g;
-    this._context.globalConstantsProvider = g;
+    if (!this._options.globalConstantsProvider && typeof globalConstantsProvider === 'undefined') {
+      const g = new NoopGlobalConstantsProvider();
+      this._context.globalConstantsProvider = g;
+      this._options.globalConstantsProvider = g;
+    } else if (typeof globalConstantsProvider !== 'undefined') {
+      this._context.globalConstantsProvider = globalConstantsProvider;
+      this._options.globalConstantsProvider = globalConstantsProvider;
+    }
   }
 
   /**

--- a/packages/taquito/test/batch/rpc-batch-provider.spec.ts
+++ b/packages/taquito/test/batch/rpc-batch-provider.spec.ts
@@ -1,354 +1,342 @@
-import { OperationBatch } from "../../src/batch/rpc-batch-provider";
-import { Context } from "../../src/context";
-import { Estimate } from "../../src/contract/estimate";
-import { OpKind, ParamsWithKind } from "../../src/operations/types";
+import { OperationBatch } from '../../src/batch/rpc-batch-provider';
+import { Context } from '../../src/context';
+import { Estimate } from '../../src/contract/estimate';
+import { OpKind, ParamsWithKind } from '../../src/operations/types';
 
 /**
  * OperationBatch test
  */
 describe('OperationBatch test', () => {
-    let mockRpcClient: {
-        getScript: jest.Mock<any, any>;
-        getStorage: jest.Mock<any, any>;
-        getBigMapExpr: jest.Mock<any, any>;
-        getBigMapKey: jest.Mock<any, any>;
-        getBlockHeader: jest.Mock<any, any>;
-        getEntrypoints: jest.Mock<any, any>;
-        getManagerKey: jest.Mock<any, any>;
-        getBlock: jest.Mock<any, any>;
-        getContract: jest.Mock<any, any>;
-        getBlockMetadata: jest.Mock<any, any>;
-        forgeOperations: jest.Mock<any, any>;
-        injectOperation: jest.Mock<any, any>;
-        packData: jest.Mock<any, any>;
-        preapplyOperations: jest.Mock<any, any>;
-        getChainId: jest.Mock<any, any>;
-        getSaplingDiffById: jest.Mock<any, any>;
+  let context: Context;
+  let operationBatch: OperationBatch;
+  let mockRpcClient: {
+    getScript: jest.Mock<any, any>;
+    getStorage: jest.Mock<any, any>;
+    getBigMapExpr: jest.Mock<any, any>;
+    getBigMapKey: jest.Mock<any, any>;
+    getBlockHeader: jest.Mock<any, any>;
+    getEntrypoints: jest.Mock<any, any>;
+    getManagerKey: jest.Mock<any, any>;
+    getBlock: jest.Mock<any, any>;
+    getContract: jest.Mock<any, any>;
+    getBlockMetadata: jest.Mock<any, any>;
+    injectOperation: jest.Mock<any, any>;
+    packData: jest.Mock<any, any>;
+    preapplyOperations: jest.Mock<any, any>;
+    getChainId: jest.Mock<any, any>;
+    getSaplingDiffById: jest.Mock<any, any>;
+  };
+
+  let mockSigner: {
+    publicKeyHash: jest.Mock<any, any>;
+    publicKey: jest.Mock<any, any>;
+    sign: jest.Mock<any, any>;
+  };
+
+  let mockEstimate: {
+    originate: jest.Mock<any, any>;
+    transfer: jest.Mock<any, any>;
+    setDelegate: jest.Mock<any, any>;
+    registerDelegate: jest.Mock<any, any>;
+    batch: jest.Mock<any, any>;
+    reveal: jest.Mock<any, any>;
+    registerGlobalConstant: jest.Mock<any, any>;
+  };
+
+  let mockForger: {
+    forge: jest.Mock<any, any>;
+  };
+
+  beforeEach(() => {
+    mockRpcClient = {
+      getBigMapExpr: jest.fn(),
+      getEntrypoints: jest.fn(),
+      getBlock: jest.fn(),
+      getScript: jest.fn(),
+      getManagerKey: jest.fn(),
+      getStorage: jest.fn(),
+      getBigMapKey: jest.fn(),
+      getBlockHeader: jest.fn(),
+      getBlockMetadata: jest.fn(),
+      getContract: jest.fn(),
+      injectOperation: jest.fn(),
+      packData: jest.fn(),
+      preapplyOperations: jest.fn(),
+      getChainId: jest.fn(),
+      getSaplingDiffById: jest.fn(),
     };
 
-    let mockSigner: {
-        publicKeyHash: jest.Mock<any, any>;
-        publicKey: jest.Mock<any, any>;
-        sign: jest.Mock<any, any>;
+    mockSigner = {
+      publicKeyHash: jest.fn(),
+      publicKey: jest.fn(),
+      sign: jest.fn(),
     };
 
-    let mockEstimate: {
-        originate: jest.Mock<any, any>;
-        transfer: jest.Mock<any, any>;
-        setDelegate: jest.Mock<any, any>;
-        registerDelegate: jest.Mock<any, any>;
-        batch: jest.Mock<any, any>;
-        reveal: jest.Mock<any, any>;
-        registerGlobalConstant: jest.Mock<any, any>;
+    mockEstimate = {
+      originate: jest.fn(),
+      transfer: jest.fn(),
+      registerDelegate: jest.fn(),
+      setDelegate: jest.fn(),
+      batch: jest.fn(),
+      reveal: jest.fn(),
+      registerGlobalConstant: jest.fn(),
     };
 
-    beforeEach(() => {
-        mockRpcClient = {
-            getBigMapExpr: jest.fn(),
-            getEntrypoints: jest.fn(),
-            getBlock: jest.fn(),
-            getScript: jest.fn(),
-            getManagerKey: jest.fn(),
-            getStorage: jest.fn(),
-            getBigMapKey: jest.fn(),
-            getBlockHeader: jest.fn(),
-            getBlockMetadata: jest.fn(),
-            getContract: jest.fn(),
-            forgeOperations: jest.fn(),
-            injectOperation: jest.fn(),
-            packData: jest.fn(),
-            preapplyOperations: jest.fn(),
-            getChainId: jest.fn(),
-            getSaplingDiffById: jest.fn()
-        };
+    mockForger = {
+      forge: jest.fn(),
+    };
 
-        mockSigner = {
-            publicKeyHash: jest.fn(),
-            publicKey: jest.fn(),
-            sign: jest.fn(),
-        };
+    // Required for operations confirmation polling
+    mockRpcClient.getBlock.mockResolvedValue({
+      operations: [[], [], [], []],
+      header: {
+        level: 0,
+      },
+    });
 
-        mockEstimate = {
-            originate: jest.fn(),
-            transfer: jest.fn(),
-            registerDelegate: jest.fn(),
-            setDelegate: jest.fn(),
-            batch: jest.fn(),
-            reveal: jest.fn(),
-            registerGlobalConstant: jest.fn()
-        };
+    mockRpcClient.getContract.mockResolvedValue({ counter: 123456 });
+    mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+    mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getManagerKey.mockResolvedValue('test');
+    mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
+    mockSigner.publicKey.mockResolvedValue('test_pub_key');
+    mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
+    mockRpcClient.preapplyOperations.mockResolvedValue([]);
+    mockRpcClient.getChainId.mockResolvedValue('chain-id');
+    mockRpcClient.injectOperation.mockResolvedValue(
+      'onwtjK2Q32ndjF9zbEPPtmifdBq5qB59wjMP2oCH22mARjyKnGP'
+    );
 
-        // Required for operations confirmation polling
-        mockRpcClient.getBlock.mockResolvedValue({
-            operations: [[], [], [], []],
-            header: {
-                level: 0,
+    context = new Context(mockRpcClient as any, mockSigner as any);
+    context.forger = mockForger;
+    operationBatch = new OperationBatch(context, mockEstimate as any);
+  });
+
+  describe('withRegisterGlobalConstant', () => {
+    it('should produce a batch operation which contains a registerGlobalConstant operation', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
+
+      const batchOp = await operationBatch
+        .withRegisterGlobalConstant({ value: { int: '2' } })
+        .send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { int: '2' },
+              counter: '123457',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
             },
-        });
-
-        mockRpcClient.getContract.mockResolvedValue({ counter: 123456 });
-        mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
-        mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
-        mockRpcClient.getManagerKey.mockResolvedValue('test');
-        mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
-        mockSigner.publicKey.mockResolvedValue('test_pub_key');
-        mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
-        mockRpcClient.preapplyOperations.mockResolvedValue([]);
-        mockRpcClient.getChainId.mockResolvedValue('chain-id');
-        mockRpcClient.injectOperation.mockResolvedValue('onwtjK2Q32ndjF9zbEPPtmifdBq5qB59wjMP2oCH22mARjyKnGP')
-
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
     });
 
-    describe('withRegisterGlobalConstant', () => {
-        it('should produce a batch operation which contains a registerGlobalConstant operation', async done => {
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimate]);
+    it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const batchOp = await operationBatch
+        .withRegisterGlobalConstant({
+          value: { int: '2' },
+          fee: 500,
+          gasLimit: 1400,
+          storageLimit: 100,
+        })
+        .send();
 
-            const batchOp = await operationBatch.withRegisterGlobalConstant({ value: { int: '2' } }).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { int: '2' },
-                            counter: '123457',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
-
-        it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async done => {
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimate]);
-
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
-
-            const batchOp = await operationBatch.withRegisterGlobalConstant({
-                value: { int: '2' },
-                fee: 500,
-                gasLimit: 1400,
-                storageLimit: 100
-            }).send();
-
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { int: '2' },
-                            counter: '123457',
-                            fee: '500',
-                            gas_limit: '1400',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '100',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
-
-        it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async done => {
-            mockRpcClient.getManagerKey.mockResolvedValue(null);
-            const estimateReveal = new Estimate(1000000, 0, 64, 250);
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
-
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
-
-            const batchOp = await operationBatch.withRegisterGlobalConstant({ value: { int: '2' } }).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            counter: '123457',
-                            fee: '374',
-                            gas_limit: '1100',
-                            kind: 'reveal',
-                            public_key: 'test_pub_key',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '0',
-                        },
-                        {
-                            value: { int: '2' },
-                            counter: '123458',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { int: '2' },
+              counter: '123457',
+              fee: '500',
+              gas_limit: '1400',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '100',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
     });
 
-    describe('with', () => {
-        it('should produce a batch operation which contains a registerGlobalConstant operation', async done => {
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimate]);
+    it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async (done) => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      const estimateReveal = new Estimate(1000000, 0, 64, 250);
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const batchOp = await operationBatch
+        .withRegisterGlobalConstant({ value: { int: '2' } })
+        .send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              counter: '123457',
+              fee: '374',
+              gas_limit: '1100',
+              kind: 'reveal',
+              public_key: 'test_pub_key',
+              source: 'test_pub_key_hash',
+              storage_limit: '0',
+            },
+            {
+              value: { int: '2' },
+              counter: '123458',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
+  });
 
-            const opToBatch: ParamsWithKind[] = [
-                {
-                    kind: OpKind.REGISTER_GLOBAL_CONSTANT,
-                    value: { string: 'test' },
-                },
-            ];
+  describe('with', () => {
+    it('should produce a batch operation which contains a registerGlobalConstant operation', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
 
-            const batchOp = await operationBatch.with(opToBatch).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { string: 'test' },
-                            counter: '123457',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: { string: 'test' },
+        },
+      ];
 
-        it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async done => {
+      const batchOp = await operationBatch.with(opToBatch).send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { string: 'test' },
+              counter: '123457',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+    it('should produce a batch operation which contains a registerGlobalConstant operation where fee, gas limit and storage limit are specified by the user', async (done) => {
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: { string: 'test' },
+          fee: 500,
+          gasLimit: 1400,
+          storageLimit: 100,
+        },
+      ];
 
-            const opToBatch: ParamsWithKind[] = [
-                {
-                    kind: OpKind.REGISTER_GLOBAL_CONSTANT,
-                    value: { string: 'test' },
-                    fee: 500,
-                    gasLimit: 1400,
-                    storageLimit: 100
-                },
-            ];
+      const batchOp = await operationBatch.with(opToBatch).send();
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              value: { string: 'test' },
+              counter: '123457',
+              fee: '500',
+              gas_limit: '1400',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '100',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
 
-            const batchOp = await operationBatch.with(opToBatch).send();
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            value: { string: 'test' },
-                            counter: '123457',
-                            fee: '500',
-                            gas_limit: '1400',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '100',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
+    it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async (done) => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      const estimateReveal = new Estimate(1000000, 0, 64, 250);
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
 
-        it('should produce a batch operation which contains a reveal and a registerGlobalConstant operation', async done => {
-            mockRpcClient.getManagerKey.mockResolvedValue(null);
-            const estimateReveal = new Estimate(1000000, 0, 64, 250);
-            const estimate = new Estimate(1230000, 93, 142, 250);
-            mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: { string: 'test' },
+        },
+      ];
 
-            const operationBatch = new OperationBatch(
-                new Context(mockRpcClient as any, mockSigner as any),
-                mockEstimate as any
-            );
+      const batchOp = await operationBatch.with(opToBatch).send();
 
-            const opToBatch: ParamsWithKind[] = [
-                {
-                    kind: OpKind.REGISTER_GLOBAL_CONSTANT,
-                    value: { string: 'test' },
-                },
-            ];
-
-            const batchOp = await operationBatch.with(opToBatch).send();
-
-            expect(batchOp.raw).toEqual({
-                counter: 123456,
-                opOb: {
-                    branch: 'test',
-                    contents: [
-                        {
-                            counter: '123457',
-                            fee: '374',
-                            gas_limit: '1100',
-                            kind: 'reveal',
-                            public_key: 'test_pub_key',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '0',
-                        },
-                        {
-                            value: { string: "test" },
-                            counter: '123458',
-                            fee: '475',
-                            gas_limit: '1330',
-                            kind: 'register_global_constant',
-                            source: 'test_pub_key_hash',
-                            storage_limit: '93',
-                        },
-                    ],
-                    protocol: 'test_proto',
-                    signature: 'test_sig',
-                },
-                opbytes: 'test',
-            })
-            done();
-        });
-    })
+      expect(batchOp.raw).toEqual({
+        counter: 123456,
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              counter: '123457',
+              fee: '374',
+              gas_limit: '1100',
+              kind: 'reveal',
+              public_key: 'test_pub_key',
+              source: 'test_pub_key_hash',
+              storage_limit: '0',
+            },
+            {
+              value: { string: 'test' },
+              counter: '123458',
+              fee: '475',
+              gas_limit: '1330',
+              kind: 'register_global_constant',
+              source: 'test_pub_key_hash',
+              storage_limit: '93',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        opbytes: 'test',
+      });
+      done();
+    });
+  });
 });

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -54,7 +54,6 @@ describe('RpcContractProvider test', () => {
     getBlock: jest.Mock<any, any>;
     getContract: jest.Mock<any, any>;
     getBlockMetadata: jest.Mock<any, any>;
-    forgeOperations: jest.Mock<any, any>;
     injectOperation: jest.Mock<any, any>;
     packData: jest.Mock<any, any>;
     preapplyOperations: jest.Mock<any, any>;
@@ -67,6 +66,10 @@ describe('RpcContractProvider test', () => {
     publicKeyHash: jest.Mock<any, any>;
     publicKey: jest.Mock<any, any>;
     sign: jest.Mock<any, any>;
+  };
+
+  let mockForger: {
+    forge: jest.Mock<any, any>;
   };
 
   let mockEstimate: {
@@ -103,12 +106,15 @@ describe('RpcContractProvider test', () => {
       getBlockHeader: jest.fn(),
       getBlockMetadata: jest.fn(),
       getContract: jest.fn(),
-      forgeOperations: jest.fn(),
       injectOperation: jest.fn(),
       packData: jest.fn(),
       preapplyOperations: jest.fn(),
       getChainId: jest.fn(),
       getSaplingDiffById: jest.fn(),
+    };
+
+    mockForger = {
+      forge: jest.fn(),
     };
 
     mockSigner = {
@@ -135,9 +141,11 @@ describe('RpcContractProvider test', () => {
       },
     });
 
+    const context = new Context(mockRpcClient as any, mockSigner as any);
+    context.forger = mockForger;
     rpcContractProvider = new RpcContractProvider(
       // deepcode ignore no-any: any is good enough
-      new Context(mockRpcClient as any, mockSigner as any),
+      context,
       mockEstimate as any
     );
 
@@ -155,7 +163,9 @@ describe('RpcContractProvider test', () => {
       packed: '747a325542477245424b7a7a5736686a586a78786951464a4e6736575232626d3647454e',
     });
     mockRpcClient.preapplyOperations.mockResolvedValue([]);
-    mockRpcClient.injectOperation.mockResolvedValue('oo6JPEAy8VuMRGaFuMmLNFFGdJgiaKfnmT1CpHJfKP3Ye5ZahiP')
+    mockRpcClient.injectOperation.mockResolvedValue(
+      'oo6JPEAy8VuMRGaFuMmLNFFGdJgiaKfnmT1CpHJfKP3Ye5ZahiP'
+    );
     mockRpcClient.getChainId.mockResolvedValue('chain-id');
     const estimateReveal = new Estimate(1000000, 0, 64, 250);
     mockEstimate.reveal.mockResolvedValue(estimateReveal);
@@ -193,7 +203,9 @@ describe('RpcContractProvider test', () => {
           })
         ),
       });
-      expect(mockRpcClient.getBigMapKey.mock.calls[0][0]).toEqual('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D');
+      expect(mockRpcClient.getBigMapKey.mock.calls[0][0]).toEqual(
+        'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D'
+      );
       expect(mockRpcClient.getBigMapKey.mock.calls[0][1]).toEqual({
         key: { bytes: '000035e993d8c7aaa42b5e3ccd86a33390ececc73abd' },
         type: { prim: 'bytes' },

--- a/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-estimate-provider.spec.ts
@@ -32,12 +32,15 @@ describe('RPCEstimateProvider test', () => {
     getBlock: jest.Mock<any, any>;
     getContract: jest.Mock<any, any>;
     getBlockMetadata: jest.Mock<any, any>;
-    forgeOperations: jest.Mock<any, any>;
     runOperation: jest.Mock<any, any>;
     injectOperation: jest.Mock<any, any>;
     preapplyOperations: jest.Mock<any, any>;
     getChainId: jest.Mock<any, any>;
     getConstants: jest.Mock<any, any>;
+  };
+
+  let mockForger: {
+    forge: jest.Mock<any, any>;
   };
 
   let mockSigner: {
@@ -57,11 +60,14 @@ describe('RPCEstimateProvider test', () => {
       getBlockHeader: jest.fn(),
       getBlockMetadata: jest.fn(),
       getContract: jest.fn(),
-      forgeOperations: jest.fn(),
       injectOperation: jest.fn(),
       preapplyOperations: jest.fn(),
       getChainId: jest.fn(),
       getConstants: jest.fn(),
+    };
+
+    mockForger = {
+      forge: jest.fn(),
     };
 
     mockSigner = {
@@ -83,7 +89,7 @@ describe('RPCEstimateProvider test', () => {
     mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
     mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
     mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
-    mockRpcClient.forgeOperations.mockResolvedValue('1234');
+    mockForger.forge.mockResolvedValue('1234');
     mockRpcClient.preapplyOperations.mockResolvedValue([]);
     mockRpcClient.getChainId.mockResolvedValue('chain-id');
     mockRpcClient.getConstants.mockResolvedValue({
@@ -96,9 +102,9 @@ describe('RPCEstimateProvider test', () => {
     mockSigner.sign.mockResolvedValue({ sbytes: 'test', prefixSig: 'test_sig' });
     mockSigner.publicKey.mockResolvedValue('test_pub_key');
     mockSigner.publicKeyHash.mockResolvedValue('test_pub_key_hash');
-    estimateProvider = new RPCEstimateProvider(
-      new Context(mockRpcClient as any, mockSigner as any)
-    );
+    const context = new Context(mockRpcClient as any, mockSigner as any);
+    context.forger = mockForger;
+    estimateProvider = new RPCEstimateProvider(context);
   });
 
   describe('originate', () => {
@@ -134,7 +140,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(multipleInternalOrigination());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(297).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(297).fill('aa').join(''));
       const estimate = await estimateProvider.transfer({
         to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
@@ -150,7 +156,7 @@ describe('RPCEstimateProvider test', () => {
     test('return the correct estimate for multiple internal origination, no reveal', async (done) => {
       mockRpcClient.runOperation.mockResolvedValue(multipleInternalOriginationNoReveal());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(297).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(297).fill('aa').join(''));
       const estimate = await estimateProvider.transfer({
         to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
@@ -167,7 +173,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(multipleInternalTransfer());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(285).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(285).fill('aa').join(''));
       const estimate = await estimateProvider.transfer({
         to: 'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
         amount: 2,
@@ -184,7 +190,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(delegate());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(149).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(149).fill('aa').join(''));
       const estimate = await estimateProvider.setDelegate({
         source: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         delegate: 'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
@@ -201,7 +207,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(origination());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(445).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(445).fill('aa').join(''));
       const estimate = await estimateProvider.originate({
         code: ligoSample,
         storage: 0,
@@ -218,7 +224,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(internalTransfer());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(226).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(226).fill('aa').join(''));
       const estimate = await estimateProvider.transfer({
         to: 'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
         amount: 2,
@@ -235,7 +241,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(transferWithoutAllocation());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(153).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(153).fill('aa').join(''));
       const estimate = await estimateProvider.transfer({
         to: 'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
         amount: 2,
@@ -252,7 +258,7 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
       mockRpcClient.runOperation.mockResolvedValue(transferWithAllocation());
       // Simulate real op size
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(153).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(153).fill('aa').join(''));
       const estimate = await estimateProvider.transfer({
         to: 'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
         amount: 2,
@@ -524,10 +530,11 @@ describe('RPCEstimateProvider test', () => {
         { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
         { kind: OpKind.TRANSACTION, to: 'tz3hRZUScFCcEVhdDjXWoyekbgd1Gatga6mp', amount: 2 },
         {
-          kind: OpKind.REGISTER_GLOBAL_CONSTANT, value: {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: {
             prim: 'Pair',
-            args: [{ int: '998' }, { int: '999' }]
-          }
+            args: [{ int: '998' }, { int: '999' }],
+          },
         },
       ]);
       expect(estimate.length).toEqual(3);
@@ -539,7 +546,7 @@ describe('RPCEstimateProvider test', () => {
 
     it('should produce a batch operation, with reveal', async (done) => {
       mockRpcClient.getManagerKey.mockResolvedValue(null);
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(224).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(224).fill('aa').join(''));
       mockRpcClient.runOperation.mockResolvedValue({
         contents: [
           {
@@ -589,10 +596,11 @@ describe('RPCEstimateProvider test', () => {
       });
       const estimate = await estimateProvider.batch([
         {
-          kind: OpKind.REGISTER_GLOBAL_CONSTANT, value: {
+          kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+          value: {
             prim: 'Pair',
-            args: [{ int: '998' }, { int: '999' }]
-          }
+            args: [{ int: '998' }, { int: '999' }],
+          },
         },
         { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 },
         { kind: OpKind.TRANSACTION, to: 'tz3hRZUScFCcEVhdDjXWoyekbgd1Gatga6mp', amount: 2 },
@@ -609,8 +617,8 @@ describe('RPCEstimateProvider test', () => {
         storageLimit: 73,
         suggestedFeeMutez: 408,
       });
-      expect(estimate[2].suggestedFeeMutez).toEqual(385)
-      expect(estimate[3].suggestedFeeMutez).toEqual(385)
+      expect(estimate[2].suggestedFeeMutez).toEqual(385);
+      expect(estimate[3].suggestedFeeMutez).toEqual(385);
       expect(estimate[2]).toMatchObject({
         gasLimit: 1100,
         storageLimit: 0,
@@ -634,7 +642,7 @@ describe('RPCEstimateProvider test', () => {
           },
         },
       };
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(149).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(149).fill('aa').join(''));
       mockRpcClient.runOperation.mockResolvedValue({
         contents: [transactionResult, transactionResult, transactionResult, transactionResult],
       });
@@ -679,7 +687,7 @@ describe('RPCEstimateProvider test', () => {
           },
         },
       };
-      mockRpcClient.forgeOperations.mockResolvedValue(new Array(149).fill('aa').join(''));
+      mockForger.forge.mockResolvedValue(new Array(149).fill('aa').join(''));
       mockRpcClient.runOperation.mockResolvedValue({
         contents: [
           transactionResult,
@@ -736,9 +744,9 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.runOperation.mockResolvedValue(registerGlobalConstantNoReveal);
       const estimate = await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
-        }
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
+        },
       });
       expect(estimate).toMatchObject({
         gasLimit: 1330,
@@ -753,9 +761,9 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.runOperation.mockResolvedValue(registerGlobalConstantWithReveal);
       const estimate = await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
-        }
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
+        },
       });
       expect(estimate).toMatchObject({
         gasLimit: 1330,
@@ -770,8 +778,8 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getBalance.mockResolvedValue(new BigNumber('1100'));
       await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
         },
         storageLimit: 200,
       });
@@ -796,8 +804,8 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getBalance.mockResolvedValue(new BigNumber('10000000000'));
       await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
         },
         gasLimit: 200,
       });
@@ -822,8 +830,8 @@ describe('RPCEstimateProvider test', () => {
       mockRpcClient.getBalance.mockResolvedValue(new BigNumber('10000000000'));
       await estimateProvider.registerGlobalConstant({
         value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
+          prim: 'Pair',
+          args: [{ int: '998' }, { int: '999' }],
         },
         fee: 10000,
       });
@@ -846,16 +854,18 @@ describe('RPCEstimateProvider test', () => {
     it('should return parsed error from RPC result', async (done) => {
       mockRpcClient.runOperation.mockResolvedValue(registerGlobalConstantWithError);
 
-      await expect(estimateProvider.registerGlobalConstant({
-        value: {
-          "prim": "Pair",
-          "args": [{ "int": "998" }, { "int": "999" }]
-        }
-      })).rejects.toMatchObject({
-        errors:
-          [{
+      await expect(
+        estimateProvider.registerGlobalConstant({
+          value: {
+            prim: 'Pair',
+            args: [{ int: '998' }, { int: '999' }],
+          },
+        })
+      ).rejects.toMatchObject({
+        errors: [
+          {
             kind: 'branch',
-            id: 'proto.011-PtHangzH.Expression_already_registered'
+            id: 'proto.011-PtHangzH.Expression_already_registered',
           },
           {
             kind: 'permanent',
@@ -863,13 +873,14 @@ describe('RPCEstimateProvider test', () => {
             existing_key: [
               'global_constant',
               'f4b54fa94f3255df3ab6a95d0112964d825642706d42de848b3c507ff4602c4a',
-              'len'
-            ]
-          }],
+              'len',
+            ],
+          },
+        ],
         name: 'TezosOperationError',
         id: 'proto.011-PtHangzH.context.storage_error',
         kind: 'permanent',
-        message: '(permanent) proto.011-PtHangzH.context.storage_error'
+        message: '(permanent) proto.011-PtHangzH.context.storage_error',
       });
       done();
     });

--- a/packages/taquito/test/forger/taquito-local-forger.spec.ts
+++ b/packages/taquito/test/forger/taquito-local-forger.spec.ts
@@ -1,0 +1,49 @@
+import { TaquitoLocalForger } from '../../src/forger/taquito-local-forger';
+import { Context, Protocols } from '../../src/taquito';
+
+describe('Taquito local forger', () => {
+  const mockRpcClient = {
+    getBlockMetadata: jest.fn(),
+  };
+
+  beforeEach(() => {
+    mockRpcClient.getBlockMetadata.mockResolvedValue({
+      next_protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
+    });
+  });
+
+  it('is instantiable', () => {
+    expect(new TaquitoLocalForger(new Context('url'))).toBeInstanceOf(TaquitoLocalForger);
+  });
+
+  it('should take the protocol hash from context.proto if it is defined', async (done) => {
+    const context = new Context(mockRpcClient as any);
+    context.proto = Protocols.PtHangz2;
+    const forger = new TaquitoLocalForger(context);
+
+    // When calling the forge method, an instance of LocalForger is created
+    // which required the protocol hash in its constructor
+    await forger.forge({
+      branch: 'BMbqNeX9fZKsuKmu5B2gX7ayA9ZUNjbHEeHCgYd7VdTMsTCALFF',
+      contents: [],
+    });
+    expect(mockRpcClient.getBlockMetadata).toHaveBeenCalledTimes(0);
+
+    done();
+  });
+
+  it('should fetch protocol hash from the Rpc', async (done) => {
+    const forger = new TaquitoLocalForger(new Context(mockRpcClient as any));
+
+    // When calling the forge method, an instance of LocalForger is created
+    // which required the protocol hash in its constructor
+    // fetch the protocol hash from the RPC if context.proto is undefined
+    await forger.forge({
+      branch: 'BMbqNeX9fZKsuKmu5B2gX7ayA9ZUNjbHEeHCgYd7VdTMsTCALFF',
+      contents: [],
+    });
+    expect(mockRpcClient.getBlockMetadata).toHaveBeenCalledTimes(1);
+
+    done();
+  });
+});

--- a/packages/taquito/test/taquito.spec.ts
+++ b/packages/taquito/test/taquito.spec.ts
@@ -1,4 +1,4 @@
-import { TezosToolkit, SetProviderOptions, Wallet } from '../src/taquito';
+import { TezosToolkit, SetProviderOptions, Wallet, RpcPacker } from '../src/taquito';
 import { RpcTzProvider } from '../src/tz/rpc-tz-provider';
 import { RpcContractProvider } from '../src/contract/rpc-contract-provider';
 import { PollingSubscribeProvider } from '../src/subscribe/polling-provider';
@@ -8,6 +8,7 @@ import { retry } from 'rxjs/operators';
 import { RPCEstimateProvider } from '../src/contract/rpc-estimate-provider';
 import { OperationFactory } from '../src/wallet/operation-factory';
 import { NoopGlobalConstantsProvider } from '../src/global-constants/noop-global-constants-provider';
+import { TaquitoLocalForger } from '../src/forger/taquito-local-forger';
 
 describe('TezosToolkit test', () => {
   let mockRpcClient: any;
@@ -71,11 +72,11 @@ describe('TezosToolkit test', () => {
     'forger',
     'wallet',
     'packer',
-    'globalConstantsProvider'
+    'globalConstantsProvider',
   ];
   providerKey
-    .filter(x => x !== 'rpc')
-    .forEach(key => {
+    .filter((x) => x !== 'rpc')
+    .forEach((key) => {
       it(`setting ${key} provider should not override the rpc provider`, () => {
         toolkit = new TezosToolkit('rpc');
         expect(toolkit.rpc).toBeInstanceOf(RpcClient);
@@ -87,8 +88,8 @@ describe('TezosToolkit test', () => {
     });
 
   providerKey
-    .filter(x => x !== 'signer')
-    .forEach(key => {
+    .filter((x) => x !== 'signer')
+    .forEach((key) => {
       it(`setting ${key} provider should not override the signer provider`, () => {
         expect(toolkit.signer).toBeInstanceOf(NoopSigner);
         toolkit.setProvider({ signer: 'test' as any });
@@ -100,8 +101,8 @@ describe('TezosToolkit test', () => {
     });
 
   providerKey
-    .filter(x => x !== 'stream')
-    .forEach(key => {
+    .filter((x) => x !== 'stream')
+    .forEach((key) => {
       it(`setting ${key} provider should not override the stream provider`, () => {
         expect(toolkit.stream).toBeInstanceOf(PollingSubscribeProvider);
         toolkit.setProvider({ stream: 'test' as any });
@@ -112,40 +113,82 @@ describe('TezosToolkit test', () => {
       });
     });
 
+  providerKey
+    .filter((x) => x !== 'packer')
+    .forEach((key) => {
+      it(`setting ${key} provider should not override the packer provider`, () => {
+        expect(toolkit['_context'].packer).toBeInstanceOf(RpcPacker);
+        toolkit.setProvider({ packer: 'test' as any });
+        const instance = toolkit['_context'].packer;
+        expect(instance).toEqual('test');
+        toolkit.setProvider({ [key]: 'test' as any });
+        expect(toolkit['_context'].packer).toEqual(instance);
+      });
+    });
+
+  providerKey
+    .filter((x) => x !== 'globalConstantsProvider')
+    .forEach((key) => {
+      it(`setting ${key} provider should not override the globalConstantsProvider`, () => {
+        expect(toolkit.globalConstants).toBeInstanceOf(NoopGlobalConstantsProvider);
+        toolkit.setProvider({ globalConstantsProvider: 'test' as any });
+        const instance = toolkit.globalConstants;
+        expect(instance).toEqual('test');
+        toolkit.setProvider({ [key]: 'test' as any });
+        expect(toolkit.globalConstants).toEqual(instance);
+      });
+    });
+
+  providerKey.forEach((key) => {
+    it(`setting ${key} provider should not override the forger provider`, () => {
+      expect(toolkit['_context'].forger).toBeInstanceOf(TaquitoLocalForger);
+      toolkit.setProvider({ forger: 'test' as any });
+      const instance = toolkit['_context'].forger;
+      expect(instance).toEqual('test');
+      toolkit.setProvider({ [key]: 'test' as any });
+      expect(toolkit['_context'].forger).toEqual(instance);
+    });
+  });
+
   it('getVersionInfo returns well formed response', () => {
     const versionInfo = toolkit.getVersionInfo();
     expect(versionInfo.commitHash).toBeTruthy();
     expect(versionInfo.version).toBeTruthy();
   });
 
-  it("setProvider allows to change configurations for the confirmation methods and streamer", () => {
+  it('setProvider allows to change configurations for the confirmation methods and streamer', () => {
     // There is default config set on the context class:
-    expect(toolkit["_context"].config.confirmationPollingIntervalSecond).toBeUndefined();
-    expect(toolkit["_context"].config.confirmationPollingTimeoutSecond).toEqual(180);
-    expect(toolkit["_context"].config.defaultConfirmationCount).toEqual(1);
-    expect(toolkit["_context"].config.streamerPollingIntervalMilliseconds).toEqual(20000);
-    expect(toolkit["_context"].config.shouldObservableSubscriptionRetry).toBeFalsy();
-    expect(toolkit["_context"].config.observableSubscriptionRetryFunction.prototype).toEqual(retry().prototype);
-    
+    expect(toolkit['_context'].config.confirmationPollingIntervalSecond).toBeUndefined();
+    expect(toolkit['_context'].config.confirmationPollingTimeoutSecond).toEqual(180);
+    expect(toolkit['_context'].config.defaultConfirmationCount).toEqual(1);
+    expect(toolkit['_context'].config.streamerPollingIntervalMilliseconds).toEqual(20000);
+    expect(toolkit['_context'].config.shouldObservableSubscriptionRetry).toBeFalsy();
+    expect(toolkit['_context'].config.observableSubscriptionRetryFunction.prototype).toEqual(
+      retry().prototype
+    );
+
     // can customize one of the config: confirmationPollingTimeoutSecond
-    toolkit.setProvider({ config: { confirmationPollingTimeoutSecond:2 } })
-    expect(toolkit["_context"].config.confirmationPollingIntervalSecond).toBeUndefined();
-    expect(toolkit["_context"].config.confirmationPollingTimeoutSecond).toEqual(2);
-    expect(toolkit["_context"].config.defaultConfirmationCount).toEqual(1);
-    expect(toolkit["_context"].config.streamerPollingIntervalMilliseconds).toEqual(20000);
-    expect(toolkit["_context"].config.shouldObservableSubscriptionRetry).toBeFalsy();
-    expect(toolkit["_context"].config.observableSubscriptionRetryFunction.prototype).toEqual(retry().prototype);
+    toolkit.setProvider({ config: { confirmationPollingTimeoutSecond: 2 } });
+    expect(toolkit['_context'].config.confirmationPollingIntervalSecond).toBeUndefined();
+    expect(toolkit['_context'].config.confirmationPollingTimeoutSecond).toEqual(2);
+    expect(toolkit['_context'].config.defaultConfirmationCount).toEqual(1);
+    expect(toolkit['_context'].config.streamerPollingIntervalMilliseconds).toEqual(20000);
+    expect(toolkit['_context'].config.shouldObservableSubscriptionRetry).toBeFalsy();
+    expect(toolkit['_context'].config.observableSubscriptionRetryFunction.prototype).toEqual(
+      retry().prototype
+    );
 
     // can customize another config: confirmationPollingIntervalSecond
     // confirmationPollingTimeoutSecond should remain to 2 as set precedently
-    toolkit.setProvider({ config: { confirmationPollingIntervalSecond:40 } });
-    expect(toolkit["_context"].config.confirmationPollingIntervalSecond).toBeDefined();
-    expect(toolkit["_context"].config.confirmationPollingIntervalSecond).toEqual(40);
-    expect(toolkit["_context"].config.confirmationPollingTimeoutSecond).toEqual(2);
-    expect(toolkit["_context"].config.defaultConfirmationCount).toEqual(1);
-    expect(toolkit["_context"].config.streamerPollingIntervalMilliseconds).toEqual(20000);
-    expect(toolkit["_context"].config.shouldObservableSubscriptionRetry).toBeFalsy();
-    expect(toolkit["_context"].config.observableSubscriptionRetryFunction.prototype).toEqual(retry().prototype);
-});
-
+    toolkit.setProvider({ config: { confirmationPollingIntervalSecond: 40 } });
+    expect(toolkit['_context'].config.confirmationPollingIntervalSecond).toBeDefined();
+    expect(toolkit['_context'].config.confirmationPollingIntervalSecond).toEqual(40);
+    expect(toolkit['_context'].config.confirmationPollingTimeoutSecond).toEqual(2);
+    expect(toolkit['_context'].config.defaultConfirmationCount).toEqual(1);
+    expect(toolkit['_context'].config.streamerPollingIntervalMilliseconds).toEqual(20000);
+    expect(toolkit['_context'].config.shouldObservableSubscriptionRetry).toBeFalsy();
+    expect(toolkit['_context'].config.observableSubscriptionRetryFunction.prototype).toEqual(
+      retry().prototype
+    );
+  });
 });

--- a/packages/taquito/test/tz/rpc-tz-provider.spec.ts
+++ b/packages/taquito/test/tz/rpc-tz-provider.spec.ts
@@ -8,7 +8,7 @@ describe('RpcTzProvider test', () => {
   });
 
   describe('getBalance', () => {
-    it('calls get balance from the rpc client', async done => {
+    it('calls get balance from the rpc client', async (done) => {
       const mockRpcClient = {
         getBalance: jest.fn(),
       };
@@ -19,13 +19,15 @@ describe('RpcTzProvider test', () => {
       const result = await provider.getBalance('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
       expect(result).toBeInstanceOf(BigNumber);
       expect(result.toString()).toStrictEqual('10000');
-      expect(mockRpcClient.getBalance.mock.calls[0][0]).toEqual('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
+      expect(mockRpcClient.getBalance.mock.calls[0][0]).toEqual(
+        'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'
+      );
       done();
     });
   });
 
   describe('getDelegate', () => {
-    it('calls get delegate from the rpc client', async done => {
+    it('calls get delegate from the rpc client', async (done) => {
       const mockRpcClient = {
         getDelegate: jest.fn(),
       };
@@ -35,7 +37,9 @@ describe('RpcTzProvider test', () => {
       const provider = new RpcTzProvider(new Context(mockRpcClient as any));
       const result = await provider.getDelegate('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
       expect(result).toStrictEqual('KT1G393LjojNshvMdf68XQD24Hwjn7xarzNe');
-      expect(mockRpcClient.getDelegate.mock.calls[0][0]).toEqual('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn');
+      expect(mockRpcClient.getDelegate.mock.calls[0][0]).toEqual(
+        'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'
+      );
       done();
     });
   });
@@ -46,7 +50,7 @@ describe('RpcTzProvider test', () => {
       publicKey: jest.Mock<any, any>;
       sign: jest.Mock<any, any>;
     };
-    it('should produce a activate_account operation', async done => {
+    it('should produce a activate_account operation', async (done) => {
       const mockRpcClient = {
         getBlock: jest.fn(),
         getScript: jest.fn(),
@@ -55,9 +59,11 @@ describe('RpcTzProvider test', () => {
         getBlockHeader: jest.fn(),
         getBlockMetadata: jest.fn(),
         getContract: jest.fn(),
-        forgeOperations: jest.fn(),
         injectOperation: jest.fn(),
         preapplyOperations: jest.fn(),
+      };
+      const mockForger = {
+        forge: jest.fn(),
       };
       // Required for operations confirmation polling
       mockRpcClient.getBlock.mockResolvedValue({
@@ -75,13 +81,19 @@ describe('RpcTzProvider test', () => {
 
       mockRpcClient.getManagerKey.mockResolvedValue('test');
       mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
-      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw' });
+      mockRpcClient.getBlockHeader.mockResolvedValue({
+        hash: 'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw',
+      });
       mockRpcClient.preapplyOperations.mockResolvedValue([]);
       mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
-      mockRpcClient.forgeOperations.mockResolvedValue('test');
-      mockRpcClient.injectOperation.mockResolvedValue('ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj');
+      mockForger.forge.mockResolvedValue('test');
+      mockRpcClient.injectOperation.mockResolvedValue(
+        'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj'
+      );
 
-      const provider = new RpcTzProvider(new Context(mockRpcClient as any, mockSigner as any));
+      const context = new Context(mockRpcClient as any, mockSigner as any);
+      context.forger = mockForger;
+      const provider = new RpcTzProvider(context);
       const result = await provider.activate('tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m', '123');
       expect(result.raw).toEqual({
         counter: 0,


### PR DESCRIPTION
Implemented a new class named TaquitoLocalForger which act as a wrapper around the LocalForger in
order to fetch and pass the protocol hash on instantiation.

This change is required in preparation for Ithaca support, where some operation schema has changed (ie endorsement), the protocol hash is passed to the constructor of the LocalForger in order to select the right encoder, decoder.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
