### PR TITLE
feat(estimate): fix estimate to work with wallet

### DIFF
--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -27,6 +27,14 @@ Taquito's estimate method can be used to estimate fees, gas, and storage associa
 
 The following example shows an estimate of the fees associated with transferring 2ꜩ to `tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY` address. The configuration of the signer is to use a throw-away private key for demonstration purposes.
 
+<Tabs
+defaultValue="signer"
+values={[
+{label: 'Signer', value: 'signer'},
+{label: 'Wallet', value: 'wallet'}
+]}>
+<TabItem value="signer">
+
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
 // const Tezos = new TezosToolkit('https://hangzhounet.api.tez.ie');
@@ -49,9 +57,46 @@ Tezos.estimate
   .catch((error) => console.table(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
 
+</TabItem>
+  <TabItem value="wallet"> 
+
+```js live noInline wallet
+// import { TezosToolkit } from '@taquito/taquito';
+// const Tezos = new TezosToolkit('https://hangzhounet.api.tez.ie');
+
+const amount = 2;
+const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
+
+println(`Estimating the transfer of ${amount} ꜩ to ${address} : `);
+Tezos.estimate
+  .transfer({ to: address, amount: amount })
+  .then((est) => {
+    println(`burnFeeMutez : ${est.burnFeeMutez}, 
+    gasLimit : ${est.gasLimit}, 
+    minimalFeeMutez : ${est.minimalFeeMutez}, 
+    storageLimit : ${est.storageLimit}, 
+    suggestedFeeMutez : ${est.suggestedFeeMutez}, 
+    totalCost : ${est.totalCost}, 
+    usingBaseFeeMutez : ${est.usingBaseFeeMutez}`);
+  })
+  .catch((error) => console.table(`Error: ${JSON.stringify(error, null, 2)}`));
+``` 
+
+  </TabItem>
+</Tabs>
+
+
 ### Estimate a smart contract call
 
 This example will demonstrate how to estimate the fees related to calling a smart contract. The Ligo source code for the smart contract used in this example is at [Ligo Web IDE](https://ide.ligolang.org/p/N2QTykOAXBkXmiKcRCyg3Q).
+
+<Tabs
+defaultValue="signer"
+values={[
+{label: 'Signer', value: 'signer'},
+{label: 'Wallet', value: 'wallet'}
+]}>
+<TabItem value="signer">
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
@@ -78,9 +123,52 @@ Tezos.contract
   })
   .catch((error) => console.table(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
+
+
+</TabItem>
+  <TabItem value="wallet"> 
+
+```js live noInline wallet
+// import { TezosToolkit } from '@taquito/taquito';
+// const Tezos = new TezosToolkit('https://hangzhounet.api.tez.ie');
+
+Tezos.wallet
+  .at('KT1NcdpzokZQY4sLmCBUwLnMHQCCQ6rRXYwS')
+  .then((contract) => {
+    const i = 7;
+    return contract.methods.increment(i).toTransferParams({});
+  })
+  .then((op) => {
+    println(`Estimating the smart contract call : `);
+    return Tezos.estimate.transfer(op);
+  })
+  .then((est) => {
+    println(`burnFeeMutez : ${est.burnFeeMutez}, 
+    gasLimit : ${est.gasLimit}, 
+    minimalFeeMutez : ${est.minimalFeeMutez}, 
+    storageLimit : ${est.storageLimit}, 
+    suggestedFeeMutez : ${est.suggestedFeeMutez}, 
+    totalCost : ${est.totalCost}, 
+    usingBaseFeeMutez : ${est.usingBaseFeeMutez}`);
+  })
+  .catch((error) => console.table(`Error: ${JSON.stringify(error, null, 2)}`));
+```
+
+  </TabItem>
+</Tabs>
+
+
 ### Estimate a contract origination
 
 In this example, we will use the estimate method of Taquito on a contract origination. The `genericMultisigJSONfile` variable contains a Michelson Smart Contract.
+
+<Tabs
+defaultValue="signer"
+values={[
+{label: 'Signer', value: 'signer'},
+{label: 'Wallet', value: 'wallet'}
+]}>
+<TabItem value="signer">
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
@@ -107,3 +195,36 @@ Tezos.estimate
   })
   .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
+
+</TabItem>
+  <TabItem value="wallet"> 
+
+
+```js live noInline wallet
+// import { TezosToolkit } from '@taquito/taquito';
+// const Tezos = new TezosToolkit('https://hangzhounet.api.tez.ie');
+
+println(`Estimating the contract origination : `);
+Tezos.estimate
+  .originate({
+    code: genericMultisigJSONfile,
+    storage: {
+      stored_counter: 0,
+      threshold: 1,
+      keys: ['edpkuLxx9PQD8fZ45eUzrK3BhfDZJHhBuK4Zi49DcEGANwd2rpX82t'],
+    },
+  })
+  .then((originationOp) => {
+    println(`burnFeeMutez : ${originationOp.burnFeeMutez},
+    gasLimit : ${originationOp.gasLimit},
+    minimalFeeMutez : ${originationOp.minimalFeeMutez},
+    storageLimit : ${originationOp.storageLimit},
+    suggestedFeeMutez : ${originationOp.suggestedFeeMutez},
+    totalCost : ${originationOp.totalCost},
+    usingBaseFeeMutez : ${originationOp.usingBaseFeeMutez}`);
+  })
+  .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
+```  
+
+  </TabItem>
+</Tabs>

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -208,6 +208,10 @@ export class Context {
     }
   }
 
+  isAnySignerConfigured() {
+    return !(this.signer instanceof NoopSigner);
+  }
+
   /**
    * @description Create a copy of the current context. Useful when you have long running operation and you do not want a context change to affect the operation
    */

--- a/packages/taquito/src/estimate/error.ts
+++ b/packages/taquito/src/estimate/error.ts
@@ -1,0 +1,6 @@
+export class RevealEstimateError extends Error {
+  name = 'Reveal Estimate Error';
+  constructor() {
+    super('Unable to estimate the reveal operation, the public key is unknown');
+  }
+}

--- a/packages/taquito/src/estimate/index.ts
+++ b/packages/taquito/src/estimate/index.ts
@@ -2,3 +2,4 @@ export * from './estimate';
 export * from './estimate-provider-interface';
 export * from './naive-estimate-provider';
 export * from './rpc-estimate-provider';
+export * from './error';

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -64,7 +64,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
   private readonly ORIGINATION_STORAGE = 257;
   private readonly OP_SIZE_REVEAL = 128;
 
-  private async getSignerOrWallet(): Promise<{
+  private async getKeys(): Promise<{
     publicKeyHash: string;
     publicKey?: string;
   }> {
@@ -224,7 +224,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @param OriginationOperation Originate operation parameter
    */
   async originate({ fee, storageLimit, gasLimit, ...rest }: OriginateParams) {
-    const { publicKeyHash } = await this.getSignerOrWallet();
+    const { publicKeyHash } = await this.getKeys();
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(publicKeyHash, protocolConstants);
     const op = await createOriginationOperation(
@@ -260,7 +260,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     if (rest.source && validateAddress(rest.source) !== ValidationResult.VALID) {
       throw new InvalidAddressError(`Invalid 'source' address: ${rest.source}`);
     }
-    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
+    const pkh = (await this.getKeys()).publicKeyHash;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
     const op = await createTransferOperation({
@@ -296,7 +296,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
       throw new InvalidAddressError(`Invalid delegate address: ${rest.delegate}`);
     }
 
-    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
+    const pkh = (await this.getKeys()).publicKeyHash;
     const sourceOrDefault = rest.source || pkh;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(sourceOrDefault, protocolConstants);
@@ -324,7 +324,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @returns An array of Estimate objects. If a reveal operation is needed, the first element of the array is the Estimate for the reveal operation.
    */
   async batch(params: ParamsWithKind[]) {
-    const { publicKeyHash } = await this.getSignerOrWallet();
+    const { publicKeyHash } = await this.getKeys();
     let operations: RPCOperation[] = [];
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(
@@ -398,7 +398,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @param Estimate
    */
   async registerDelegate(params: RegisterDelegateParams) {
-    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
+    const pkh = (await this.getKeys()).publicKeyHash;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
     const op = await createRegisterDelegateOperation({ ...params, ...DEFAULT_PARAMS }, pkh);
@@ -424,7 +424,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @param Estimate
    */
   async reveal(params?: RevealParams) {
-    const { publicKeyHash, publicKey } = await this.getSignerOrWallet();
+    const { publicKeyHash, publicKey } = await this.getKeys();
     if (!publicKey) {
       throw new RevealEstimateError();
     }
@@ -462,7 +462,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     gasLimit,
     ...rest
   }: RegisterGlobalConstantParams) {
-    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
+    const pkh = (await this.getKeys()).publicKeyHash;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
     const op = await createRegisterGlobalConstantOperation({
@@ -483,7 +483,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
   }
 
   private async addRevealOp(op: RPCOperation[], pkh: string) {
-    const { publicKey } = await this.getSignerOrWallet();
+    const { publicKey } = await this.getKeys();
     if (!publicKey) {
       throw new RevealEstimateError();
     }

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -30,6 +30,7 @@ import {
   createRegisterGlobalConstantOperation,
 } from '../contract/prepare';
 import { validateAddress, InvalidAddressError, ValidationResult } from '@taquito/utils';
+import { RevealEstimateError } from './error';
 
 interface Limits {
   fee?: number;
@@ -62,6 +63,19 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
   private readonly ALLOCATION_STORAGE = 257;
   private readonly ORIGINATION_STORAGE = 257;
   private readonly OP_SIZE_REVEAL = 128;
+
+  private async getSignerOrWallet(): Promise<{
+    publicKeyHash: string;
+    publicKey?: string;
+  }> {
+    const isSignerConfigured = this.context.isAnySignerConfigured();
+    return {
+      publicKeyHash: isSignerConfigured
+        ? await this.signer.publicKeyHash()
+        : await this.context.walletProvider.getPKH(),
+      publicKey: isSignerConfigured ? await this.signer.publicKey() : undefined,
+    };
+  }
 
   // Maximum values defined by the protocol
   private async getAccountLimits(
@@ -161,9 +175,10 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
 
   private async prepareEstimate(
     params: PrepareOperationParams,
-    constants: Pick<ConstantsResponse, 'cost_per_byte'>
+    constants: Pick<ConstantsResponse, 'cost_per_byte'>,
+    pkh: string
   ) {
-    const prepared = await this.prepareOperation(params);
+    const prepared = await this.prepareOperation(params, pkh);
     const {
       opbytes,
       opOb: { branch, contents },
@@ -209,20 +224,21 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @param OriginationOperation Originate operation parameter
    */
   async originate({ fee, storageLimit, gasLimit, ...rest }: OriginateParams) {
-    const pkh = await this.signer.publicKeyHash();
+    const { publicKeyHash } = await this.getSignerOrWallet();
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
-    const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
+    const DEFAULT_PARAMS = await this.getAccountLimits(publicKeyHash, protocolConstants);
     const op = await createOriginationOperation(
       await this.context.parser.prepareCodeOrigination({
         ...rest,
         ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
       })
     );
-    const isRevealNeeded = await this.isRevealOpNeeded([op], pkh);
-    const ops = isRevealNeeded ? await this.addRevealOp([op], pkh) : op;
+    const isRevealNeeded = await this.isRevealOpNeeded([op], publicKeyHash);
+    const ops = isRevealNeeded ? await this.addRevealOp([op], publicKeyHash) : op;
     const estimateProperties = await this.prepareEstimate(
-      { operation: ops, source: pkh },
-      protocolConstants
+      { operation: ops, source: publicKeyHash },
+      protocolConstants,
+      publicKeyHash
     );
     if (isRevealNeeded) {
       estimateProperties.shift();
@@ -244,7 +260,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     if (rest.source && validateAddress(rest.source) !== ValidationResult.VALID) {
       throw new InvalidAddressError(`Invalid 'source' address: ${rest.source}`);
     }
-    const pkh = await this.signer.publicKeyHash();
+    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
     const op = await createTransferOperation({
@@ -255,7 +271,8 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     const ops = isRevealNeeded ? await this.addRevealOp([op], pkh) : op;
     const estimateProperties = await this.prepareEstimate(
       { operation: ops, source: pkh },
-      protocolConstants
+      protocolConstants,
+      pkh
     );
     if (isRevealNeeded) {
       estimateProperties.shift();
@@ -279,7 +296,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
       throw new InvalidAddressError(`Invalid delegate address: ${rest.delegate}`);
     }
 
-    const pkh = await this.signer.publicKeyHash();
+    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
     const sourceOrDefault = rest.source || pkh;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(sourceOrDefault, protocolConstants);
@@ -291,7 +308,8 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     const ops = isRevealNeeded ? await this.addRevealOp([op], pkh) : op;
     const estimateProperties = await this.prepareEstimate(
       { operation: ops, source: pkh },
-      protocolConstants
+      protocolConstants,
+      pkh
     );
     if (isRevealNeeded) {
       estimateProperties.shift();
@@ -306,10 +324,14 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @returns An array of Estimate objects. If a reveal operation is needed, the first element of the array is the Estimate for the reveal operation.
    */
   async batch(params: ParamsWithKind[]) {
-    const pkh = await this.signer.publicKeyHash();
+    const { publicKeyHash } = await this.getSignerOrWallet();
     let operations: RPCOperation[] = [];
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
-    const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants, params.length);
+    const DEFAULT_PARAMS = await this.getAccountLimits(
+      publicKeyHash,
+      protocolConstants,
+      params.length
+    );
     for (const param of params) {
       switch (param.kind) {
         case OpKind.TRANSACTION:
@@ -356,11 +378,12 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
           throw new Error(`Unsupported operation kind: ${(param as any).kind}`);
       }
     }
-    const isRevealNeeded = await this.isRevealOpNeeded(operations, pkh);
-    operations = isRevealNeeded ? await this.addRevealOp(operations, pkh) : operations;
+    const isRevealNeeded = await this.isRevealOpNeeded(operations, publicKeyHash);
+    operations = isRevealNeeded ? await this.addRevealOp(operations, publicKeyHash) : operations;
     const estimateProperties = await this.prepareEstimate(
-      { operation: operations, source: pkh },
-      protocolConstants
+      { operation: operations, source: publicKeyHash },
+      protocolConstants,
+      publicKeyHash
     );
 
     return Estimate.createArrayEstimateInstancesFromProperties(estimateProperties);
@@ -375,7 +398,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @param Estimate
    */
   async registerDelegate(params: RegisterDelegateParams) {
-    const pkh = await this.signer.publicKeyHash();
+    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
     const op = await createRegisterDelegateOperation({ ...params, ...DEFAULT_PARAMS }, pkh);
@@ -383,7 +406,8 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     const ops = isRevealNeeded ? await this.addRevealOp([op], pkh) : op;
     const estimateProperties = await this.prepareEstimate(
       { operation: ops, source: pkh },
-      protocolConstants
+      protocolConstants,
+      pkh
     );
     if (isRevealNeeded) {
       estimateProperties.shift();
@@ -400,21 +424,25 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
    * @param Estimate
    */
   async reveal(params?: RevealParams) {
-    const pkh = await this.signer.publicKeyHash();
-    if (await this.isAccountRevealRequired(pkh)) {
+    const { publicKeyHash, publicKey } = await this.getSignerOrWallet();
+    if (!publicKey) {
+      throw new RevealEstimateError();
+    }
+    if (await this.isAccountRevealRequired(publicKeyHash)) {
       const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
-      const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
+      const DEFAULT_PARAMS = await this.getAccountLimits(publicKeyHash, protocolConstants);
       const op = await createRevealOperation(
         {
           ...params,
           ...DEFAULT_PARAMS,
         },
-        pkh,
-        await this.signer.publicKey()
+        publicKeyHash,
+        publicKey
       );
       const estimateProperties = await this.prepareEstimate(
-        { operation: op, source: pkh },
-        protocolConstants
+        { operation: op, source: publicKeyHash },
+        protocolConstants,
+        publicKeyHash
       );
       return Estimate.createEstimateInstanceFromProperties(estimateProperties);
     }
@@ -434,7 +462,7 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     gasLimit,
     ...rest
   }: RegisterGlobalConstantParams) {
-    const pkh = await this.signer.publicKeyHash();
+    const pkh = (await this.getSignerOrWallet()).publicKeyHash;
     const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
     const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
     const op = await createRegisterGlobalConstantOperation({
@@ -445,7 +473,8 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
     const ops = isRevealNeeded ? await this.addRevealOp([op], pkh) : op;
     const estimateProperties = await this.prepareEstimate(
       { operation: ops, source: pkh },
-      protocolConstants
+      protocolConstants,
+      pkh
     );
     if (isRevealNeeded) {
       estimateProperties.shift();
@@ -454,6 +483,10 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
   }
 
   private async addRevealOp(op: RPCOperation[], pkh: string) {
+    const { publicKey } = await this.getSignerOrWallet();
+    if (!publicKey) {
+      throw new RevealEstimateError();
+    }
     op.unshift(
       await createRevealOperation(
         {

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -60,10 +60,10 @@ export abstract class OperationEmitter {
   }
 
   // Originally from sotez (Copyright (c) 2018 Andrew Kishino)
-  protected async prepareOperation({
-    operation,
-    source,
-  }: PrepareOperationParams): Promise<PreparedOperation> {
+  protected async prepareOperation(
+    { operation, source }: PrepareOperationParams,
+    pkh?: string
+  ): Promise<PreparedOperation> {
     const counters: { [key: string]: number } = {};
     let ops: RPCOperation[] = [];
 
@@ -77,7 +77,7 @@ export abstract class OperationEmitter {
     }
 
     // Implicit account who emit the operation
-    const publicKeyHash = await this.signer.publicKeyHash();
+    const publicKeyHash = pkh ? pkh : await this.signer.publicKeyHash();
     let counterPromise: Promise<string | undefined> = Promise.resolve(undefined);
 
     for (let i = 0; i < ops.length; i++) {


### PR DESCRIPTION
Estimation is done with the configured signer. If there is no configured signer, estimation is done
using the public key hash of the configured wallet. Taquito does not have access to the public key
of the wallet (only the pkh), so won't estimate reveal operation. If the account is unrevealed, an
exception is throwned.

re #1387

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
