### PR TITLE
made use of HttpRequestFailed error to expose generic error details

### DIFF
--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -9,8 +9,6 @@ import axios from 'axios';
 export * from './status_code';
 export { VERSION } from './version';
 
-const defaultTimeout = 30000;
-
 enum ResponseType {
   TEXT = 'text',
   JSON = 'json',
@@ -50,8 +48,8 @@ export class HttpResponseError extends Error {
 export class HttpRequestFailed extends Error {
   public name = 'HttpRequestFailed';
 
-  constructor(public url: string, public innerEvent: any) {
-    super(`Request to ${url} failed`);
+  constructor(public errorDetail: string) {
+    super(errorDetail);
   }
 }
 
@@ -144,7 +142,7 @@ export class HttpBackend {
           url + this.serialize(query)
         );
       } else {
-        throw new Error(err);
+        throw new HttpRequestFailed(err);
       }
     }
 


### PR DESCRIPTION
#1091 
- Simple change to expose the full error object using the existing HttpRequestFailed error object

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
