### PR TITLE
feat(beacon wallet): updated beacon-sdk to version 2.3.11

### DIFF
--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "@airgap/beacon-sdk": "^2.3.10",
+    "@airgap/beacon-sdk": "^2.3.11",
     "@taquito/taquito": "^12.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update of taquito to include latest patch release of beacon-sdk. 
This taquito branch was created from the `12.0.1` tag.