### PR TITLE
[ci] Sticky comments for Pull Requests

### DIFF
--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -53,4 +53,4 @@ jobs:
       uses: marocchino/sticky-pull-request-comment@v2
       with:
         header: deploy-packages
-        message: ${{ process.env.COMMENT_BODY }}
+        message: ${{ env.COMMENT_BODY }}

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -39,7 +39,7 @@ jobs:
     - run: git add . && git commit -m "committing changes to files to make lerna happy in next step, this is expected to never be pushed to remote"
     - run: echo ${VERDACCIO_TOKEN} >> ~/.npmrc
     - run: npm run lerna -- publish --dist-tag edge from-package --yes --registry https://npm.preview.tezostaquito.io/
-    - if: github.event.pull_request != null
+    - if: ${{ github.event_name == 'pull_request' }}
       run: |
           echo "COMMENT_BODY<<EOF"  >> $GITHUB_ENV
           echo "New packages have been deployed to the preview repository at https://npm.preview.tezostaquito.io/." >> $GITHUB_ENV
@@ -49,14 +49,8 @@ jobs:
           find packages/ -mindepth 1 -maxdepth 2 -name package.json | xargs -I{} node -pe "require('./{}')['name']" | sed "s/^\(.*\)$/npm i \1@${TARGET_VERSION} --registry https:\/\/npm.preview.tezostaquito.io\//" >> $GITHUB_ENV
           echo "\`\`\`" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-    - if: github.event.pull_request != null
-      uses: actions/github-script@v3
+    - if: ${{ github.event_name == 'pull_request' }}
+      uses: marocchino/sticky-pull-request-comment@v2
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: process.env.COMMENT_BODY
-          })
+        header: deploy-packages
+        message: ${{ process.env.COMMENT_BODY }}

--- a/.github/workflows/preview_website.yml
+++ b/.github/workflows/preview_website.yml
@@ -2,7 +2,8 @@ name: Netlify Preview Deploy
 
 on:
   pull_request:
-    branches: [master]
+    branches: 
+      - master
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}

--- a/.github/workflows/preview_website.yml
+++ b/.github/workflows/preview_website.yml
@@ -2,8 +2,7 @@ name: Netlify Preview Deploy
 
 on:
   pull_request:
-    branches: 
-      - master
+    branches: [master]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}

--- a/.github/workflows/preview_website.yml
+++ b/.github/workflows/preview_website.yml
@@ -32,17 +32,11 @@ jobs:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
 
-    - uses: actions/github-script@v3
+    - uses: marocchino/sticky-pull-request-comment@v2
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          github.issues.createComment({
-            issue_number: context.issue.number,
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            body: 'A new deploy preview is available on Netlify at https://${{ env.short_sha }}--tezostaquito.netlify.app'
-          })
-    - uses: actions/checkout@v2
+        header: netlify-preview
+        message: 'A new deploy preview is available on Netlify at https://${{ env.short_sha }}--tezostaquito.netlify.app'
+
     - name: Slack Notification
       uses: rtCamp/action-slack-notify@v2
       env:


### PR DESCRIPTION
Currently, Taquito PRs get polluted by automated comments every time a new commit is pushed.

Instead of creating new comments for Netlify previews and NPM package deployments we can update the existing ones with the latest information.

| Before | After |
| --- | --- |
| ![Screenshot from 2022-04-09 00-13-42](https://user-images.githubusercontent.com/22307776/162540705-55a41f66-0ae7-4315-9fc4-8c4ffc4d08ee.png) | ![Screenshot from 2022-04-09 02-07-14](https://user-images.githubusercontent.com/22307776/162548266-0559e703-9c7c-444e-a08a-e8646209cc78.png)
 |



