### PR TITLE
add support for transaction rollup contract addresses

### DIFF
--- a/packages/taquito-utils/src/constants.ts
+++ b/packages/taquito-utils/src/constants.ts
@@ -96,7 +96,7 @@ export const prefix = {
   [Prefix.TXI]: new Uint8Array([79, 148, 196]),
   [Prefix.TXM]: new Uint8Array([79, 149, 30]),
   [Prefix.TXC]: new Uint8Array([79, 148, 17]),
-  [Prefix.TXMR]: new Uint8Array([18, 7, 206, 087]),
+  [Prefix.TXMR]: new Uint8Array([18, 7, 206, 87]),
   [Prefix.TXRL]: new Uint8Array([79, 146, 82]),
   [Prefix.TXW]: new Uint8Array([79, 150, 72]),
    

--- a/packages/taquito-utils/src/constants.ts
+++ b/packages/taquito-utils/src/constants.ts
@@ -4,6 +4,7 @@ export enum Prefix {
   TZ3 = 'tz3',
   KT = 'KT',
   KT1 = 'KT1',
+  TXR1 = 'txr1',
 
   EDSK2 = 'edsk2',
   SPSK = 'spsk',
@@ -45,6 +46,7 @@ export const prefix = {
   [Prefix.TZ3]: new Uint8Array([6, 161, 164]),
   [Prefix.KT]: new Uint8Array([2, 90, 121]),
   [Prefix.KT1]: new Uint8Array([2, 90, 121]),
+  [Prefix.TXR1]: new Uint8Array([2, 90, 121]),
 
   [Prefix.EDSK]: new Uint8Array([43, 246, 78, 7]),
   [Prefix.EDSK2]: new Uint8Array([13, 15, 58, 7]),

--- a/packages/taquito-utils/src/constants.ts
+++ b/packages/taquito-utils/src/constants.ts
@@ -2,9 +2,9 @@ export enum Prefix {
   TZ1 = 'tz1',
   TZ2 = 'tz2',
   TZ3 = 'tz3',
+  TZ4 = 'tz4',
   KT = 'KT',
   KT1 = 'KT1',
-  TXR1 = 'txr1',
 
   EDSK2 = 'edsk2',
   SPSK = 'spsk',
@@ -38,15 +38,25 @@ export enum Prefix {
   TZ = 'TZ',
 
   VH = 'vh', // block_payload_hash
+
+  //rollups
+  TXR1 = 'txr1',
+  TXI = 'txi',
+  TXM = 'txm',
+  TXC = 'txc',
+  TXMR = 'txmr',
+  TXRL = 'txM',
+  TXW = 'txw',
+
 }
 
 export const prefix = {
   [Prefix.TZ1]: new Uint8Array([6, 161, 159]),
   [Prefix.TZ2]: new Uint8Array([6, 161, 161]),
   [Prefix.TZ3]: new Uint8Array([6, 161, 164]),
+  [Prefix.TZ4]: new Uint8Array([6, 161, 166]),
   [Prefix.KT]: new Uint8Array([2, 90, 121]),
   [Prefix.KT1]: new Uint8Array([2, 90, 121]),
-  [Prefix.TXR1]: new Uint8Array([2, 90, 121]),
 
   [Prefix.EDSK]: new Uint8Array([43, 246, 78, 7]),
   [Prefix.EDSK2]: new Uint8Array([13, 15, 58, 7]),
@@ -81,14 +91,25 @@ export const prefix = {
   [Prefix.TZ]: new Uint8Array([2, 90, 121]),
 
   [Prefix.VH]: new Uint8Array([1, 106, 242]),
+
+  [Prefix.TXR1]: new Uint8Array([1, 128, 120, 31]),
+  [Prefix.TXI]: new Uint8Array([79, 148, 196]),
+  [Prefix.TXM]: new Uint8Array([79, 149, 30]),
+  [Prefix.TXC]: new Uint8Array([79, 148, 17]),
+  [Prefix.TXMR]: new Uint8Array([18, 7, 206, 087]),
+  [Prefix.TXRL]: new Uint8Array([79, 146, 82]),
+  [Prefix.TXW]: new Uint8Array([79, 150, 72]),
+   
 };
 
 export const prefixLength: { [key: string]: number } = {
   [Prefix.TZ1]: 20,
   [Prefix.TZ2]: 20,
   [Prefix.TZ3]: 20,
+  [Prefix.TZ4]: 20,
   [Prefix.KT]: 20,
   [Prefix.KT1]: 20,
+
   [Prefix.EDPK]: 32,
   [Prefix.SPPK]: 33,
   [Prefix.P2PK]: 33,
@@ -101,4 +122,12 @@ export const prefixLength: { [key: string]: number } = {
   [Prefix.P]: 32,
   [Prefix.O]: 32,
   [Prefix.VH]: 32,
+  [Prefix.TXR1]: 20,
+  [Prefix.TXI]: 32,
+  [Prefix.TXM]: 32,
+  [Prefix.TXC]: 32,
+  [Prefix.TXMR]: 32,
+  [Prefix.TXRL]: 32,
+  [Prefix.TXW]: 32,
+
 };

--- a/packages/taquito-utils/src/validators.ts
+++ b/packages/taquito-utils/src/validators.ts
@@ -59,7 +59,7 @@ function validatePrefixedValue(value: any, prefixes: Prefix[]) {
 }
 
 const implicitPrefix = [Prefix.TZ1, Prefix.TZ2, Prefix.TZ3];
-const contractPrefix = [Prefix.KT1];
+const contractPrefix = [Prefix.KT1,Prefix.TXR1];
 const signaturePrefix = [Prefix.EDSIG, Prefix.P2SIG, Prefix.SPSIG, Prefix.SIG];
 const pkPrefix = [Prefix.EDPK, Prefix.SPPK, Prefix.P2PK];
 const operationPrefix = [Prefix.O];

--- a/packages/taquito-utils/src/validators.ts
+++ b/packages/taquito-utils/src/validators.ts
@@ -58,7 +58,7 @@ function validatePrefixedValue(value: any, prefixes: Prefix[]) {
   return ValidationResult.VALID;
 }
 
-const implicitPrefix = [Prefix.TZ1, Prefix.TZ2, Prefix.TZ3];
+const implicitPrefix = [Prefix.TZ1, Prefix.TZ2, Prefix.TZ3,Prefix.TZ4];
 const contractPrefix = [Prefix.KT1,Prefix.TXR1];
 const signaturePrefix = [Prefix.EDSIG, Prefix.P2SIG, Prefix.SPSIG, Prefix.SIG];
 const pkPrefix = [Prefix.EDPK, Prefix.SPPK, Prefix.P2PK];

--- a/packages/taquito-utils/test/validators.spec.ts
+++ b/packages/taquito-utils/test/validators.spec.ts
@@ -18,6 +18,7 @@ describe('validateAddress', () => {
     expect(validateAddress('tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m')).toEqual(ValidationResult.VALID);
     expect(validateAddress('tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN')).toEqual(ValidationResult.VALID);
     expect(validateAddress('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D%test')).toEqual(ValidationResult.VALID);
+    expect(validateAddress('tz4EECtMxAuJ9UDLaiMZH7G1GCFYUWsj8HZn')).toEqual(ValidationResult.VALID);
 
     // Invalid checksum
     expect(validateAddress('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hm')).toEqual(
@@ -30,6 +31,7 @@ describe('validateAddress', () => {
     expect(validateAddress('tz2')).toEqual(ValidationResult.INVALID_CHECKSUM);
     expect(validateAddress('tz3')).toEqual(ValidationResult.INVALID_CHECKSUM);
     expect(validateAddress('KT1')).toEqual(ValidationResult.INVALID_CHECKSUM);
+    expect(validateAddress('tz4')).toEqual(ValidationResult.INVALID_CHECKSUM);
     expect(validateAddress('test')).toEqual(ValidationResult.NO_PREFIX_MATCHED);
     expect(validateAddress([])).toEqual(ValidationResult.NO_PREFIX_MATCHED);
     expect(validateAddress('')).toEqual(ValidationResult.NO_PREFIX_MATCHED);
@@ -71,6 +73,7 @@ describe('validateContractAddress', () => {
     expect(validateContractAddress('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D')).toEqual(
       ValidationResult.VALID
     );
+    expect(validateContractAddress('txr1YNMEtkj5Vkqsbdmt7xaxBTMRZjzS96UAi')).toEqual(ValidationResult.VALID);
     expect(validateContractAddress('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toEqual(
       ValidationResult.NO_PREFIX_MATCHED
     );
@@ -80,6 +83,7 @@ describe('validateContractAddress', () => {
     expect(validateContractAddress('tz3VEZ4k6a4Wx42iyev6i2aVAptTRLEAivNN')).toEqual(
       ValidationResult.NO_PREFIX_MATCHED
     );
+    expect(validateContractAddress('txr1YNMEtkj5Vkqsbdmt7xaxBTMRZjzS96UAu')).toEqual(ValidationResult.INVALID_CHECKSUM);
   });
 });
 


### PR DESCRIPTION
I just authorized "txr1" rollup addresses to the list of valid contract prefixes.
rollups on Mondaynet are protocol smart contract that acts like any user smart contract, taquito should allow to forge a Contract object from a rollup contract address

This is a minor change but it is blocking my development on a dapp for the Tezos rollups