### PR TITLE
Updated tailscale version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,7 @@ jobs:
       uses: tailscale/github-action@v1
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+        version: 1.22.2
     - run: cd integration-tests && npm run test:hangzhounet -- --maxWorkers=8
       env:
         CI: true
@@ -74,6 +75,7 @@ jobs:
       uses: tailscale/github-action@v1
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+        version: 1.22.2
     - run: cd integration-tests && npm run test:ithacanet -- --maxWorkers=8
       env:
         CI: true

--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -18,24 +18,25 @@ jobs:
     - run: npm ci
     - run: npm run lerna -- bootstrap
     - run: npm run build
-    - 
+    -
       name: Tailscale
       uses: tailscale/github-action@v1
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-    - 
+        version: 1.22.2
+    -
       id: originate-contracts-mondaynet
       working-directory: ./integration-tests
       env:
         MONDAYNET: true
       run: npm run test:originate-known-contracts
-    - 
+    -
       if: always()
       id: integration-tests-mondaynet
       working-directory: ./integration-tests
       env:
         TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
-        TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }} 
-        TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }} 
+        TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
+        TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
         TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
       run: npm run test:mondaynet -- --maxWorkers=2


### PR DESCRIPTION
The Tailscale action is still using `v1.14.2` and should be updated to use a newer version `v1.22.2`