### PR TITLE
update no unused vars, strict

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,9 +16,9 @@
     },
     "rules": { 
         "no-unused-vars": "off", // note you must disable the base rule as it can report incorrect errors
-        "@typescript-eslint/no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
         "@typescript-eslint/no-explicit-any": "off",
-        "@typescript-eslint/no-var-requires": "off"
+        "@typescript-eslint/no-var-requires": "error"
     },
     "ignorePatterns": [
         "**/dist/**",

--- a/packages/taquito-contracts-library/src/rpc-wrapper.ts
+++ b/packages/taquito-contracts-library/src/rpc-wrapper.ts
@@ -23,7 +23,6 @@ import {
   ManagerKeyResponse,
   MichelsonV1Expression,
   PackDataParams,
-  PeriodKindResponse,
   PreapplyParams,
   PreapplyResponse,
   ProposalsResponse,

--- a/packages/taquito-local-forging/src/proto12-ithaca/constants.ts
+++ b/packages/taquito-local-forging/src/proto12-ithaca/constants.ts
@@ -1,7 +1,7 @@
 import { kindMapping } from '../constants';
 import { pad } from '../utils';
 
-const { [0x00]: ommited, ...kindMappingNoEndorsement } = kindMapping;
+const { [0x00]: _ommited, ...kindMappingNoEndorsement } = kindMapping;
 
 export const kindMappingProto12: { [key: number]: string } = {
   ...kindMappingNoEndorsement,

--- a/packages/taquito-michel-codec/src/michelson-typecheck.ts
+++ b/packages/taquito-michel-codec/src/michelson-typecheck.ts
@@ -2,7 +2,6 @@ import { Prim, Expr } from './micheline';
 import {
   MichelsonType,
   MichelsonData,
-  MichelsonMapElt,
   MichelsonCode,
   MichelsonTypeOption,
   MichelsonContract,
@@ -211,7 +210,7 @@ export function assertTypeAnnotationsValid(t: MichelsonType, field = false): voi
 
 // Data integrity check
 
-function compareMichelsonData(t: MichelsonType, a: MichelsonData, b: MichelsonData): number {
+function _compareMichelsonData(t: MichelsonType, a: MichelsonData, b: MichelsonData): number {
   if (isPairType(t)) {
     if (isPairData(a) && isPairData(b)) {
       assertDataListIfAny(a);
@@ -219,11 +218,11 @@ function compareMichelsonData(t: MichelsonType, a: MichelsonData, b: MichelsonDa
       const tComb = unpackComb('pair', t);
       const aComb = unpackComb('Pair', a);
       const bComb = unpackComb('Pair', b);
-      const x = compareMichelsonData(tComb.args[0], aComb.args[0], bComb.args[0]);
+      const x = _compareMichelsonData(tComb.args[0], aComb.args[0], bComb.args[0]);
       if (x !== 0) {
         return x;
       }
-      return compareMichelsonData(tComb.args[0], aComb.args[1], bComb.args[1]);
+      return _compareMichelsonData(tComb.args[0], aComb.args[1], bComb.args[1]);
     }
   } else {
     switch (t.prim) {
@@ -733,7 +732,7 @@ function functionTypeInternal(
           ]
         : undefined;
 
-    const { annots, ...rest } = t;
+    const { annots: _annots, ...rest } = t;
     return { ...(rest as T), ...(ann && ann.length !== 0 && { annots: ann }) };
   }
 
@@ -1218,7 +1217,7 @@ function functionTypeInternal(
       }
 
       case 'SUB_MUTEZ': {
-        const s = args(0, ['mutez'], ['mutez']);
+        const _s = args(0, ['mutez'], ['mutez']);
         return [annotateVar({ prim: 'option', args: [{ prim: 'mutez' }] }), ...stack.slice(2)];
       }
 

--- a/packages/taquito-michel-codec/test/contracts_010.spec.ts
+++ b/packages/taquito-michel-codec/test/contracts_010.spec.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import  * as fs from 'fs';
 import path from 'path';
 import { inspect } from 'util';
 import { Contract, ContractOptions } from '../src/michelson-contract';

--- a/packages/taquito-remote-signer/test/taquito-remote-signer.spec.ts
+++ b/packages/taquito-remote-signer/test/taquito-remote-signer.spec.ts
@@ -4,7 +4,6 @@ import { RemoteSigner } from '../src/taquito-remote-signer';
  * RemoteSigner test
  */
 describe('RemoteSigner test', () => {
-  let _signer: RemoteSigner;
   let httpBackend: {
     createRequest: jest.Mock<any, any>;
   };
@@ -13,12 +12,6 @@ describe('RemoteSigner test', () => {
     httpBackend = {
       createRequest: jest.fn(),
     };
-    _signer = new RemoteSigner(
-      'tz1iD5nmudc4QtfNW14WWaiP7JEDuUHnbXuv',
-      'http://127.0.0.1:6732',
-      {},
-      httpBackend as any
-    );
   });
 
   it('RemoteSigner is instantiable', () => {

--- a/packages/taquito-remote-signer/test/taquito-remote-signer.spec.ts
+++ b/packages/taquito-remote-signer/test/taquito-remote-signer.spec.ts
@@ -4,7 +4,7 @@ import { RemoteSigner } from '../src/taquito-remote-signer';
  * RemoteSigner test
  */
 describe('RemoteSigner test', () => {
-  let signer: RemoteSigner;
+  let _signer: RemoteSigner;
   let httpBackend: {
     createRequest: jest.Mock<any, any>;
   };
@@ -13,7 +13,7 @@ describe('RemoteSigner test', () => {
     httpBackend = {
       createRequest: jest.fn(),
     };
-    signer = new RemoteSigner(
+    _signer = new RemoteSigner(
       'tz1iD5nmudc4QtfNW14WWaiP7JEDuUHnbXuv',
       'http://127.0.0.1:6732',
       {},

--- a/packages/taquito-rpc/src/rpc-client-interface.ts
+++ b/packages/taquito-rpc/src/rpc-client-interface.ts
@@ -24,7 +24,6 @@ import {
   ManagerKeyResponse,
   OperationHash,
   PackDataParams,
-  PeriodKindResponse,
   PreapplyParams,
   PreapplyResponse,
   ProposalsResponse,

--- a/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
+++ b/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
@@ -25,7 +25,6 @@ import {
   ManagerKeyResponse,
   OperationHash,
   PackDataParams,
-  PeriodKindResponse,
   PreapplyParams,
   PreapplyResponse,
   ProposalsResponse,

--- a/packages/taquito-rpc/test/rpc-cache.spec.ts
+++ b/packages/taquito-rpc/test/rpc-cache.spec.ts
@@ -17,7 +17,6 @@ import {
   endorsingRights,
   ballotList,
   ballots,
-  currentPeriodKind,
   currentProposal,
   currentQuorum,
   votesListing,

--- a/packages/taquito-tezbridge-wallet/src/taquito-tezbridge-wallet.ts
+++ b/packages/taquito-tezbridge-wallet/src/taquito-tezbridge-wallet.ts
@@ -77,7 +77,7 @@ export class TezBridgeWallet implements WalletProvider {
   }
 
   private removeFeeAndLimit<T extends { gas_limit: any; storage_limit: any; fee: any }>(op: T) {
-    const { fee, gas_limit, storage_limit, ...rest } = op;
+    const { fee: _fee, gas_limit: _gas_limit, storage_limit: _storage_limit, ...rest } = op;
     return rest;
   }
 }

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -1,4 +1,4 @@
-import { encodeExpr, char2Bytes, bytes2Char, encodeOpHash, getPkhfromPk, encodeKeyHash, encodeKey, encodePubKey, b58decode, b58cdecode, prefix, Prefix, b58cencode } from '../src/taquito-utils';
+import { encodeExpr, char2Bytes, bytes2Char, encodeOpHash, getPkhfromPk, encodeKeyHash, encodeKey, encodePubKey } from '../src/taquito-utils';
 
 describe('Encode expr', () => {
   it('Should encode expression properly', () => {

--- a/packages/taquito/patch.js
+++ b/packages/taquito/patch.js
@@ -1,4 +1,5 @@
-import * as fs from 'fs';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const fs = require("fs")
 const angularWebpackConfig =
   '../../@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
 

--- a/packages/taquito/patch.js
+++ b/packages/taquito/patch.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+import * as fs from 'fs';
 const angularWebpackConfig =
   '../../@angular-devkit/build-angular/src/angular-cli-files/models/webpack-configs/browser.js';
 

--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -80,9 +80,6 @@ const isView = (entrypoint: MichelsonV1Expression): boolean => {
 export type Contract = ContractAbstraction<ContractProvider>;
 export type WalletContract = ContractAbstraction<Wallet>;
 
-const _isContractProvider = (variableToCheck: any): variableToCheck is ContractProvider =>
-  variableToCheck.contractProviderTypeSymbol !== undefined;
-
 type DefaultMethods<T extends ContractProvider | Wallet> = Record<
   string,
   (...args: any[]) => ContractMethod<T>

--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -80,7 +80,7 @@ const isView = (entrypoint: MichelsonV1Expression): boolean => {
 export type Contract = ContractAbstraction<ContractProvider>;
 export type WalletContract = ContractAbstraction<Wallet>;
 
-const isContractProvider = (variableToCheck: any): variableToCheck is ContractProvider =>
+const _isContractProvider = (variableToCheck: any): variableToCheck is ContractProvider =>
   variableToCheck.contractProviderTypeSymbol !== undefined;
 
 type DefaultMethods<T extends ContractProvider | Wallet> = Record<

--- a/packages/taquito/src/wallet/wallet.ts
+++ b/packages/taquito/src/wallet/wallet.ts
@@ -1,4 +1,3 @@
-import { Protocols } from '../constants';
 import { Context } from '../context';
 import { ContractAbstraction, ContractStorageType, DefaultWalletType } from '../contract';
 import { ContractMethod } from '../contract/contract-methods/contract-method-flat-param';

--- a/packages/taquito/test/read-provider/rpc-read-adapter.spec.ts
+++ b/packages/taquito/test/read-provider/rpc-read-adapter.spec.ts
@@ -13,7 +13,6 @@ import {
   contractStorage,
   liveBlocks,
   saplingState,
-  storageType,
 } from './data';
 
 describe('RpcReadAdapter test', () => {

--- a/packages/taquito/webpack.config.js
+++ b/packages/taquito/webpack.config.js
@@ -1,7 +1,8 @@
-import TerserPlugin from 'terser-webpack-plugin';
-import pkg from './package.json';
-import SriPlugin from 'webpack-subresource-integrity';
-import WebpackAssetsManifest from 'webpack-assets-manifest';
+/* eslint-disable @typescript-eslint/no-var-requires */
+const TerserPlugin = require('terser-webpack-plugin');
+const pkg = require('./package.json');
+var SriPlugin = require('webpack-subresource-integrity');
+var WebpackAssetsManifest = require('webpack-assets-manifest');
 
 module.exports = {
   mode: 'production',

--- a/packages/taquito/webpack.config.js
+++ b/packages/taquito/webpack.config.js
@@ -1,7 +1,7 @@
-const TerserPlugin = require('terser-webpack-plugin');
-const pkg = require('./package.json');
-var SriPlugin = require('webpack-subresource-integrity');
-var WebpackAssetsManifest = require('webpack-assets-manifest');
+import TerserPlugin from 'terser-webpack-plugin';
+import pkg from './package.json';
+import SriPlugin from 'webpack-subresource-integrity';
+import WebpackAssetsManifest from 'webpack-assets-manifest';
 
 module.exports = {
   mode: 'production',


### PR DESCRIPTION
linter throw error if contains unused variables / uses require() instead of import

ignores arguments and variables that start with `_`

only one disable comment for require() in patch.js

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
