### PR TITLE
Removed Teznode from list of community-run nodes

### DIFF
--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -25,7 +25,6 @@ author: Roxane Letourneau
 | SmartPy          | Ithacanet   | https://ithacanet.smartpy.io/      | [Check](https://ithacanet.smartpy.io/chains/main/blocks/head/header)    |
 | Tezos Foundation | Mainnet     | https://rpc.tzbeta.net/            | [Check](https://rpc.tzbeta.net/chains/main/blocks/head/header)      |
 | Tezos Foundation | Ithacanet   | https://rpczero.tzbeta.net/        | [Check](https://rpczero.tzbeta.net/chains/main/blocks/head/header)      |
-| LetzBake!        | Mainnet     | https://teznode.letzbake.com       |  [Check](https://teznode.letzbake.com/chains/main/blocks/head/header)     |
 | GigaNode         | Mainnet     | https://mainnet-tezos.giganode.io  |  [Check](https://mainnet-tezos.giganode.io/chains/main/blocks/head/header)     |
 | GigaNode         | Hangzhounet | https://testnet-tezos.giganode.io/ | [Check](https://testnet-tezos.giganode.io/chains/main/blocks/head/header)      |
 


### PR DESCRIPTION
The node is no longer maintained. 