### PR TITLE
1641 txr1 encoder addition to AddressToken Class

### DIFF
--- a/integration-tests/contract-with-txr1-address.spec.ts
+++ b/integration-tests/contract-with-txr1-address.spec.ts
@@ -1,0 +1,147 @@
+import { CONFIGS } from "./config";
+import { MichelsonMap } from "@taquito/taquito";
+import { contractWithTxr1Address } from "./data/contract-txr1-address";
+import { Protocols } from "@taquito/taquito";
+
+
+CONFIGS().forEach(({lib, setup, protocol}) => {
+  const Tezos = lib;
+  const jakartanet = Protocols.PtJakart2 === protocol ? test : test.skip
+
+  beforeEach(async (done) => {
+    await setup();
+    done();
+  })
+  describe('test', () => {
+    type Storage = { addressSet: string[], addressMap: MichelsonMap<string, number>; }
+
+    jakartanet('should pass with tz addresses', async (done) => {
+
+      const initialStorage: Storage = {
+        addressSet: [
+          'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL',
+          'tz1LHWNoM2TgPXixyohzP9adhNCmz2Vja6Wz',
+          'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i',
+          'tz2SikbT8j5B2Yu1nwygWLU2yNyLdgMyFQnG',
+          'txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo',
+          'tz3N4qSiF46pwfbuCUQ7j7vKqDCYHjcRxkC7',
+        ],
+        addressMap: MichelsonMap.fromLiteral({
+          'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL': 10,
+          'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i': 21,
+          'tz1LHWNoM2TgPXixyohzP9adhNCmz2Vja6Wz': 100,
+          'tz2SikbT8j5B2Yu1nwygWLU2yNyLdgMyFQnG': 23,
+          'tz3N4qSiF46pwfbuCUQ7j7vKqDCYHjcRxkC7': 17,
+        }) as MichelsonMap<string, number>
+      }
+      const op = await Tezos.contract.originate({
+        balance: '1',
+        code: contractWithTxr1Address,
+        storage: initialStorage
+      })
+      await op.confirmation();
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+
+      const contract = await op.contract();
+      const storage = await contract.storage<Storage>();
+      expect([...storage.addressSet].sort()).toEqual([...initialStorage.addressSet].sort());
+      expect(storage.addressMap.get('txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL')?.toString()).toEqual('10')
+      expect(storage.addressMap.get('tz2SikbT8j5B2Yu1nwygWLU2yNyLdgMyFQnG')?.toString()).toEqual('23')
+      expect(storage.addressMap.get('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i')?.toString()).toEqual('21');
+
+      const newAddressSet = [
+        'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL',
+        'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+        'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i',
+        'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y',
+        'txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo',
+        'KT1A87ZZL8mBKcWGr34BVsERPCJjfX82iBto',
+      ]
+      const setOp = await contract.methods['setAddressSet'](newAddressSet).send();
+      await setOp.confirmation();
+      const newSetStorage = await contract.storage<Storage>();
+      expect([...newSetStorage.addressSet].sort()).toEqual([...newAddressSet].sort());
+
+      const newAddressMap = MichelsonMap.fromLiteral({
+        'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL': 1,
+        'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i': 3,
+        'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D': 5,
+        'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y': 4,
+        'KT1A87ZZL8mBKcWGr34BVsERPCJjfX82iBto': 2,
+      }) as MichelsonMap<string, number>
+      const mapOp = await contract.methods['setAddressMap'](newAddressMap).send();
+      await mapOp.confirmation();
+      const newMapStorage = await contract.storage<Storage>();
+      expect(newMapStorage.addressMap.get('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i')?.toString()).toEqual('3');
+      expect(newMapStorage.addressMap.get('KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y')?.toString()).toEqual('4');
+      expect(newMapStorage.addressMap.get('txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL')?.toString()).toEqual('1');
+      expect(newMapStorage.addressMap.get('txr1bZx7qro4xNsxLhmpXfmzQojHkg8XqrUvL')).toBeUndefined();
+      done();
+    })
+    jakartanet('should pass with KT1', async (done) => {
+
+      const initialStorage: Storage = {
+        addressSet: [
+          'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL',
+          'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+          'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i',
+          'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y',
+          'txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo',
+          'KT1A87ZZL8mBKcWGr34BVsERPCJjfX82iBto',
+        ],
+        addressMap: MichelsonMap.fromLiteral({
+          'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL': 1,
+          'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i': 3,
+          'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D': 5,
+          'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y': 4,
+          'KT1A87ZZL8mBKcWGr34BVsERPCJjfX82iBto': 2,
+        }) as MichelsonMap<string, number>
+      }
+      const op = await Tezos.contract.originate({
+        balance: '1',
+        code: contractWithTxr1Address,
+        storage: initialStorage
+      })
+      await op.confirmation();
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+
+      const contract = await op.contract();
+      const storage = await contract.storage<Storage>();
+      expect([...storage.addressSet].sort()).toEqual([...initialStorage.addressSet].sort());
+      expect(storage.addressMap.get('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D')?.toString()).toEqual('5');
+      expect(storage.addressMap.get('txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL')?.toString()).toEqual('1');
+      expect(storage.addressMap.get('KT1A87ZZL8mBKcWGr34BVsERPCJjfX82iBto')?.toString()).toEqual('2');
+      const newAddressSet = [
+        'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL',
+        'tz1LHWNoM2TgPXixyohzP9adhNCmz2Vja6Wz',
+        'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i',
+        'tz2SikbT8j5B2Yu1nwygWLU2yNyLdgMyFQnG',
+        'txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo',
+        'tz3N4qSiF46pwfbuCUQ7j7vKqDCYHjcRxkC7',
+      ]
+      const setOp = await contract.methods['setAddressSet'](newAddressSet).send();
+      await setOp.confirmation();
+      const newSetStorage = await (await contract.storage<Storage>()).addressSet;
+      expect([...newSetStorage].sort()).toEqual([...newAddressSet].sort());
+
+      const newAddressMap = MichelsonMap.fromLiteral({
+        'txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL': 10,
+        'txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i': 21,
+        'tz1LHWNoM2TgPXixyohzP9adhNCmz2Vja6Wz': 100,
+        'tz2SikbT8j5B2Yu1nwygWLU2yNyLdgMyFQnG': 23,
+        'tz3N4qSiF46pwfbuCUQ7j7vKqDCYHjcRxkC7': 17,
+      }) as MichelsonMap<string, number>
+      const mapOp = await contract.methods['setAddressMap'](newAddressMap).send();
+      await mapOp.confirmation();
+      const newMapStorage = await (await contract.storage<Storage>()).addressMap
+      expect(newMapStorage.get('txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL')?.toString()).toEqual('10');
+      expect(newMapStorage.get('tz2SikbT8j5B2Yu1nwygWLU2yNyLdgMyFQnG')?.toString()).toEqual('23');
+      expect(newMapStorage.get('tz1LHWNoM2TgPXixyohzP9adhNCmz2Vja6Wz')?.toString()).toEqual('100');
+      expect(newMapStorage.get('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i')?.toString()).toEqual('21');
+      expect(newMapStorage.get('txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo')).toBeUndefined();
+      done();
+    })
+  })
+})

--- a/integration-tests/data/contract-txr1-address.ts
+++ b/integration-tests/data/contract-txr1-address.ts
@@ -1,0 +1,52 @@
+export const contractWithTxr1Address = [{
+  "prim": "parameter",
+  "args": [
+    {
+      "prim": "or",
+      "args": [
+        {
+          "prim": "map",
+          "args": [{ "prim": "address" }, { "prim": "int" }],
+          "annots": ["%setAddressMap"]
+        },
+        {
+          "prim": "set", "args": [{ "prim": "address" }],
+          "annots": ["%setAddressSet"]
+        }]
+    }
+  ]
+},
+{
+  "prim": "storage",
+  "args": [
+    {
+      "prim": "pair",
+      "args":
+        [{
+          "prim": "map",
+          "args": [{ "prim": "address" }, { "prim": "int" }],
+          "annots": ["%addressMap"]
+        },
+        {
+          "prim": "set", "args": [{ "prim": "address" }],
+          "annots": ["%addressSet"]
+        }]
+    }
+  ]
+},
+{
+  "prim": "code",
+  "args": [
+    [{ "prim": "UNPAIR" },
+    {
+      "prim": "IF_LEFT",
+      "args":
+        [[{ "prim": "SWAP" }, { "prim": "CDR" }, { "prim": "SWAP" },
+        { "prim": "PAIR" }],
+        [{ "prim": "SWAP" }, { "prim": "CAR" }, { "prim": "PAIR" }]]
+    },
+    { "prim": "NIL", "args": [{ "prim": "operation" }] },
+    { "prim": "PAIR" }]
+  ]
+
+}]

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
@@ -70,6 +70,9 @@ export class AddressToken extends ComparableToken {
     if (val.string) {
       return val.string;
     }
+    if (!val.bytes) {
+      throw new AddressValidationError(val, this, `cannot be missing both string and bytes: ${val}`)
+    }
 
     return encodePubKey(val.bytes);
   }
@@ -93,12 +96,17 @@ export class AddressToken extends ComparableToken {
     if (string) {
       return string;
     }
+    if (!bytes) {
+      throw new AddressValidationError({bytes, string}, this, `cannot be missing both string and bytes ${{string, bytes}}`)
+    }
 
     return encodePubKey(bytes);
   }
   compare(address1: string, address2: string) {
     const isImplicit = (address: string) => {
-      return address.startsWith('tz')
+      // handle two different addresses one with tz the other with txr
+      // redundant... should be removed? or kept for clarity? same happens with KT1 addresses, goes to super
+      return address.startsWith('tz') && !address.startsWith('txr')
     }
     const implicit1 = isImplicit(address1)
     const implicit2 = isImplicit(address2)

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
@@ -104,9 +104,7 @@ export class AddressToken extends ComparableToken {
   }
   compare(address1: string, address2: string) {
     const isImplicit = (address: string) => {
-      // handle two different addresses one with tz the other with txr
-      // redundant... should be removed? or kept for clarity? same happens with KT1 addresses, goes to super
-      return address.startsWith('tz') && !address.startsWith('txr')
+      return address.startsWith('tz')
     }
     const implicit1 = isImplicit(address1)
     const implicit2 = isImplicit(address2)

--- a/packages/taquito-michelson-encoder/src/tokens/contract.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/contract.ts
@@ -1,3 +1,4 @@
+import { TokenSchema } from './../schema/types';
 import { encodePubKey, validateAddress, ValidationResult } from '@taquito/utils';
 import { ContractTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
@@ -32,6 +33,9 @@ export class ContractToken extends Token {
   public Execute(val: { bytes: string; string: string }) {
     if (val.string) {
       return val.string;
+    }
+    if (!val.bytes) {
+      throw new ContractValidationError(val, this, 'must contain bytes or string')
     }
 
     return encodePubKey(val.bytes);
@@ -70,7 +74,7 @@ export class ContractToken extends Token {
     return {
       __michelsonType: ContractToken.prim,
       schema: {
-        parameter: valueSchema.generateSchema(),
+        parameter: this.val.args[0] ? valueSchema.generateSchema() : {} as TokenSchema,
       },
     };
   }

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -81,8 +81,6 @@ describe("Address Token with txr1", () => {
       expect(() => token.EncodeObject({})).toThrowError(AddressValidationError)
       expect(() => token.EncodeObject(1)).toThrowError(AddressValidationError)
       expect(() => token.EncodeObject('tz4QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
-      // does not throw error should this throw an error if given a token that
-      // expect(() => token.EncodeObject('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
     })
   })
 

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -1,3 +1,4 @@
+import { b58decode } from '@taquito/utils';
 import { AddressToken, AddressValidationError } from '../../src/tokens/comparable/address';
 
 describe('Address token', () => {
@@ -47,3 +48,96 @@ describe('Address token', () => {
     });
   });
 });
+describe("Address Token with txr1", () => {
+  let token: AddressToken;
+  const bytes = b58decode("txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL");
+  beforeEach(() => {
+    token = new AddressToken({prim: "address", args: [], annots: []}, 0, null as any)
+  });
+
+  describe('test ToBigMapKey', () => {
+    it("to bytes", () => {
+      expect(token.ToBigMapKey('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')).toEqual({ key: { bytes }, type: { prim: 'bytes' } })
+    })
+  })
+
+  describe("EncodeObject", () => {
+    it("should add string to object with key 'string'", () => {
+      expect(token.EncodeObject('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')).toEqual({
+        string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'
+      });
+    });
+
+    it("test semantic", () => {
+      const val1 = token.EncodeObject('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL', { address: () => ({string: 'tester'})});
+      const val2 = token.EncodeObject('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL', { address: (arg) => ({string: arg})});
+      expect(val1).toEqual({string: 'tester'});
+      expect(val2).toEqual({string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'});
+    });
+
+    it('should throw error with invalid args', () => {
+      expect(() => token.EncodeObject('txr1')).toThrowError(AddressValidationError)
+      expect(() => token.EncodeObject([])).toThrowError(AddressValidationError)
+      expect(() => token.EncodeObject({})).toThrowError(AddressValidationError)
+      expect(() => token.EncodeObject(1)).toThrowError(AddressValidationError)
+      expect(() => token.EncodeObject('tz4QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
+      // does not throw error should this throw an error if given a token that
+      // expect(() => token.EncodeObject('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
+    })
+  })
+
+  describe('Encode', () => {
+    it('should encode address to object with key "string"', () => {
+      expect(token.Encode(['txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'])).toEqual({
+        string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'
+      })
+    })
+    it('should throw error if address not valid', () => {
+      expect(() => token.Encode(['something'])).toThrowError(AddressValidationError)
+      expect(() => token.Encode(['', '', '', ''])).toThrowError(AddressValidationError)
+      expect(() => token.Encode([])).toThrowError(AddressValidationError)
+      expect(() => token.Encode(['1'])).toThrowError(AddressValidationError)
+      try {
+        token.Encode(['async']);
+      } catch(ex) {
+        expect(ex.name).toEqual('AddressValidationError')
+      }
+    })
+  })
+  describe('generateSchema', () => {
+    it('should generate properly', () => {
+      expect(token.generateSchema()).toEqual({
+        __michelsonType: 'address',
+        schema: 'address'
+      });
+    })
+  })
+
+  describe("Execute", () => {
+    it("should throw if no bytes or string", () => {
+      expect(() => token.Execute({string: '', bytes: ''})).toThrowError(AddressValidationError)
+    })
+    it('should return string', () => {
+      expect(token.Execute({string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL', bytes: ""})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
+      expect(token.Execute({bytes, string: ''})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
+    })
+  })
+  describe("Tokey", () => {
+    it('should change bytes to pkh', () => {
+      expect(token.ToKey({bytes})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
+      expect(token.ToKey({string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
+    })
+    it('throw error if empty', () => {
+      expect(() => token.ToKey({bytes: '', string: ''})).toThrowError(AddressValidationError)
+    })
+  })
+  // describe('compare', () => {
+  //   it('should ')
+  // })
+  describe('find return tokens', () => {
+    it('should return or not return token', () => {
+      expect(token.findAndReturnTokens('address', [])).toEqual([token])
+      expect(token.findAndReturnTokens('tx_rollup_l2_address', [])).toEqual([])
+    })
+  })
+})

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -131,9 +131,14 @@ describe("Address Token with txr1", () => {
       expect(() => token.ToKey({bytes: '', string: ''})).toThrowError(AddressValidationError)
     })
   })
-  // describe('compare', () => {
-  //   it('should ')
-  // })
+  describe('compare', () => {
+    it('should order addresses correctly', () => {
+      expect(token.compare('KT1CDEg2oY3VfMa1neB7hK5LoVMButvivKYv', 'tz2Ch1abG7FNiibmV26Uzgdsnfni9XGrk5wD')).toEqual(1)
+      expect(token.compare('tz3YjfexGakCDeCseXFUpcXPSAN9xHxE9TH2', 'tz1ccqAEwfPgeoipnXtjAv1iucrpQv3DFmmS')).toEqual(1)
+      expect(token.compare('KT1CDEg2oY3VfMa1neB7hK5LoVMButvivKYv', 'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y')).toEqual(-1)
+      expect(token.compare('txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo', 'txr1YpFMKsYwTJ4YBmYqy2kw4pxCUgeQkZmwo')).toEqual(0)
+    })
+  })
   describe('find return tokens', () => {
     it('should return or not return token', () => {
       expect(token.findAndReturnTokens('address', [])).toEqual([token])

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -1,4 +1,3 @@
-import { b58decode } from '@taquito/utils';
 import { AddressToken, AddressValidationError } from '../../src/tokens/comparable/address';
 
 describe('Address token', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -50,14 +50,13 @@ describe('Address token', () => {
 });
 describe("Address Token with txr1", () => {
   let token: AddressToken;
-  const bytes = b58decode("txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL");
   beforeEach(() => {
     token = new AddressToken({prim: "address", args: [], annots: []}, 0, null as any)
   });
 
   describe('test ToBigMapKey', () => {
     it("to bytes", () => {
-      expect(token.ToBigMapKey('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')).toEqual({ key: { bytes }, type: { prim: 'bytes' } })
+      expect(token.ToBigMapKey('txr1MfFbj6diPLS2MN2ntoid6cyuk4mUzLibP')).toEqual({ key: { bytes: '02012e7a294c836eeb02010b907c2632b88ed3e23a00' }, type: { prim: 'bytes' } })
     })
   })
 
@@ -117,12 +116,12 @@ describe("Address Token with txr1", () => {
     })
     it('should return string', () => {
       expect(token.Execute({string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL', bytes: ""})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
-      expect(token.Execute({bytes, string: ''})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
+      expect(token.Execute({bytes: '02f16e732d45ba6f24d5ec421f20ab199b3a82907100', string: ''})).toEqual('txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL')
     })
   })
   describe("Tokey", () => {
     it('should change bytes to pkh', () => {
-      expect(token.ToKey({bytes})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
+      expect(token.ToKey({bytes: '02012e7a294c836eeb02010b907c2632b88ed3e23a00'})).toEqual('txr1MfFbj6diPLS2MN2ntoid6cyuk4mUzLibP')
       expect(token.ToKey({string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'})).toEqual('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')
     })
     it('throw error if empty', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/contract.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/contract.spec.ts
@@ -1,0 +1,69 @@
+import { b58decode } from '@taquito/utils';
+import { ContractToken, ContractValidationError } from './../../src/tokens/contract';
+
+describe('Contract Token Tests', () => {
+  let token: ContractToken;
+  const testFunction = (val: any, idx: number) => new ContractToken(val, idx, testFunction)
+  beforeEach(() => {
+    token = new ContractToken({ prim: 'contract', args: [{prim: 'contract', args: [], annots: []}], annots: [] }, 0, testFunction);
+  });
+
+  describe('EncodeObject', () => {
+    it('should encode address to string', () => {
+      expect(token.EncodeObject('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')).toEqual({
+        string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL',
+      });
+    });
+
+    it('should throw error when improper args', () => {
+      expect(() => token.EncodeObject('test')).toThrowError(ContractValidationError);
+      expect(() => token.EncodeObject(0)).toThrowError(ContractValidationError);
+      expect(() => token.EncodeObject([])).toThrowError(ContractValidationError);
+    });
+
+    it('should handle semantics', () => {
+      expect(token.EncodeObject('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL', {contract: () => ({string: 'test'})}).string).toEqual('test')
+    })
+  });
+  describe('execute', () => {
+    const decoded = b58decode('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL');
+    it('should return contract address', () => {
+      expect(token.Execute({ bytes: '', string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL' })).toEqual(
+        'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'
+      );
+      expect(token.Execute({ bytes: decoded, string: '' })).toEqual(
+        'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'
+      );
+    });
+    it('should throw error', () => {
+      expect(() => token.Execute({ bytes: '', string: '' })).toThrowError(ContractValidationError);
+    });
+  });
+  describe('Encode', () => {
+    it('should return string', () => {
+      expect(token.Encode(['txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL'])).toEqual({
+        string: 'txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL',
+      });
+    });
+    it('should throw error', () => {
+      expect(() => token.Encode(['test'])).toThrowError(ContractValidationError);
+      expect(() => token.Encode([1])).toThrowError(ContractValidationError);
+      expect(() => token.Encode([])).toThrowError(ContractValidationError);
+    });
+  });
+  // TODO check
+  describe('schema', () => {
+    it('should generate schema', () => {
+      expect(token.generateSchema()).toEqual({__michelsonType: 'contract', schema: { parameter: { __michelsonType: 'contract', schema: { parameter: {} }}}})
+    })
+    it('should return prim', () => {
+      expect(token.ExtractSchema()).toEqual('contract')
+    })
+  })
+  describe('find and return token', () => {
+    it('should find this token or return without', () => {
+      expect(token.findAndReturnTokens('contract', [])).toEqual([token])
+      expect(token.findAndReturnTokens('missing', [])).toEqual([])
+    })
+  })
+});

--- a/packages/taquito-michelson-encoder/test/tokens/tx_rollup_l2_address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/tx_rollup_l2_address.spec.ts
@@ -80,7 +80,7 @@ describe("TxRollupL2Address Token", () => {
       expect(token.Execute({bytes: '', string: 'tz49XoaXbDZcWi2R1iKxQUxtBWXt4g4S1qtf'})).toEqual("tz49XoaXbDZcWi2R1iKxQUxtBWXt4g4S1qtf")
     })
     it("should return string", () => {
-      expect(token.Execute({bytes,})).toEqual("tz49XoaXbDZcWi2R1iKxQUxtBWXt4g4S1qtf")
+      expect(token.Execute({bytes})).toEqual("tz49XoaXbDZcWi2R1iKxQUxtBWXt4g4S1qtf")
     })
   })
   describe('ToKey', () => {

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -63,6 +63,14 @@ export function b58cencode(value: string | Uint8Array, prefix: Uint8Array) {
   return bs58check.encode(Buffer.from(n.buffer));
 }
 
+export function b58cencodeRollupAddress(value: string | Uint8Array) {
+  const payloadAr = typeof value === 'string' ? Uint8Array.from(Buffer.from(value, 'hex')) : value
+
+  const n = new Uint8Array(payloadAr.length)
+  n.set(payloadAr)
+  return bs58check.encode(Buffer.from(n.buffer));
+}
+
 /**
  *
  * @description Base58 decode a string and remove the prefix from it
@@ -93,6 +101,10 @@ export function b58decode(payload: string) {
     // tz addresses
     const hex = buf2hex(buf.slice(3));
     return pref + hex;
+  } else if (payload.startsWith("txr")) {
+    // txr addresses
+    const hex = buf2hex(buf)
+    return hex;
   } else {
     // other (kt addresses)
     return '01' + buf2hex(buf.slice(3, 42)) + '00';
@@ -128,7 +140,10 @@ export function encodePubKey(value: string) {
 
     return b58cencode(value.substring(4), pref[value.substring(0, 4)]);
   }
-
+  if (b58cencodeRollupAddress(value).startsWith('txr1')) {
+    return b58cencodeRollupAddress(value)
+  }
+  return b58cencode(value.substring(3), prefix.txr1)
   return b58cencode(value.substring(2, 42), prefix.KT);
 }
 /**

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -63,14 +63,6 @@ export function b58cencode(value: string | Uint8Array, prefix: Uint8Array) {
   return bs58check.encode(Buffer.from(n.buffer));
 }
 
-export function b58cencodeRollupAddress(value: string | Uint8Array) {
-  const payloadAr = typeof value === 'string' ? Uint8Array.from(Buffer.from(value, 'hex')) : value
-
-  const n = new Uint8Array(payloadAr.length)
-  n.set(payloadAr)
-  return bs58check.encode(Buffer.from(n.buffer));
-}
-
 /**
  *
  * @description Base58 decode a string and remove the prefix from it
@@ -96,15 +88,19 @@ export function b58decode(payload: string) {
     [prefix.tz3.toString()]: '0002',
   };
 
+  const rollupPrefMap = {
+    [prefix.txr1.toString()]: '02',
+  }
+
   const pref = prefixMap[new Uint8Array(buf.slice(0, 3)).toString()];
+  const rollupPref = rollupPrefMap[new Uint8Array(buf.slice(0, 4)).toString()]
   if (pref) {
     // tz addresses
     const hex = buf2hex(buf.slice(3));
     return pref + hex;
-  } else if (payload.startsWith("txr")) {
-    // txr addresses
-    const hex = buf2hex(buf)
-    return hex;
+  } else if (rollupPref) {
+    const hex = buf2hex(buf.slice(4))
+    return rollupPref + hex + '00'
   } else {
     // other (kt addresses)
     return '01' + buf2hex(buf.slice(3, 42)) + '00';
@@ -139,10 +135,9 @@ export function encodePubKey(value: string) {
     };
 
     return b58cencode(value.substring(4), pref[value.substring(0, 4)]);
-  }
-  const checkTxr1 = b58cencodeRollupAddress(value)
-  if (checkTxr1.startsWith('txr1')) {
-    return checkTxr1
+  } else if (value.substring(0, 2) === '02') {
+    // 42 also works but the removes the 00 padding at the end
+    return b58cencode(value.substring(2, value.length - 2), prefix.txr1)
   }
   return b58cencode(value.substring(2, 42), prefix.KT);
 }

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -143,7 +143,6 @@ export function encodePubKey(value: string) {
   if (b58cencodeRollupAddress(value).startsWith('txr1')) {
     return b58cencodeRollupAddress(value)
   }
-  return b58cencode(value.substring(3), prefix.txr1)
   return b58cencode(value.substring(2, 42), prefix.KT);
 }
 /**

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -140,8 +140,9 @@ export function encodePubKey(value: string) {
 
     return b58cencode(value.substring(4), pref[value.substring(0, 4)]);
   }
-  if (b58cencodeRollupAddress(value).startsWith('txr1')) {
-    return b58cencodeRollupAddress(value)
+  const checkTxr1 = b58cencodeRollupAddress(value)
+  if (checkTxr1.startsWith('txr1')) {
+    return checkTxr1
   }
   return b58cencode(value.substring(2, 42), prefix.KT);
 }

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -1,3 +1,4 @@
+import { b58decode } from '../src/taquito-utils';
 import { encodeExpr, char2Bytes, bytes2Char, encodeOpHash, getPkhfromPk, encodeKeyHash, encodeKey, encodePubKey, b58decodeL2Address, encodeL2Address } from '../src/taquito-utils';
 
 describe('Encode expr', () => {
@@ -32,6 +33,11 @@ describe('encodePubKey', () => {
       'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y'
     );
   });
+
+  it('Should encode address properly (txr1)', () => {
+    const decoded = b58decode('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i');
+    expect(encodePubKey(decoded)).toEqual('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i')
+  })
 });
 
 describe('encodeKey', () => {

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -1,4 +1,3 @@
-import { b58decode } from '../src/taquito-utils';
 import { encodeExpr, char2Bytes, bytes2Char, encodeOpHash, getPkhfromPk, encodeKeyHash, encodeKey, encodePubKey, b58decodeL2Address, encodeL2Address } from '../src/taquito-utils';
 
 describe('Encode expr', () => {
@@ -35,8 +34,7 @@ describe('encodePubKey', () => {
   });
 
   it('Should encode address properly (txr1)', () => {
-    const decoded = b58decode('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i');
-    expect(encodePubKey(decoded)).toEqual('txr1X9N7MQfJENXxAFGpgxv17z1A9ntGMdQ6i')
+    expect(encodePubKey('02f16e732d45ba6f24d5ec421f20ab199b3a82907100')).toEqual('txr1jZaQfi9zdwzJteYkRBSN9D7RDvMh1QNkL')
   })
 });
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1427,6 +1427,15 @@
             "@svgr/plugin-svgo": "^6.2.0"
           }
         },
+        "react-loadable": {
+          "version": "npm:@docusaurus/react-loadable@5.5.2",
+          "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+          "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+          "requires": {
+            "@types/react": "*",
+            "prop-types": "^15.6.2"
+          }
+        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -11678,15 +11687,6 @@
             "jsesc": "~0.5.0"
           }
         }
-      }
-    },
-    "react-loadable": {
-      "version": "npm:@docusaurus/react-loadable@5.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "requires": {
-        "@types/react": "*",
-        "prop-types": "^15.6.2"
       }
     },
     "react-loadable-ssr-addon-v5-slorber": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1427,15 +1427,6 @@
             "@svgr/plugin-svgo": "^6.2.0"
           }
         },
-        "react-loadable": {
-          "version": "npm:@docusaurus/react-loadable@5.5.2",
-          "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-          "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-          "requires": {
-            "@types/react": "*",
-            "prop-types": "^15.6.2"
-          }
-        },
         "semver": {
           "version": "7.3.7",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
@@ -11687,6 +11678,15 @@
             "jsesc": "~0.5.0"
           }
         }
+      }
+    },
+    "react-loadable": {
+      "version": "npm:@docusaurus/react-loadable@5.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "requires": {
+        "@types/react": "*",
+        "prop-types": "^15.6.2"
       }
     },
     "react-loadable-ssr-addon-v5-slorber": {


### PR DESCRIPTION
adaptation for Address Token to accept and properly manage txr1 addresses from tx rollup transactions 

added integration tests for jakartanet and unit tests 

- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [x]  You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
