### PR TITLE
[ci] Run integration tests against tezedge node every tuesday

### DIFF
--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -5,7 +5,6 @@ on:
     - cron: '0 0 * * 2'
   # Allows to run this workflow manually from the Actions tab
   workflow_dispatch:
-  push:
 
 jobs:
   integration-tests-mondaynet:

--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -1,6 +1,9 @@
 name: Mondaynet Integration Tests
 
 on:
+  push:
+    branches:
+      - '**mondaynet**'
   schedule:
     - cron: '0 0 * * 2'
   # Allows to run this workflow manually from the Actions tab

--- a/.github/workflows/tezedge.yml
+++ b/.github/workflows/tezedge.yml
@@ -1,6 +1,8 @@
 name: Tezedge Integration Tests
 
 on:
+  schedule:
+    - cron: '0 0 * * 2'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/tezedge.yml
+++ b/.github/workflows/tezedge.yml
@@ -1,6 +1,9 @@
 name: Tezedge Integration Tests
 
 on:
+  push:
+    branches:
+      - '**tezedge**'
   schedule:
     - cron: '0 0 * * 2'
   workflow_dispatch:


### PR DESCRIPTION
Relates to #1446

 - Run integration tests against Tezedge node on a schedule every Tuesday just like Mondaynet tests
 - Run Tezedge and Mondaynet tests selectively only when we include their name in a branch name. for example `update_mondaynet_tests` or `fix_tests_tezedge` 
 - Avoid running mondaynet tests against each commit to avoid pipeline failures caused by mondaynet tests like the screenshot below
![Screenshot from 2022-06-14 18-00-38](https://user-images.githubusercontent.com/22307776/173623311-10263c62-fcd2-43e6-8ec6-cc2c33700955.png)
 