### PR TITLE
added rpc check for mondaynet

### DIFF
--- a/integration-tests/rpc-get-protocol-constants.spec.ts
+++ b/integration-tests/rpc-get-protocol-constants.spec.ts
@@ -14,7 +14,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
 
         const rpcUrl = 'https://mainnet-archive.api.tez.ie/';
         Tezos.setRpcProvider(rpcUrl)
-        it('succesfully fails at fetching constants for level 0', async (done) => {
+        it('successfully fails at fetching constants for level 0', async (done) => {
             try {
                 await Tezos.rpc.getConstants({ block: "0" });
                 expect.assertions(1);
@@ -458,7 +458,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
 
     describe(`Fetch constants for testnet`, () => {
 
-        ithacanet(`succesfully fetches all constants for ithacanet using ${rpc}`, async (done) => {
+        ithacanet(`successfully fetches all constants for ithacanet using ${rpc}`, async (done) => {
             Tezos.setRpcProvider(rpc);
             const constants: ConstantsResponseProto012 & ConstantsResponseCommon = await Tezos.rpc.getConstants();
 
@@ -516,7 +516,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
             done();
         })
 
-        jakartanet(`succesfully fetches all constants for jakartanet using ${rpc}`, async (done) => {
+        jakartanet(`successfully fetches all constants for jakartanet using ${rpc}`, async (done) => {
             Tezos.setRpcProvider(rpc);
             const constants: ConstantsResponseProto013 & ConstantsResponseCommon = await Tezos.rpc.getConstants();
 
@@ -596,7 +596,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
             done();
         })
 
-        mondaynet(`succesfully fetches all constants for mondaynet using ${rpc}`, async (done) => {
+        mondaynet(`successfully fetches all constants for mondaynet using ${rpc}`, async (done) => {
             Tezos.setRpcProvider(rpc);
             const constants: ConstantsResponseProto012 & ConstantsResponseCommon = await Tezos.rpc.getConstants();
 

--- a/integration-tests/rpc-get-protocol-constants.spec.ts
+++ b/integration-tests/rpc-get-protocol-constants.spec.ts
@@ -8,6 +8,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
 
     const jakartanet = (protocol === Protocols.PtJakart2) ? test : test.skip;
     const ithacanet = (protocol === Protocols.Psithaca2) ? test : test.skip;
+    const mondaynet = (protocol === Protocols.ProtoALpha) ? test : test.skip;
 
     describe('Fetch constants for all protocols on Mainnet', () => {
 
@@ -457,6 +458,64 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
 
     describe(`Fetch constants for testnet`, () => {
 
+        ithacanet(`succesfully fetches all constants for ithacanet using ${rpc}`, async (done) => {
+            Tezos.setRpcProvider(rpc);
+            const constants: ConstantsResponseProto012 & ConstantsResponseCommon = await Tezos.rpc.getConstants();
+
+            expect(constants).toEqual({
+                proof_of_work_nonce_size: 8,
+                nonce_length: 32,
+                max_anon_ops_per_block: 132,
+                max_operation_data_length: 32768,
+                max_proposals_per_delegate: 20,
+                preserved_cycles: 3,
+                blocks_per_cycle: 4096,
+                blocks_per_commitment: 32,
+                blocks_per_voting_period: 20480,
+                hard_gas_limit_per_operation: new BigNumber(1040000),
+                hard_gas_limit_per_block: new BigNumber(5200000),
+                proof_of_work_threshold: new BigNumber(70368744177663),
+                tokens_per_roll: new BigNumber(6000000000),
+                seed_nonce_revelation_tip: new BigNumber(125000),
+                origination_size: 257,
+                cost_per_byte: new BigNumber(250),
+                hard_storage_limit_per_operation: new BigNumber(60000),
+                quorum_min: 2000,
+                quorum_max: 7000,
+                min_proposal_quorum: 500,
+                liquidity_baking_subsidy: new BigNumber(2500000),
+                liquidity_baking_sunset_level: 10000000,
+                liquidity_baking_escape_ema_threshold: 666667,
+                max_allowed_global_constants_depth: 10000,
+                max_micheline_bytes_limit: 50000,
+                max_micheline_node_count: 50000,
+                michelson_maximum_type_size: 2001,
+                cache_layout: [new BigNumber(100000000), new BigNumber(240000), new BigNumber(2560)],
+                blocks_per_stake_snapshot: 256,
+                baking_reward_fixed_portion: new BigNumber(5000000),
+                baking_reward_bonus_per_slot: new BigNumber(2143),
+                endorsing_reward_per_slot: new BigNumber(1428),
+                max_operations_time_to_live: 120,
+                consensus_committee_size: 7000,
+                consensus_threshold: 4667,
+                minimal_participation_ratio: {
+                    denominator: 3,
+                    numerator: 2,
+                },
+                max_slashing_period: 2,
+                frozen_deposits_percentage: 10,
+                double_baking_punishment: new BigNumber(640000000),
+                ratio_of_frozen_deposits_slashed_per_double_endorsement: {
+                    denominator: 2,
+                    numerator: 1,
+                },
+                minimal_block_delay: new BigNumber(15),
+                delay_increment_per_round: new BigNumber(5)
+            });
+
+            done();
+        })
+
         jakartanet(`succesfully fetches all constants for jakartanet using ${rpc}`, async (done) => {
             Tezos.setRpcProvider(rpc);
             const constants: ConstantsResponseProto013 & ConstantsResponseCommon = await Tezos.rpc.getConstants();
@@ -537,7 +596,7 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
             done();
         })
 
-        ithacanet(`succesfully fetches all constants for ithacanet using ${rpc}`, async (done) => {
+        mondaynet(`succesfully fetches all constants for mondaynet using ${rpc}`, async (done) => {
             Tezos.setRpcProvider(rpc);
             const constants: ConstantsResponseProto012 & ConstantsResponseCommon = await Tezos.rpc.getConstants();
 
@@ -548,13 +607,12 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
                 max_operation_data_length: 32768,
                 max_proposals_per_delegate: 20,
                 preserved_cycles: 3,
-                blocks_per_cycle: 4096,
-                blocks_per_commitment: 32,
-                blocks_per_voting_period: 20480,
+                blocks_per_cycle: 128,
+                blocks_per_commitment: 16,
                 hard_gas_limit_per_operation: new BigNumber(1040000),
                 hard_gas_limit_per_block: new BigNumber(5200000),
-                proof_of_work_threshold: new BigNumber(70368744177663),
-                tokens_per_roll: new BigNumber(6000000000),
+                proof_of_work_threshold: new BigNumber(-1),
+                tokens_per_roll: new BigNumber(8000000000),
                 seed_nonce_revelation_tip: new BigNumber(125000),
                 origination_size: 257,
                 cost_per_byte: new BigNumber(250),
@@ -564,16 +622,15 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
                 min_proposal_quorum: 500,
                 liquidity_baking_subsidy: new BigNumber(2500000),
                 liquidity_baking_sunset_level: 10000000,
-                liquidity_baking_escape_ema_threshold: 666667,
+                liquidity_baking_toggle_ema_threshold: 100000,
                 max_allowed_global_constants_depth: 10000,
                 max_micheline_bytes_limit: 50000,
                 max_micheline_node_count: 50000,
                 michelson_maximum_type_size: 2001,
-                cache_layout: [new BigNumber(100000000), new BigNumber(240000), new BigNumber(2560)],
-                blocks_per_stake_snapshot: 256,
-                baking_reward_fixed_portion: new BigNumber(5000000),
-                baking_reward_bonus_per_slot: new BigNumber(2143),
-                endorsing_reward_per_slot: new BigNumber(1428),
+                blocks_per_stake_snapshot: 64,
+                baking_reward_fixed_portion: new BigNumber(10000000),
+                baking_reward_bonus_per_slot: new BigNumber(4286),
+                endorsing_reward_per_slot: new BigNumber(2857),
                 max_operations_time_to_live: 120,
                 consensus_committee_size: 7000,
                 consensus_threshold: 4667,
@@ -589,7 +646,43 @@ CONFIGS().forEach(({ lib, protocol, rpc }) => {
                     numerator: 1,
                 },
                 minimal_block_delay: new BigNumber(15),
-                delay_increment_per_round: new BigNumber(5)
+                delay_increment_per_round: new BigNumber(15),
+                dal_parametric: {
+                    availability_threshold: 50,
+                    endorsement_lag: 2,
+                    feature_enable: false,
+                    number_of_shards: 2048,
+                    number_of_slots: 256,
+                    },
+                cache_layout_size: 3,
+                cache_sampler_state_cycles: 8,
+                cache_script_size: 100000000,
+                cache_stake_distribution_cycles: 8,
+                cycles_per_voting_period: 1,
+                sc_rollup_challenge_window_in_blocks: 20160,
+                sc_rollup_enable: false,
+                sc_rollup_max_available_messages: 1000000,
+                sc_rollup_origination_size: 6314,
+                sc_rollup_commitment_period_in_blocks: 30,
+                sc_rollup_max_active_outbox_levels: 20160,
+                sc_rollup_max_lookahead_in_blocks: 30000,
+                sc_rollup_max_outbox_messages_per_level: 100,
+                sc_rollup_stake_amount: "32000000",
+                tx_rollup_commitment_bond: new BigNumber(10000000000),
+                tx_rollup_cost_per_byte_ema_factor: 120,
+                tx_rollup_enable: true,
+                tx_rollup_finality_period: 10,
+                tx_rollup_hard_size_limit_per_inbox: 500000,
+                tx_rollup_hard_size_limit_per_message: 5000,
+                tx_rollup_max_commitments_count: 30,
+                tx_rollup_max_inboxes_count: 15,
+                tx_rollup_max_messages_per_inbox: 1010,
+                tx_rollup_max_ticket_payload_size: 2048,
+                tx_rollup_max_withdrawals_per_batch: 15,
+                tx_rollup_origination_size: 4000,
+                tx_rollup_rejection_max_proof_size: 30000,
+                tx_rollup_sunset_level: 17280,
+                tx_rollup_withdraw_period: 10,
             });
 
             done();


### PR DESCRIPTION
added a test that
successfully fetches all constants for mondaynet using ${rpc}

we need this to know as soon as possible when new rpc endpoints are added or default values changed.