### PR TITLE
[ci] Send Slack notification for Mondaynet integration tests result

### DIFF
--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -57,10 +57,25 @@ jobs:
       env:
         MONDAYNET: true
       run: npm run test:originate-known-contracts
-    -
+    # -
+    #   if: always()
+    #   id: integration-tests-mondaynet
+    #   working-directory: ./integration-tests
+    #   env:
+    #     TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
+    #     TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
+    #     TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
+    #     TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
+    #   run: npm run test:mondaynet -- --maxWorkers=2
+    - 
+      name: Slack Notification
       if: always()
-      id: integration-tests-mondaynet
-      working-directory: ./integration-tests
+      uses: ravsamhq/notify-slack-action@v1
+      with:
+        status: ${{ job.status }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        notification_title: "Taquito Mondaynet Integration Tests ${{job.status}}"
+        message_format: "{emoji} *{workflow}* {status_message} on <{commit_url}|{commit_sha}> | <{run_url}|View Run>"
       env:
         TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
         TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}

--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -57,16 +57,16 @@ jobs:
       env:
         MONDAYNET: true
       run: npm run test:originate-known-contracts
-    # -
-    #   if: always()
-    #   id: integration-tests-mondaynet
-    #   working-directory: ./integration-tests
-    #   env:
-    #     TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
-    #     TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
-    #     TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
-    #     TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
-    #   run: npm run test:mondaynet -- --maxWorkers=2
+    -
+      if: always()
+      id: integration-tests-mondaynet
+      working-directory: ./integration-tests
+      env:
+        TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
+        TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
+        TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
+        TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
+      run: npm run test:mondaynet -- --maxWorkers=2
     - 
       name: Slack Notification
       if: always()

--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -66,6 +66,10 @@ jobs:
         TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
         TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
         TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
+        TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT: ${{ steps.originate-contracts-mondaynet.outputs.knownOnChainViewContractAddress }}
+        TX_ROLLUP_WITHDRAW_CONTRACT: ${{ steps.toru-addresses.outputs.tx-rollup-withdraw-contract }}
+        TX_ROLLUP_DEPOSIT_CONTRACT: ${{ steps.toru-addresses.outputs.tx-rollup-deposit-contract }}
+        TX_ROLLUP_TICKETS_OWNER_SECRET: ${{ secrets.TX_ROLLUP_TICKETS_OWNER_SECRET }}
       run: npm run test:mondaynet -- --maxWorkers=2
     - 
       name: Slack Notification
@@ -77,12 +81,4 @@ jobs:
         notification_title: "Taquito Mondaynet Integration Tests ${{job.status}}"
         message_format: "{emoji} *{workflow}* {status_message} on <{commit_url}|{commit_sha}> | <{run_url}|View Run>"
       env:
-        TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
-        TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
-        TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
-        TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
-        TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT: ${{ steps.originate-contracts-mondaynet.outputs.knownOnChainViewContractAddress }}
-        TX_ROLLUP_WITHDRAW_CONTRACT: ${{ steps.toru-addresses.outputs.tx-rollup-withdraw-contract }}
-        TX_ROLLUP_DEPOSIT_CONTRACT: ${{ steps.toru-addresses.outputs.tx-rollup-deposit-contract }}
-        TX_ROLLUP_TICKETS_OWNER_SECRET: ${{ secrets.TX_ROLLUP_TICKETS_OWNER_SECRET }}
-      run: npm run test:mondaynet -- --maxWorkers=2
+        SLACK_WEBHOOK_URL: ${{ secrets.INTEGRATION_TESTS_SLACK_WEBHOOK }}


### PR DESCRIPTION
Send a slack notification to the `taquito_integration_tests` Slack channel with the result of the scheduled integration test ran against Mondaynet network and Tezedge nodes on Ithacanet

## Test Plan
Triggered the workflow and confirmed we are receiving the Slack notification
![Screenshot from 2022-06-23 15-44-27](https://user-images.githubusercontent.com/22307776/175314751-bff77f4f-c6f1-4439-90bf-7512b97dda82.png)
 