### PR TITLE
[WIP] 1662 update unit tests for rollup operations

### DIFF
--- a/packages/taquito-rpc/test/data/rpc-responses.ts
+++ b/packages/taquito-rpc/test/data/rpc-responses.ts
@@ -4157,6 +4157,38 @@ export const blockJakartanetSample = {
               },
             ],
           },
+          {
+            kind: 'tx_rollup_remove_commitment',
+            source: 'tz1M1PXyMAhAsXroc6DtuWUUeHvb79ZzCnCp',
+            fee: '574',
+            counter: '252310',
+            gas_limit: '3272',
+            storage_limit: '0',
+            rollup: 'txr1YMZxstAHqQ9V313sYjLBCHBXsvSmDZuTs',
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz1M1PXyMAhAsXroc6DtuWUUeHvb79ZzCnCp',
+                  change: '-574',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '574',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                balance_updates: [],
+                consumed_gas: '3172',
+                consumed_milligas: '3171088',
+                level: 0,
+              },
+            },
+          },
         ],
         signature:
           'sigmpiJiuk1wbno2KAvxFufUkZ4JnrTuuxmVWmGVP3bPKNft8Nv8LZwkKAKtvUeBSiBEMxa5vAxcKc5FddwZvhjuZyydZeKD',

--- a/packages/taquito-rpc/test/data/rpc-responses.ts
+++ b/packages/taquito-rpc/test/data/rpc-responses.ts
@@ -4131,6 +4131,32 @@ export const blockJakartanetSample = {
               },
             },
           },
+          {
+            kind: 'tx_rollup_dispatch_tickets',
+            source: 'tz1inuxjXxKhd9e4b97N1Wgz7DwmZSxFcDpM',
+            fee: '835',
+            counter: '252405',
+            gas_limit: '4354',
+            storage_limit: '86',
+            tx_rollup: 'txr1YMZxstAHqQ9V313sYjLBCHBXsvSmDZuTs',
+            level: 4,
+            context_hash: 'CoV7iqRirVx7sZa5TAK9ymoEJBrW6z4hwwrzMhz6YLeHYXrQwRWG',
+            message_index: 0,
+            message_result_path: ['txM2eYt63gJ98tv3z4nj3aWPMzpjLnW9xpUdmz4ftMnbvNG34Y4wB'],
+            tickets_info: [
+              {
+                contents: {
+                  string: 'third-deposit',
+                },
+                ty: {
+                  prim: 'string',
+                },
+                ticketer: 'KT1EMQxfYVvhTJTqMiVs2ho2dqjbYfYKk6BY',
+                amount: '2',
+                claimer: 'tz1inuxjXxKhd9e4b97N1Wgz7DwmZSxFcDpM',
+              },
+            ],
+          },
         ],
         signature:
           'sigmpiJiuk1wbno2KAvxFufUkZ4JnrTuuxmVWmGVP3bPKNft8Nv8LZwkKAKtvUeBSiBEMxa5vAxcKc5FddwZvhjuZyydZeKD',

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -17,6 +17,9 @@ import {
   OperationContentsAndResultTxRollupSubmitBatch,
   OperationContentsAndResultTxRollupCommit,
   OperationContentsAndResultTxRollupFinalizeCommitment,
+  OperationContentsAndResultTxRollupDispatchTickets,
+  MichelsonV1ExpressionBase,
+  MichelsonV1ExpressionExtended,
 } from '../src/types';
 import {
   blockIthacanetSample,
@@ -2583,6 +2586,41 @@ describe('RpcClient test', () => {
       expect(content.metadata.operation_result.consumed_gas).toEqual('2502');
       expect(content.metadata.operation_result.consumed_milligas).toEqual('2501420');
       expect(content.metadata.operation_result.level).toEqual(0);
+      done();
+    });
+
+    it('should access the properties of the operation type tx_rollup_dispatch_tickets, proto13', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+
+      const response = await client.getBlock();
+      const content = response.operations[3][0]
+        .contents[4] as OperationContentsAndResultTxRollupDispatchTickets;
+
+      expect(content.kind).toEqual(OpKind.TX_ROLLUP_DISPATCH_TICKETS);
+      expect(content.source).toEqual('tz1inuxjXxKhd9e4b97N1Wgz7DwmZSxFcDpM');
+      expect(content.fee).toEqual('835');
+      expect(content.counter).toEqual('252405');
+      expect(content.gas_limit).toEqual('4354');
+      expect(content.storage_limit).toEqual('86');
+      expect(content.tx_rollup).toEqual('txr1YMZxstAHqQ9V313sYjLBCHBXsvSmDZuTs');
+      expect(content.level).toEqual(4);
+      expect(content.context_hash).toEqual('CoV7iqRirVx7sZa5TAK9ymoEJBrW6z4hwwrzMhz6YLeHYXrQwRWG');
+      expect(content.message_index).toEqual(0);
+      expect(content.message_result_path).toBeDefined();
+      expect(content.message_result_path![0]).toEqual(
+        'txM2eYt63gJ98tv3z4nj3aWPMzpjLnW9xpUdmz4ftMnbvNG34Y4wB'
+      );
+
+      expect(content.tickets_info).toBeDefined();
+
+      expect((content.tickets_info![0].contents as MichelsonV1ExpressionBase).string).toEqual(
+        'third-deposit'
+      );
+      expect((content.tickets_info![0].ty as MichelsonV1ExpressionExtended).prim).toEqual('string');
+      expect(content.tickets_info![0].ticketer).toEqual('KT1EMQxfYVvhTJTqMiVs2ho2dqjbYfYKk6BY');
+      expect(content.tickets_info![0].amount).toEqual('2');
+      expect(content.tickets_info![0].claimer).toEqual('tz1inuxjXxKhd9e4b97N1Wgz7DwmZSxFcDpM');
+
       done();
     });
   });

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -20,6 +20,7 @@ import {
   OperationContentsAndResultTxRollupDispatchTickets,
   MichelsonV1ExpressionBase,
   MichelsonV1ExpressionExtended,
+  OperationContentsAndResultTxRollupRemoveCommitment,
 } from '../src/types';
 import {
   blockIthacanetSample,
@@ -2621,6 +2622,41 @@ describe('RpcClient test', () => {
       expect(content.tickets_info![0].amount).toEqual('2');
       expect(content.tickets_info![0].claimer).toEqual('tz1inuxjXxKhd9e4b97N1Wgz7DwmZSxFcDpM');
 
+      done();
+    });
+
+    it('should access the properties of the operation type tx_rollup_remove_commitment, proto13', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+
+      const response = await client.getBlock();
+      const content = response.operations[3][0]
+        .contents[5] as OperationContentsAndResultTxRollupRemoveCommitment;
+
+      expect(content.kind).toEqual(OpKind.TX_ROLLUP_REMOVE_COMMITMENT);
+      expect(content.source).toEqual('tz1M1PXyMAhAsXroc6DtuWUUeHvb79ZzCnCp');
+      expect(content.fee).toEqual('574');
+      expect(content.counter).toEqual('252310');
+      expect(content.gas_limit).toEqual('3272');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('txr1YMZxstAHqQ9V313sYjLBCHBXsvSmDZuTs');
+
+      expect(content.metadata.balance_updates).toBeDefined();
+
+      expect(content.metadata.balance_updates![0].kind).toEqual('contract');
+      expect(content.metadata.balance_updates![0].contract).toEqual(
+        'tz1M1PXyMAhAsXroc6DtuWUUeHvb79ZzCnCp'
+      );
+
+      expect(content.metadata.balance_updates![1].kind).toEqual('accumulator');
+      expect(content.metadata.balance_updates![1].category).toEqual('block fees');
+      expect(content.metadata.balance_updates![1].change).toEqual('574');
+      expect(content.metadata.balance_updates![1].origin).toEqual('block');
+
+      expect(content.metadata.operation_result.status).toEqual('applied');
+      expect(content.metadata.operation_result.balance_updates).toBeDefined();
+      expect(content.metadata.operation_result.consumed_gas).toEqual('3172');
+      expect(content.metadata.operation_result.consumed_milligas).toEqual('3171088');
+      expect(content.metadata.operation_result.level).toEqual(0);
       done();
     });
   });


### PR DESCRIPTION
added unit tests for tx_rollup_dispatch_tickets and tx_rollup_remove_commitment
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
