### PR TITLE
Remove unnecessary gas fee offset from integration test

### DIFF
--- a/integration-tests/contract-empty-implicit-account-into-new-implicit-account.spec.ts
+++ b/integration-tests/contract-empty-implicit-account-into-new-implicit-account.spec.ts
@@ -1,14 +1,19 @@
+import { Protocols } from "@taquito/taquito";
 import { CONFIGS } from "./config";
 
-CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
+CONFIGS().forEach(({ lib, rpc, setup, createAddress, protocol }) => {
     const Tezos = lib;
+    const jakartanet = (protocol === Protocols.PtJakart2) ? test : test.skip;
+    const kathmandunet = (protocol === Protocols.PtKathman) ? test : test.skip;
+
     describe(`Test emptying a revealed implicit account into a new implicit account using: ${rpc}`, () => {
 
         beforeEach(async (done) => {
             await setup()
             done()
         })
-        it('reveals the sender account, creates an unrevealed implicit account, empties the sender account into the created one', async (done) => {
+
+        jakartanet('on J protocol, reveals the sender account, creates an unrevealed implicit account, empties the sender account into the created one', async (done) => {
             const receiver = await createAddress();
             const receiver_pkh = await receiver.signer.publicKeyHash();
 
@@ -47,6 +52,49 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
                  amount: maxAmount - increasedFee(gasBuffer, Number(estimate.opSize)),
                  fee: estimate.suggestedFeeMutez + increasedFee(gasBuffer, Number(estimate.opSize)), // baker fees
                  gasLimit: estimate.gasLimit + gasBuffer,
+                 storageLimit: estimate.storageLimit 
+             });
+
+             await opTransfer.confirmation();
+             const finalBalance = await Tezos.tz.getBalance(sender_pkh);
+
+             expect(finalBalance.toString()).toEqual("0")
+
+            done();
+        });
+
+        kathmandunet('on K protocol, reveals the sender account, creates an unrevealed implicit account, empties the sender account into the created one', async (done) => {
+            const receiver = await createAddress();
+            const receiver_pkh = await receiver.signer.publicKeyHash();
+
+            // create and fund the account we want to empty
+            const sender = await createAddress();
+            const sender_pkh = await sender.signer.publicKeyHash();
+            const op = await Tezos.contract.transfer({ to: sender_pkh, amount: 1 });
+            await op.confirmation();
+            
+            // Sending 1 token from the account we want to empty
+            // This will do the reveal operation automatically
+            const op2 = await sender.contract.transfer({ to: await Tezos.signer.publicKeyHash(), amount: 0.1 });
+            await op2.confirmation();
+
+            const balance = await Tezos.tz.getBalance(sender_pkh);
+
+            const estimate = await sender.estimate.transfer({
+                to: receiver_pkh,
+                amount: 0.5,
+            });
+
+            // // Emptying the account
+            const totalFees = estimate.suggestedFeeMutez + estimate.burnFeeMutez;
+            const maxAmount = balance.minus(totalFees).toNumber();
+        
+            const opTransfer = await sender.contract.transfer({
+                 to: receiver_pkh,
+                 mutez: true,
+                 amount: maxAmount, 
+                 fee: estimate.suggestedFeeMutez, 
+                 gasLimit: estimate.gasLimit, 
                  storageLimit: estimate.storageLimit 
              });
 

--- a/integration-tests/contract-estimation-tests.spec.ts
+++ b/integration-tests/contract-estimation-tests.spec.ts
@@ -180,7 +180,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol, rpc }) => 
       expect(estimate.minimalFeeMutez).toEqual(651);
       expect(estimate.totalCost).toEqual(651);
       expect(estimate.usingBaseFeeMutez).toEqual(651);
-      expect(estimate.consumedMilligas).toEqual(3149456);
+      expect(estimate.consumedMilligas).toEqual(3149542);
       done();
     })
 
@@ -216,7 +216,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol, rpc }) => 
       expect(estimate.minimalFeeMutez).toEqual(811);
       expect(estimate.totalCost).toEqual(129311);
       expect(estimate.usingBaseFeeMutez).toEqual(811);
-      expect(estimate.consumedMilligas).toEqual(4157632);
+      expect(estimate.consumedMilligas).toEqual(4157718);
       done();
     })
 
@@ -244,7 +244,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol, rpc }) => 
       expect(estimate.minimalFeeMutez).toEqual(698);
       expect(estimate.totalCost).toEqual(79948);
       expect(estimate.usingBaseFeeMutez).toEqual(698);
-      expect(estimate.consumedMilligas).toEqual(3557245);
+      expect(estimate.consumedMilligas).toEqual(3557331);
       done();
     })
 
@@ -275,7 +275,7 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, protocol, rpc }) => 
       expect(estimate.minimalFeeMutez).toEqual(905);
       expect(estimate.totalCost).toEqual(159405);
       expect(estimate.usingBaseFeeMutez).toEqual(905);
-      expect(estimate.consumedMilligas).toEqual(4973210);
+      expect(estimate.consumedMilligas).toEqual(4973296);
       // Do the actual operation
       const op2 = await contract.methods.do(originate2()).send();
       await op2.confirmation();


### PR DESCRIPTION
Close #1771 

This is a redo of this issue as the previous PR ran into too many rebase conflicts.

updates the tet for K by removing the now unneeded gas fee offset from the implicit account draining operation