### PR TITLE
[ci] Fix pipeline failures with integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
 
   integration-tests:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         protocol:


### PR DESCRIPTION
Taquito integration test pipeline cancels the entire job if one of the job fails. This shouldn't happen since the 2 testnets should test separately
![Screenshot from 2022-08-09 22-29-28](https://user-images.githubusercontent.com/22307776/183755314-5ae37e16-498a-4caf-be0c-666a45cf82dc.png)

This PR fixes this behaviour
![Screenshot from 2022-08-09 22-28-42](https://user-images.githubusercontent.com/22307776/183755896-0ba1dddb-f81c-4595-8537-5c0bf5a2b4e8.png)
