### PR TITLE
refactor(read-adapter): remove the context from the constructor

### DIFF
--- a/docs/sapling.md
+++ b/docs/sapling.md
@@ -137,7 +137,7 @@ import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
-// Note you need to set up your signer on the TezosToolkit as usual
+// Note: you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -191,7 +191,7 @@ import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
-// Note you need to set up your signer on the TezosToolkit as usual
+// Note: you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -233,7 +233,7 @@ import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
-// Note you need to set up your signer on the TezosToolkit as usual
+// Note: you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -273,7 +273,7 @@ import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
-// Note you need to set up your signer on the TezosToolkit as usual
+// Note: you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/docs/sapling.md
+++ b/docs/sapling.md
@@ -43,10 +43,12 @@ The constructor of the `SaplingToolkit` takes the following properties:
 Here is an example of how to instantiate a `SaplingToolkit`:
 
 ```ts
-import { TezosToolkit } from '@taquito/taquito';
+import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
+import { RpcClient } from '@taquito/rpc';
 
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
+const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -54,7 +56,7 @@ const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONI
 const saplingToolkit = new SaplingToolkit(
     inMemorySpendingKey, 
     { contractAddress: saplingContract.address, memoSize: 8 }, 
-    tezos.getFactory(RpcReadAdapter)()
+    readProvider
 )
 ```
 
@@ -129,11 +131,13 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
 ```ts
-import { TezosToolkit } from '@taquito/taquito';
+import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
+import { RpcClient } from '@taquito/rpc';
 
+const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
-// set up your signer on the TezosToolkit as usual
+// Note you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -141,7 +145,7 @@ const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONI
 const saplingToolkit = new SaplingToolkit(
     inMemorySpendingKey, 
     { contractAddress: saplingContract.address, memoSize: 8 }, 
-    tezos.getFactory(RpcReadAdapter)()
+    readProvider
 )
 
 // Fetch a payment address (zet)
@@ -181,10 +185,13 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
 ```ts
-import { TezosToolkit } from '@taquito/taquito';
+import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
+import { RpcClient } from '@taquito/rpc';
 
+const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
+// Note you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -192,7 +199,7 @@ const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONI
 const saplingToolkit = new SaplingToolkit(
     inMemorySpendingKey, 
     { contractAddress: saplingContract.address, memoSize: 8 }, 
-    tezos.getFactory(RpcReadAdapter)()
+    readProvider
 )
 
 const shieldedTx = await saplingToolkit.prepareSaplingTransaction([{
@@ -220,10 +227,13 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
 ```ts
-import { TezosToolkit } from '@taquito/taquito';
+import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
+import { RpcClient } from '@taquito/rpc';
 
+const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
+// Note you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
@@ -231,7 +241,7 @@ const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONI
 const saplingToolkit = new SaplingToolkit(
     inMemorySpendingKey, 
     { contractAddress: saplingContract.address, memoSize: 8 }, 
-    tezos.getFactory(RpcReadAdapter)()
+    readProvider
 )
 
 const shieldedTx = await saplingToolkit.prepareUnshieldedTransaction({
@@ -257,10 +267,13 @@ The constructor of the `SaplingTransactionViewer` takes the following properties
 Here is an example of how to instantiate a `SaplingTransactionViewer`:
 
 ```ts
-import { TezosToolkit } from '@taquito/taquito';
+import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { InMemoryViewingKey } from '@taquito/sapling';
+import { RpcClient } from '@taquito/rpc';
 
+const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
+// Note you need to set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemoryViewingKey = new InMemoryViewingKey(
@@ -270,7 +283,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 const saplingTransactionViewer = new SaplingTransactionViewer(
     inMemoryViewingKey, 
     { contractAddress: saplingContract.address }, 
-    tezos.getFactory(RpcReadAdapter)()
+    readProvider
 )
 ```
 

--- a/integration-tests/sapling-batched-transactions.spec.ts
+++ b/integration-tests/sapling-batched-transactions.spec.ts
@@ -48,14 +48,14 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const mnemonic1: string = bip39.generateMnemonic();
       inmemorySpendingKey1 = await InMemorySpendingKey.fromMnemonic(mnemonic1);
       inMemoryViewingKey1 = await inmemorySpendingKey1.getInMemoryViewingKey();
-      saplingToolkit1 = new SaplingToolkit(inmemorySpendingKey1, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)());
+      saplingToolkit1 = new SaplingToolkit(inmemorySpendingKey1, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer1 = await saplingToolkit1.getSaplingTransactionViewer();
       paymentAddress1Index0 = (await inMemoryViewingKey1.getAddress(0)).address;
 
       const mnemonic2: string = bip39.generateMnemonic();
       inmemorySpendingKey2 = await InMemorySpendingKey.fromMnemonic(mnemonic2);
       inMemoryViewingKey2 = await inmemorySpendingKey2.getInMemoryViewingKey();
-      saplingToolkit2 = new SaplingToolkit(inmemorySpendingKey2, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)());
+      saplingToolkit2 = new SaplingToolkit(inmemorySpendingKey2, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer2 = await saplingToolkit2.getSaplingTransactionViewer();
       paymentAddress2Index0 = (await inMemoryViewingKey2.getAddress(0)).address;
       paymentAddress2Index5 = (await inMemoryViewingKey2.getAddress(5)).address;
@@ -63,7 +63,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       inmemorySpendingKey3 = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
       inMemoryViewingKey3 = await inmemorySpendingKey3.getInMemoryViewingKey();
-      saplingToolkit3 = new SaplingToolkit(inmemorySpendingKey3, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)());
+      saplingToolkit3 = new SaplingToolkit(inmemorySpendingKey3, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer3 = await saplingToolkit3.getSaplingTransactionViewer();
       paymentAddress3Index0 = (await inMemoryViewingKey3.getAddress(0)).address;
       paymentAddress3Index5 = (await inMemoryViewingKey3.getAddress(5)).address;

--- a/integration-tests/sapling-transactions.spec.ts
+++ b/integration-tests/sapling-transactions.spec.ts
@@ -40,13 +40,13 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
     it('Verify that the initial balance for Alice and Bob are 0 in the sapling contract', async (done) => {
 
-      const bobSaplingToolkit = new SaplingToolkit(bobInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)())
+      const bobSaplingToolkit = new SaplingToolkit(bobInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
       const bobTxViewer = await bobSaplingToolkit.getSaplingTransactionViewer();
       const bobInitialBalance = await bobTxViewer.getBalance();
 
       expect(bobInitialBalance).toEqual(new BigNumber(0));
 
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)())
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceInitialBalance = await aliceTxViewer.getBalance();
 
@@ -58,7 +58,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Prepare and inject a shielded transaction of 3 tez for Alice', async (done) => {
 
       const amountToAlice = 3;
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)());
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       const aliceInMemoryViewingKey = await aliceInmemorySpendingKey.getInMemoryViewingKey();
       // Fetch a payment address (zet) for Alice
       alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress()).address;
@@ -78,7 +78,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it('Retrieve Alice updated balance in the sapling contract after the shielded tx', async (done) => {
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)())
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
@@ -106,7 +106,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const bobInMemoryViewingKey = await bobInmemorySpendingKey.getInMemoryViewingKey();
       bobPaymentAddress = (await bobInMemoryViewingKey.getAddress()).address;
 
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)());
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       const tx = await aliceSaplingToolkit.prepareSaplingTransaction([{
         to: bobPaymentAddress,
         amount: amountToBob,
@@ -121,7 +121,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it('Retrieve Alice and Bob updated balances in the sapling contract after the sapling tx', async (done) => {
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)())
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
@@ -159,7 +159,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
         ]
       })
 
-      const bobSaplingToolkit = new SaplingToolkit(bobInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)())
+      const bobSaplingToolkit = new SaplingToolkit(bobInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
       const bobTxViewer = await bobSaplingToolkit.getSaplingTransactionViewer();
       const bobBalance = await bobTxViewer.getBalance();
 
@@ -184,7 +184,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Prepare and inject an unshield transaction of 1 tez for Alice', async (done) => {
 
       const amount = 1;
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)());
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       const tezosInitialBalance = await Tezos.tz.getBalance(tezosAddress1);
 
       const unshieldedTx = await aliceSaplingToolkit.prepareUnshieldedTransaction({
@@ -203,7 +203,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it('Retrieve Alice updated balances in the sapling contract after the unshielded tx', async (done) => {
-      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, Tezos.getFactory(RpcReadAdapter)())
+      const aliceSaplingToolkit = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 

--- a/packages/taquito-sapling/src/taquito-sapling.ts
+++ b/packages/taquito-sapling/src/taquito-sapling.ts
@@ -44,6 +44,17 @@ export { InMemorySpendingKey } from './sapling-keys/in-memory-spending-key';
  * @param packer Optional. Allows packing data. Use the `MichelCodecPacker` by default.
  * @param saplingForger Optional. Allows serializing the sapling transactions. Use the `SaplingForger` by default.
  * @param saplingTxBuilder Optional. Allows to prepare the sapling transactions. Use the `SaplingTransactionBuilder` by default.
+ * @example
+ * ```
+ * const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
+ * const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'))
+ *
+ * const saplingToolkit = new SaplingToolkit(
+ *    inMemorySpendingKey,
+ *    { contractAddress: SAPLING_CONTRACT_ADDRESS, memoSize: 8 },
+ *    readProvider
+ * )
+ * ```
  */
 export class SaplingToolkit {
   #inMemorySpendingKey: InMemorySpendingKey;

--- a/packages/taquito-tzip16/test/viewKind/michelson-storage-view.spec.ts
+++ b/packages/taquito-tzip16/test/viewKind/michelson-storage-view.spec.ts
@@ -1,4 +1,4 @@
-import { Context, RpcReadAdapter } from '@taquito/taquito';
+import { RpcReadAdapter } from '@taquito/taquito';
 import { ForbiddenInstructionInViewCode, NoParameterExpectedError } from '../../src/tzip16-errors';
 import { MichelsonStorageView } from '../../src/viewKind/michelson-storage-view';
 
@@ -57,8 +57,7 @@ describe('MichelsonStorageView test', () => {
       args: [{ int: '7' }, { int: '38671' }],
     });
 
-    const context = new Context(mockRpcClient as any);
-    mockReadProvider = new RpcReadAdapter(context);
+    mockReadProvider = new RpcReadAdapter(mockRpcClient as any);
   });
 
   it('Should succesfully execute a view that get the balance of the contrat', async (done) => {

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -90,7 +90,7 @@ export class Context {
     this._globalConstantsProvider = globalConstantsProvider
       ? globalConstantsProvider
       : new NoopGlobalConstantsProvider();
-    this._readProvider = readProvider ? readProvider : new RpcReadAdapter(this);
+    this._readProvider = readProvider ? readProvider : new RpcReadAdapter(this._rpcClient);
     this._stream = stream ? stream : new PollingSubscribeProvider(this);
   }
 

--- a/packages/taquito/src/read-provider/rpc-read-adapter.ts
+++ b/packages/taquito/src/read-provider/rpc-read-adapter.ts
@@ -2,18 +2,18 @@ import {
   BlockResponse,
   EntrypointsResponse,
   MichelsonV1Expression,
+  RpcClientInterface,
   SaplingDiffResponse,
   ScriptedContracts,
 } from '@taquito/rpc';
 import BigNumber from 'bignumber.js';
-import { Context } from '../context';
 import { BigMapQuery, BlockIdentifier, SaplingStateQuery, TzReadProvider } from './interface';
 
 /**
  * @description Converts calls from TzReadProvider into calls to the wrapped RpcClient in a format it can understand.
  */
 export class RpcReadAdapter implements TzReadProvider {
-  constructor(private context: Context) {}
+  constructor(private rpc: RpcClientInterface) {}
 
   /**
    * @description Access the balance of a contract.
@@ -22,7 +22,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @returns the balance in mutez
    */
   async getBalance(address: string, block: BlockIdentifier): Promise<BigNumber> {
-    return this.context.rpc.getBalance(address, { block: String(block) });
+    return this.rpc.getBalance(address, { block: String(block) });
   }
 
   /**
@@ -32,7 +32,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @returns the public key hash of the delegate or null if no delegate
    */
   async getDelegate(address: string, block: BlockIdentifier): Promise<string | null> {
-    return this.context.rpc.getDelegate(address, { block: String(block) });
+    return this.rpc.getDelegate(address, { block: String(block) });
   }
 
   /**
@@ -40,7 +40,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param block from which we want to retrieve the next protocol hash
    */
   async getNextProtocol(block: BlockIdentifier): Promise<string> {
-    const protocols = await this.context.rpc.getProtocols({ block: String(block) });
+    const protocols = await this.rpc.getProtocols({ block: String(block) });
     return protocols.next_protocol;
   }
 
@@ -65,7 +65,7 @@ export class RpcReadAdapter implements TzReadProvider {
       hard_storage_limit_per_operation,
       cost_per_byte,
       tx_rollup_origination_size,
-    } = await this.context.rpc.getConstants({ block: String(block) });
+    } = await this.rpc.getConstants({ block: String(block) });
     return {
       time_between_blocks,
       minimal_block_delay,
@@ -84,7 +84,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @returns Note: The code must be in the JSON format and not contain global constant
    */
   async getScript(contract: string, block: BlockIdentifier): Promise<ScriptedContracts> {
-    const { script } = await this.context.rpc.getContract(contract, { block: String(block) });
+    const { script } = await this.rpc.getContract(contract, { block: String(block) });
     return script;
   }
 
@@ -94,14 +94,14 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param block from which we want to retrieve the storage value
    */
   async getStorage(contract: string, block: BlockIdentifier): Promise<MichelsonV1Expression> {
-    return this.context.rpc.getStorage(contract, { block: String(block) });
+    return this.rpc.getStorage(contract, { block: String(block) });
   }
 
   /**
    * @description Access the block hash
    */
   async getBlockHash(block: BlockIdentifier): Promise<string> {
-    const { hash } = await this.context.rpc.getBlockHeader({ block: String(block) });
+    const { hash } = await this.rpc.getBlockHeader({ block: String(block) });
     return hash;
   }
 
@@ -109,7 +109,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @description Access the block level
    */
   async getBlockLevel(block: BlockIdentifier): Promise<number> {
-    const { level } = await this.context.rpc.getBlockHeader({ block: String(block) });
+    const { level } = await this.rpc.getBlockHeader({ block: String(block) });
     return level;
   }
 
@@ -119,7 +119,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param block from which we want to retrieve the counter
    */
   async getCounter(pkh: string, block: BlockIdentifier): Promise<string> {
-    const { counter } = await this.context.rpc.getContract(pkh, { block: String(block) });
+    const { counter } = await this.rpc.getContract(pkh, { block: String(block) });
     return counter || '0';
   }
 
@@ -129,7 +129,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @returns date ISO format zero UTC offset ("2022-01-19T22:37:07Z")
    */
   async getBlockTimestamp(block: BlockIdentifier): Promise<string> {
-    const { timestamp } = await this.context.rpc.getBlockHeader({ block: String(block) });
+    const { timestamp } = await this.rpc.getBlockHeader({ block: String(block) });
     return timestamp;
   }
 
@@ -142,7 +142,7 @@ export class RpcReadAdapter implements TzReadProvider {
     bigMapQuery: BigMapQuery,
     block: BlockIdentifier
   ): Promise<MichelsonV1Expression> {
-    return this.context.rpc.getBigMapExpr(bigMapQuery.id, bigMapQuery.expr, {
+    return this.rpc.getBigMapExpr(bigMapQuery.id, bigMapQuery.expr, {
       block: String(block),
     });
   }
@@ -156,7 +156,7 @@ export class RpcReadAdapter implements TzReadProvider {
     saplingStateQuery: SaplingStateQuery,
     block: BlockIdentifier
   ): Promise<SaplingDiffResponse> {
-    return this.context.rpc.getSaplingDiffById(saplingStateQuery.id, { block: String(block) });
+    return this.rpc.getSaplingDiffById(saplingStateQuery.id, { block: String(block) });
   }
 
   /**
@@ -168,7 +168,7 @@ export class RpcReadAdapter implements TzReadProvider {
     contractAddress: string,
     block: BlockIdentifier
   ): Promise<SaplingDiffResponse> {
-    return this.context.rpc.getSaplingDiffByContract(contractAddress, { block: String(block) });
+    return this.rpc.getSaplingDiffByContract(contractAddress, { block: String(block) });
   }
 
   /**
@@ -176,14 +176,14 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param contract address of the contract we want to get the entrypoints of
    */
   async getEntrypoints(contract: string): Promise<EntrypointsResponse> {
-    return this.context.rpc.getEntrypoints(contract);
+    return this.rpc.getEntrypoints(contract);
   }
 
   /**
    * @description Access the chain id
    */
   async getChainId(): Promise<string> {
-    return this.context.rpc.getChainId();
+    return this.rpc.getChainId();
   }
 
   /**
@@ -192,7 +192,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param block from which we want to know if the account is revealed
    */
   async isAccountRevealed(publicKeyHash: string, block: BlockIdentifier): Promise<boolean> {
-    const manager = await this.context.rpc.getManagerKey(publicKeyHash, { block: String(block) });
+    const manager = await this.rpc.getManagerKey(publicKeyHash, { block: String(block) });
     const haveManager = manager && typeof manager === 'object' ? !!manager.key : !!manager;
     return haveManager;
   }
@@ -202,7 +202,7 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param block from which we want to retrieve the information
    */
   async getBlock(block: BlockIdentifier): Promise<BlockResponse> {
-    return this.context.rpc.getBlock({ block: String(block) });
+    return this.rpc.getBlock({ block: String(block) });
   }
 
   /**
@@ -210,6 +210,6 @@ export class RpcReadAdapter implements TzReadProvider {
    * @param block from which we want to retrieve the information
    */
   getLiveBlocks(block: BlockIdentifier): Promise<string[]> {
-    return this.context.rpc.getLiveBlocks({ block: String(block) });
+    return this.rpc.getLiveBlocks({ block: String(block) });
   }
 }

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -307,8 +307,7 @@ export class TezosToolkit {
    *
    */
   setReadProvider(readProvider?: SetProviderOptions['readProvider']) {
-    const readP =
-      typeof readProvider === 'undefined' ? new RpcReadAdapter(this._context.rpc) : readProvider;
+    const readP = readProvider? readProvider: new RpcReadAdapter(this._context.rpc);
     this._options.readProvider = readP;
     this._context.readProvider = readP;
   }

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -308,7 +308,7 @@ export class TezosToolkit {
    */
   setReadProvider(readProvider?: SetProviderOptions['readProvider']) {
     const readP =
-      typeof readProvider === 'undefined' ? this.getFactory(RpcReadAdapter)() : readProvider;
+      typeof readProvider === 'undefined' ? new RpcReadAdapter(this._context.rpc) : readProvider;
     this._options.readProvider = readP;
     this._context.readProvider = readP;
   }

--- a/packages/taquito/test/contract/contract-abstraction-composer.spec.ts
+++ b/packages/taquito/test/contract/contract-abstraction-composer.spec.ts
@@ -38,8 +38,7 @@ describe('Contract abstraction composer test', () => {
     });
     mockRpcClient.getChainId.mockResolvedValue('test');
 
-    toolkit = new TezosToolkit('url');
-    toolkit['_context'].rpc = mockRpcClient;
+    toolkit = new TezosToolkit(mockRpcClient);
   });
 
   it('Should add a helloWorld method on the contract abstraction', async (done) => {

--- a/packages/taquito/test/contract/contract-on-chain-view.spec.ts
+++ b/packages/taquito/test/contract/contract-on-chain-view.spec.ts
@@ -7,7 +7,6 @@ import {
   ViewSimulationError,
 } from '../../src/contract';
 import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
-import { Context } from '../../src/context';
 import { RpcReadAdapter } from '../../src/read-provider/rpc-read-adapter';
 
 describe('OnChainView test', () => {
@@ -34,8 +33,7 @@ describe('OnChainView test', () => {
     });
     mockRpcClient.getStorage.mockResolvedValue({ int: '3' });
 
-    const context = new Context(mockRpcClient as any);
-    mockReadProvider = new RpcReadAdapter(context);
+    mockReadProvider = new RpcReadAdapter(mockRpcClient as any);
 
     view = new OnChainView(
       mockRpcClient as any,

--- a/packages/taquito/test/contract/lambda-view-class.spec.ts
+++ b/packages/taquito/test/contract/lambda-view-class.spec.ts
@@ -18,8 +18,7 @@ describe('LambdaView test', () => {
     mockRpcClientView.getContract.mockResolvedValue({ script });
     mockRpcClientView.getChainId.mockResolvedValue('NetXjD3HPJJjmcd');
 
-    toolkitView = new TezosToolkit('url');
-    toolkitView['_context'].rpc = mockRpcClientView;
+    toolkitView = new TezosToolkit(mockRpcClientView);
 
     mockRpcClientLambda = {
       getContract: jest.fn(),
@@ -57,8 +56,7 @@ describe('LambdaView test', () => {
     mockRpcClientLambda.getChainId.mockResolvedValue('NetXjD3HPJJjmcd');
     mockRpcClientLambda.getEntrypoints.mockResolvedValue({ entrypoints: {} });
 
-    toolkitLambda = new TezosToolkit('url');
-    toolkitLambda['_context'].rpc = mockRpcClientLambda;
+    toolkitLambda = new TezosToolkit(mockRpcClientLambda);
   });
 
   it('LambdaView is instantiable with parameters', async (done) => {

--- a/packages/taquito/test/read-provider/rpc-read-adapter.spec.ts
+++ b/packages/taquito/test/read-provider/rpc-read-adapter.spec.ts
@@ -1,6 +1,5 @@
 import { RpcReadAdapter } from '../../src/read-provider/rpc-read-adapter';
 import BigNumber from 'bignumber.js';
-import { Context } from '../../src/context';
 import { BlockIdentifier } from '../../src/read-provider/interface';
 import {
   bigmapValue,
@@ -14,6 +13,7 @@ import {
   liveBlocks,
   saplingState,
 } from './data';
+import { RpcClient } from '@taquito/rpc';
 
 describe('RpcReadAdapter test', () => {
   let readProvider: RpcReadAdapter;
@@ -55,10 +55,10 @@ describe('RpcReadAdapter test', () => {
       getBlock: jest.fn(),
       getLiveBlocks: jest.fn(),
     };
-    readProvider = new RpcReadAdapter(new Context(mockRpcClient as any));
+    readProvider = new RpcReadAdapter(mockRpcClient as any);
   });
   it('should instantiate RpcReadAdapter', () => {
-    expect(new RpcReadAdapter(new Context('url'))).toBeInstanceOf(RpcReadAdapter);
+    expect(new RpcReadAdapter(new RpcClient('url'))).toBeInstanceOf(RpcReadAdapter);
   });
 
   // block identifiers in the various formats accepted by the RPC

--- a/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
+++ b/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
@@ -38,8 +38,7 @@ describe('Contract abstraction composer test', () => {
     });
     mockRpcClient.getChainId.mockResolvedValue('test');
 
-    toolkit = new TezosToolkit('url');
-    toolkit['_context'].rpc = mockRpcClient;
+    toolkit = new TezosToolkit(mockRpcClient);
   });
 
   it('Should add a helloWorld method on the contract abstraction', async (done) => {


### PR DESCRIPTION
Takes a rpcClient in the constructor instead of a context. Context is an internal class that should
not be available to the users.

BREAKING CHANGE: RpcReadAdapter needs a RpcClient in the constructor

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
