### PR TITLE
1762 map typecheck error bug

### DIFF
--- a/packages/taquito-michelson-encoder/src/schema/storage.ts
+++ b/packages/taquito-michelson-encoder/src/schema/storage.ts
@@ -147,7 +147,7 @@ export class Schema {
 
   Typecheck(val: any) {
     try {
-      this.root.TypecheckValue(val)
+      this.root.EncodeObject(val)
       return true;
     } catch (ex) {
       return false;

--- a/packages/taquito-michelson-encoder/src/schema/storage.ts
+++ b/packages/taquito-michelson-encoder/src/schema/storage.ts
@@ -3,6 +3,7 @@ import { BigMapToken } from '../tokens/bigmap';
 import { createToken } from '../tokens/createToken';
 import { OrToken } from '../tokens/or';
 import { PairToken } from '../tokens/pair';
+import { TicketToken } from '../tokens/ticket';
 import {
   BigMapKeyType,
   Semantic,
@@ -150,7 +151,7 @@ export class Schema {
       return true;
     }
     try {
-      this.root.EncodeObject(val);
+      this.root.TypecheckValue(val)
       return true;
     } catch (ex) {
       return false;

--- a/packages/taquito-michelson-encoder/src/schema/storage.ts
+++ b/packages/taquito-michelson-encoder/src/schema/storage.ts
@@ -146,9 +146,6 @@ export class Schema {
   }
 
   Typecheck(val: any) {
-    if (this.root instanceof BigMapToken && Number.isInteger(Number(val))) {
-      return true;
-    }
     try {
       this.root.TypecheckValue(val)
       return true;

--- a/packages/taquito-michelson-encoder/src/schema/storage.ts
+++ b/packages/taquito-michelson-encoder/src/schema/storage.ts
@@ -3,7 +3,6 @@ import { BigMapToken } from '../tokens/bigmap';
 import { createToken } from '../tokens/createToken';
 import { OrToken } from '../tokens/or';
 import { PairToken } from '../tokens/pair';
-import { TicketToken } from '../tokens/ticket';
 import {
   BigMapKeyType,
   Semantic,

--- a/packages/taquito-michelson-encoder/src/tokens/bigmap.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bigmap.ts
@@ -121,6 +121,13 @@ export class BigMapToken extends Token {
       });
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   public Execute(val: any[] | { int: string }, semantic?: Semantic) {
     if (semantic && semantic[BigMapToken.prim]) {
       return semantic[BigMapToken.prim](val as any, this.val);

--- a/packages/taquito-michelson-encoder/src/tokens/bigmap.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bigmap.ts
@@ -122,6 +122,9 @@ export class BigMapToken extends Token {
   }
 
   public TypecheckValue(val: unknown) {
+    if (this instanceof BigMapToken && Number.isInteger(Number(val))) {
+      return true;
+    }
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/bls12-381-fr.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bls12-381-fr.ts
@@ -1,3 +1,4 @@
+import { isValidHexDec } from '@taquito/utils';
 import { BaseTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
 
@@ -21,7 +22,7 @@ export class Bls12381frToken extends Token {
   }
 
   private isValid(val: any): Bls12381frValidationError | null {
-    if (/^[0-9a-fA-F]*$/.test(val) && val.length % 2 === 0) {
+    if (isValidHexDec(val)) {
       return null;
     } else {
       return new Bls12381frValidationError(val, this, `Invalid bytes: ${val}`);
@@ -62,10 +63,15 @@ export class Bls12381frToken extends Token {
     }
   }
 
-  public TypecheckValue(val: unknown) {
-    const err = this.isValid(val);
-    if (err) {
-      throw err;
+  public TypecheckValue(val: string | Uint8Array | number) {
+    if (typeof val === 'number') {
+      return { int: val.toString() };
+    } else {
+      val = this.convertUint8ArrayToHexString(val);
+      const err = this.isValid(val);
+      if (err) {
+        throw err;
+      }
     }
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/bls12-381-fr.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bls12-381-fr.ts
@@ -62,6 +62,13 @@ export class Bls12381frToken extends Token {
     }
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   Execute(val: any): string {
     return val.bytes;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/bls12-381-g1.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bls12-381-g1.ts
@@ -54,6 +54,13 @@ export class Bls12381g1Token extends Token {
     return { bytes: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   Execute(val: any): string {
     return val.bytes;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/bls12-381-g1.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bls12-381-g1.ts
@@ -1,3 +1,4 @@
+import { isValidHexDec } from '@taquito/utils';
 import { BaseTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
 
@@ -21,7 +22,7 @@ export class Bls12381g1Token extends Token {
   }
 
   private isValid(val: any): Bls12381g1ValidationError | null {
-    if (/^[0-9a-fA-F]*$/.test(val) && val.length % 2 === 0) {
+    if (isValidHexDec(val)) {
       return null;
     } else {
       return new Bls12381g1ValidationError(val, this, `Invalid bytes: ${val}`);
@@ -55,6 +56,7 @@ export class Bls12381g1Token extends Token {
   }
 
   public TypecheckValue(val: unknown) {
+    val = this.convertUint8ArrayToHexString(val);
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/bls12-381-g2.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bls12-381-g2.ts
@@ -1,3 +1,4 @@
+import { isValidHexDec } from '@taquito/utils';
 import { BaseTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
 
@@ -21,7 +22,7 @@ export class Bls12381g2Token extends Token {
   }
 
   private isValid(val: any): Bls12381g2ValidationError | null {
-    if (/^[0-9a-fA-F]*$/.test(val) && val.length % 2 === 0) {
+    if (isValidHexDec(val)) {
       return null;
     } else {
       return new Bls12381g2ValidationError(val, this, `Invalid bytes: ${val}`);
@@ -55,6 +56,7 @@ export class Bls12381g2Token extends Token {
   }
 
   public TypecheckValue(val: unknown) {
+    val = this.convertUint8ArrayToHexString(val);
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/bls12-381-g2.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/bls12-381-g2.ts
@@ -54,6 +54,13 @@ export class Bls12381g2Token extends Token {
     return { bytes: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   Execute(val: any): string {
     return val.bytes;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/chain-id.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/chain-id.ts
@@ -77,7 +77,7 @@ export class ChainIDToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/chain-id.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/chain-id.ts
@@ -77,6 +77,13 @@ export class ChainIDToken extends ComparableToken {
     return { string: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   public ToKey({ string }: any) {
     return string;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/chest-key.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/chest-key.ts
@@ -1,3 +1,4 @@
+import { isValidHexDec } from '@taquito/utils';
 import { BaseTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
 
@@ -19,7 +20,7 @@ export class ChestKeyToken extends Token {
   }
 
   private isValid(val: any): ChestKeyValidationError | null {
-    if (/^[0-9a-fA-F]*$/.test(val) && val.length % 2 === 0) {
+    if (isValidHexDec(val)) {
       return null;
     } else {
       return new ChestKeyValidationError(val, this, `Invalid bytes: ${val}`);
@@ -54,7 +55,8 @@ export class ChestKeyToken extends Token {
     return { bytes: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string | Uint8Array,) {
+    val = this.convertUint8ArrayToHexString(val);
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/chest-key.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/chest-key.ts
@@ -54,6 +54,13 @@ export class ChestKeyToken extends Token {
     return { bytes: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   Execute(val: any): string {
     return val.bytes;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/chest.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/chest.ts
@@ -54,6 +54,13 @@ export class ChestToken extends Token {
     return { bytes: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   Execute(val: any): string {
     return val.bytes;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/chest.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/chest.ts
@@ -1,3 +1,4 @@
+import { isValidHexDec } from '@taquito/utils';
 import { BaseTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
 
@@ -19,7 +20,7 @@ export class ChestToken extends Token {
   }
 
   private isValid(val: any): ChestValidationError | null {
-    if (/^[0-9a-fA-F]*$/.test(val) && val.length % 2 === 0) {
+    if (isValidHexDec(val)) {
       return null;
     } else {
       return new ChestValidationError(val, this, `Invalid bytes: ${val}`);
@@ -54,7 +55,8 @@ export class ChestToken extends Token {
     return { bytes: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string | Uint8Array,) {
+    val = this.convertUint8ArrayToHexString(val);
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
@@ -66,6 +66,13 @@ export class AddressToken extends ComparableToken {
     return { string: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   public Execute(val: { bytes: string; string: string }): string {
     if (val.string) {
       return val.string;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
@@ -66,7 +66,7 @@ export class AddressToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/bool.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/bool.ts
@@ -1,6 +1,13 @@
 import { BaseTokenSchema } from '../../schema/types';
-import { Token, TokenFactory, ComparableToken, SemanticEncoding } from '../token';
+import { Token, TokenFactory, ComparableToken, SemanticEncoding, TokenValidationError } from '../token';
 
+
+export class BoolValidationError extends TokenValidationError {
+  name = "BoolValidationError";
+  constructor(public value: unknown, public token: BoolToken, message: string) {
+    super(value, token, message);
+  }
+}
 export class BoolToken extends ComparableToken {
   static prim: 'bool' = 'bool';
 
@@ -28,8 +35,10 @@ export class BoolToken extends ComparableToken {
     return { prim: val ? 'True' : 'False' };
   }
 
-  public TypecheckValue(_arg?: unknown) {
-    return
+  public TypecheckValue(val: boolean) {
+    if (typeof val !== 'boolean') {
+      throw new BoolValidationError(val, this, `${val} is not a Boolean`)
+    }
   }
 
   /**

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/bool.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/bool.ts
@@ -28,6 +28,10 @@ export class BoolToken extends ComparableToken {
     return { prim: val ? 'True' : 'False' };
   }
 
+  public TypecheckValue(_arg: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/bool.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/bool.ts
@@ -28,7 +28,7 @@ export class BoolToken extends ComparableToken {
     return { prim: val ? 'True' : 'False' };
   }
 
-  public TypecheckValue(_arg: unknown) {
+  public TypecheckValue(_arg?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/bytes.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/bytes.ts
@@ -6,7 +6,7 @@ import {
   Token,
   SemanticEncoding,
 } from '../token';
-import { stripHexPrefix } from '@taquito/utils';
+import { isValidHexDec, stripHexPrefix } from '@taquito/utils';
 
 export class BytesValidationError extends TokenValidationError {
   name = 'BytesValidationError';
@@ -34,7 +34,7 @@ export class BytesToken extends ComparableToken {
   }
 
   private isValid(val: any): BytesValidationError | null {
-    if (typeof val === 'string' && /^[0-9a-fA-F]*$/.test(val) && val.length % 2 === 0) {
+    if (isValidHexDec(val)) {
       return null;
     } else {
       return new BytesValidationError(val, this, `Invalid bytes: ${val}`);
@@ -76,7 +76,7 @@ export class BytesToken extends ComparableToken {
     return { bytes: String(val).toString() };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/bytes.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/bytes.ts
@@ -76,6 +76,13 @@ export class BytesToken extends ComparableToken {
     return { bytes: String(val).toString() };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   public Execute(val: any): string {
     return val.bytes;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
@@ -78,7 +78,7 @@ export class IntToken extends ComparableToken {
     return { int: new BigNumber(val).toFixed() };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: BigNumber.Value) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
@@ -78,6 +78,13 @@ export class IntToken extends ComparableToken {
     return { int: new BigNumber(val).toFixed() };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   public ToBigMapKey(val: string | number) {
     return {
       key: { int: String(val) },

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/key_hash.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/key_hash.ts
@@ -66,6 +66,13 @@ export class KeyHashToken extends ComparableToken {
     return { string: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/key_hash.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/key_hash.ts
@@ -66,7 +66,7 @@ export class KeyHashToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
@@ -78,6 +78,13 @@ export class MutezToken extends ComparableToken {
     return { int: String(val).toString() };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   public ToBigMapKey(val: string | number) {
     return {
       key: { int: String(val) },

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
@@ -78,7 +78,7 @@ export class MutezToken extends ComparableToken {
     return { int: String(val).toString() };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: BigNumber.Value) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
@@ -47,6 +47,8 @@ export class NatToken extends ComparableToken {
       return new NatValidationError(val, this, `Value is not a number: ${val}`);
     } else if (bigNumber.isNegative()) {
       return new NatValidationError(val, this, `Value cannot be negative: ${val}`);
+    } else if(bigNumber.decimalPlaces() !== 0) {
+      return new NatValidationError(val, this, `Value must not have a float: ${val}`)
     } else {
       return null;
     }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
@@ -65,6 +65,13 @@ export class NatToken extends ComparableToken {
     return { int: new BigNumber(val).toFixed() };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
@@ -65,7 +65,7 @@ export class NatToken extends ComparableToken {
     return { int: new BigNumber(val).toFixed() };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: BigNumber.Value) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/string.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/string.ts
@@ -43,7 +43,7 @@ export class StringToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/string.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/string.ts
@@ -43,6 +43,10 @@ export class StringToken extends ComparableToken {
     return { string: val };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   public ToKey({ string }: any) {
     return string;
   }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/string.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/string.ts
@@ -43,7 +43,7 @@ export class StringToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(_val?: unknown) {
+  public TypecheckValue(_val?: string) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/timestamp.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/timestamp.ts
@@ -34,7 +34,7 @@ export class TimestampToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/timestamp.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/timestamp.ts
@@ -34,6 +34,10 @@ export class TimestampToken extends ComparableToken {
     return { string: val };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/timestamp.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/timestamp.ts
@@ -34,7 +34,7 @@ export class TimestampToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(_val?: unknown) {
+  public TypecheckValue(_val?: Date) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/tx_rollup_l2_address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/tx_rollup_l2_address.ts
@@ -56,7 +56,7 @@ export class TxRollupL2AddressToken extends ComparableToken {
     return { string: val }
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     this.isValid(val);
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/tx_rollup_l2_address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/tx_rollup_l2_address.ts
@@ -56,6 +56,10 @@ export class TxRollupL2AddressToken extends ComparableToken {
     return { string: val }
   }
 
+  public TypecheckValue(val: unknown) {
+    this.isValid(val);
+  }
+
   public Execute(val: {bytes?: string; string?: string}): string {
     if (val.string) {
       return val.string

--- a/packages/taquito-michelson-encoder/src/tokens/constant.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/constant.ts
@@ -57,7 +57,7 @@ export class GlobalConstantToken extends Token {
     );
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/constant.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/constant.ts
@@ -57,6 +57,10 @@ export class GlobalConstantToken extends Token {
     );
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/contract.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/contract.ts
@@ -61,6 +61,13 @@ export class ContractToken extends Token {
     return { string: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/contract.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/contract.ts
@@ -61,7 +61,7 @@ export class ContractToken extends Token {
     return { string: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/key.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/key.ts
@@ -75,7 +75,7 @@ export class KeyToken extends ComparableToken {
     return { string: val };
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: string) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/key.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/key.ts
@@ -75,6 +75,13 @@ export class KeyToken extends ComparableToken {
     return { string: val };
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/lambda.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/lambda.ts
@@ -40,6 +40,10 @@ export class LambdaToken extends Token {
     return val;
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/lambda.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/lambda.ts
@@ -40,7 +40,7 @@ export class LambdaToken extends Token {
     return val;
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/list.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/list.ts
@@ -75,6 +75,13 @@ export class ListToken extends Token {
     }, []);
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/list.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/list.ts
@@ -75,7 +75,7 @@ export class ListToken extends Token {
     }, []);
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: unknown[]) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/map.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/map.ts
@@ -107,7 +107,7 @@ export class MapToken extends Token {
       });
   }
 
-  public TypecheckValue(val: MichelsonMap<keyof MichelsonMapKey, unknown>) {
+  public TypecheckValue(val: MichelsonMap<MichelsonMapKey, unknown>) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/map.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/map.ts
@@ -107,6 +107,13 @@ export class MapToken extends Token {
       });
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/map.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/map.ts
@@ -1,4 +1,4 @@
-import { MichelsonMap } from '../michelson-map';
+import { MichelsonMap, MichelsonMapKey } from '../michelson-map';
 import { MapTokenSchema } from '../schema/types';
 import {
   ComparableToken,
@@ -107,7 +107,7 @@ export class MapToken extends Token {
       });
   }
 
-  public TypecheckValue(val: unknown) {
+  public TypecheckValue(val: MichelsonMap<keyof MichelsonMapKey, unknown>) {
     const err = this.isValid(val);
     if (err) {
       throw err;

--- a/packages/taquito-michelson-encoder/src/tokens/never.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/never.ts
@@ -28,7 +28,10 @@ export class NeverToken extends Token {
     throw new NeverTokenError(val, this, 'Assigning a value to the type never is forbidden.');
   }
 
-  public TypecheckValue(_val?: unknown) {
+  public TypecheckValue(val?: unknown) {
+    if (val !== null || val !== undefined) {
+      throw new NeverTokenError(val, this, 'Assigning a value to the type never is forbidden')
+    }
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/never.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/never.ts
@@ -27,6 +27,11 @@ export class NeverToken extends Token {
     }
     throw new NeverTokenError(val, this, 'Assigning a value to the type never is forbidden.');
   }
+
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   public Execute(val: any) {
     throw new NeverTokenError(val, this, 'There is no literal value for the type never.');
   }

--- a/packages/taquito-michelson-encoder/src/tokens/never.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/never.ts
@@ -28,7 +28,7 @@ export class NeverToken extends Token {
     throw new NeverTokenError(val, this, 'Assigning a value to the type never is forbidden.');
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/operation.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/operation.ts
@@ -28,7 +28,7 @@ export class OperationToken extends Token {
     return { string: val };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/operation.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/operation.ts
@@ -28,6 +28,10 @@ export class OperationToken extends Token {
     return { string: val };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/option.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/option.ts
@@ -51,6 +51,10 @@ export class OptionToken extends ComparableToken {
     return { prim: 'Some', args: [this.schema().EncodeObject(value, semantic)] };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   public Execute(val: any, semantics?: Semantic) {
     if (val.prim === 'None') {
       return null;

--- a/packages/taquito-michelson-encoder/src/tokens/option.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/option.ts
@@ -51,7 +51,7 @@ export class OptionToken extends ComparableToken {
     return { prim: 'Some', args: [this.schema().EncodeObject(value, semantic)] };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/or.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/or.ts
@@ -1,3 +1,4 @@
+import { FixedLengthArray } from '@taquito/utils';
 import { OrTokenSchema } from '../schema/types';
 import { Token, TokenFactory, Semantic, ComparableToken, SemanticEncoding } from './token';
 
@@ -121,7 +122,7 @@ export class OrToken extends ComparableToken {
     }
   }
 
-  public TypecheckValue(_val?: unknown) {
+  public TypecheckValue(_val?: FixedLengthArray<string, 2>) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/or.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/or.ts
@@ -121,7 +121,7 @@ export class OrToken extends ComparableToken {
     }
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/or.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/or.ts
@@ -121,6 +121,10 @@ export class OrToken extends ComparableToken {
     }
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   public Execute(val: any, semantics?: Semantic): any {
     const leftToken = this.createToken(this.val.args[0], this.idx);
     let keyCount = 1;

--- a/packages/taquito-michelson-encoder/src/tokens/pair.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/pair.ts
@@ -158,6 +158,10 @@ export class PairToken extends ComparableToken {
     };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   private traversal(getLeftValue: (token: Token) => any, getRightValue: (token: Token) => any) {
     const args = this.args();
 

--- a/packages/taquito-michelson-encoder/src/tokens/pair.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/pair.ts
@@ -2,6 +2,7 @@ import { Token, TokenFactory, Semantic, ComparableToken, SemanticEncoding } from
 import { OrToken } from './or';
 import { PairTokenSchema } from '../schema/types';
 import { MichelsonV1Expression, MichelsonV1ExpressionExtended } from '@taquito/rpc';
+import { FixedLengthArray } from '@taquito/utils';
 
 /**
  *  @category Error
@@ -158,7 +159,7 @@ export class PairToken extends ComparableToken {
     };
   }
 
-  public TypecheckValue(_val?: unknown) {
+  public TypecheckValue(_val?: FixedLengthArray<unknown, 2>) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/pair.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/pair.ts
@@ -158,7 +158,7 @@ export class PairToken extends ComparableToken {
     };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/sapling-state.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/sapling-state.ts
@@ -67,9 +67,7 @@ export class SaplingStateToken extends Token {
   }
 
   public TypecheckValue(val: unknown) {
-    if (this.isValid(val)) {
-      return [];
-    } else {
+    if (!this.isValid(val)) {
       throw new SaplingStateValidationError(
         val,
         this,

--- a/packages/taquito-michelson-encoder/src/tokens/sapling-state.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/sapling-state.ts
@@ -66,6 +66,18 @@ export class SaplingStateToken extends Token {
     }
   }
 
+  public TypecheckValue(val: unknown) {
+    if (this.isValid(val)) {
+      return [];
+    } else {
+      throw new SaplingStateValidationError(
+        val,
+        this,
+        `Invalid sapling_state. Received: ${val} while expecting: {}`
+      );
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/sapling-transaction-deprecated.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/sapling-transaction-deprecated.ts
@@ -54,7 +54,8 @@ export class SaplingTransactionDeprecatedToken extends Token {
     return { bytes: String(val).toString() };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(val: string | Uint8Array) {
+    this.validateBytes(this.convertUint8ArrayToHexString(val));
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/sapling-transaction-deprecated.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/sapling-transaction-deprecated.ts
@@ -54,6 +54,10 @@ export class SaplingTransactionDeprecatedToken extends Token {
     return { bytes: String(val).toString() };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/sapling-transaction.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/sapling-transaction.ts
@@ -54,6 +54,10 @@ export class SaplingTransactionToken extends Token {
     return { bytes: String(val).toString() };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/sapling-transaction.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/sapling-transaction.ts
@@ -54,7 +54,8 @@ export class SaplingTransactionToken extends Token {
     return { bytes: String(val).toString() };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(val: string | Uint8Array) {
+    this.validateBytes(this.convertUint8ArrayToHexString(val));
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/set.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/set.ts
@@ -76,6 +76,13 @@ export class SetToken extends Token {
       }, []);
   }
 
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
+  }
+
   /**
    * @deprecated ExtractSchema has been deprecated in favor of generateSchema
    *

--- a/packages/taquito-michelson-encoder/src/tokens/signature.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/signature.ts
@@ -56,8 +56,15 @@ export class SignatureToken extends ComparableToken {
     if (semantic && semantic[SignatureToken.prim]) {
       return semantic[SignatureToken.prim](val);
     }
-    
+
     return { string: val };
+  }
+
+  public TypecheckValue(val: unknown) {
+    const err = this.isValid(val);
+    if (err) {
+      throw err;
+    }
   }
 
   /**

--- a/packages/taquito-michelson-encoder/src/tokens/ticket.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/ticket.ts
@@ -41,7 +41,12 @@ export class TicketToken extends Token {
     if (semantic && semantic[TicketToken.prim]) {
       return semantic[TicketToken.prim](args, this.val);
     }
+
     throw new EncodeTicketError();
+  }
+
+  public TypecheckValue(_arg: unknown) {
+    return
   }
 
   public Execute(val: any, semantics?: Semantic) {

--- a/packages/taquito-michelson-encoder/src/tokens/ticket.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/ticket.ts
@@ -45,7 +45,7 @@ export class TicketToken extends Token {
     throw new EncodeTicketError();
   }
 
-  public TypecheckValue(_arg: unknown) {
+  public TypecheckValue(_arg?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/token.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/token.ts
@@ -103,7 +103,12 @@ export abstract class Token {
 
   public abstract EncodeObject(args: any, semantics?: SemanticEncoding): any;
 
-  public abstract TypecheckValue(arg: any): void;
+  /**
+   *
+   * @description checks the value of what is passed validating the same way as EncodeObject and throws error if necessary
+   * @param arg same as EncodeObject
+   */
+  public abstract TypecheckValue(arg: unknown): void;
 
   public ExtractSignature() {
     return [[this.ExtractSchema()]];

--- a/packages/taquito-michelson-encoder/src/tokens/token.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/token.ts
@@ -103,6 +103,8 @@ export abstract class Token {
 
   public abstract EncodeObject(args: any, semantics?: SemanticEncoding): any;
 
+  public abstract TypecheckValue(arg: any): void;
+
   public ExtractSignature() {
     return [[this.ExtractSchema()]];
   }

--- a/packages/taquito-michelson-encoder/src/tokens/token.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/token.ts
@@ -108,7 +108,7 @@ export abstract class Token {
    * @description checks the value of what is passed validating the same way as EncodeObject and throws error if necessary
    * @param arg same as EncodeObject
    */
-  public abstract TypecheckValue(arg: unknown): void;
+  public abstract TypecheckValue(arg?: unknown): void;
 
   public ExtractSignature() {
     return [[this.ExtractSchema()]];

--- a/packages/taquito-michelson-encoder/src/tokens/unit.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/unit.ts
@@ -25,7 +25,7 @@ export class UnitToken extends ComparableToken {
     return { prim: 'Unit' };
   }
 
-  public TypecheckValue(_val: unknown) {
+  public TypecheckValue(_val?: unknown) {
     return
   }
 

--- a/packages/taquito-michelson-encoder/src/tokens/unit.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/unit.ts
@@ -25,6 +25,10 @@ export class UnitToken extends ComparableToken {
     return { prim: 'Unit' };
   }
 
+  public TypecheckValue(_val: unknown) {
+    return
+  }
+
   public Execute(_val: { prim: string }) {
     return UnitValue;
   }

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -27,8 +27,9 @@ describe('Address token', () => {
 
     it('Should throw a validation error when address is not valid', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(AddressValidationError);
-      expect(() => token.TypecheckValue(0)).toThrowError(AddressValidationError);
-      expect(() => token.TypecheckValue([])).toThrowError(AddressValidationError);
+      // not accepted
+      expect(() => token.TypecheckValue(0 as any)).toThrowError(AddressValidationError);
+      expect(() => token.TypecheckValue([] as any)).toThrowError(AddressValidationError);
     });
   });
 
@@ -100,9 +101,10 @@ describe("Address Token with txr1", () => {
 
     it('should throw error with invalid args', () => {
       expect(() => token.TypecheckValue('txr1')).toThrowError(AddressValidationError)
-      expect(() => token.TypecheckValue([])).toThrowError(AddressValidationError)
-      expect(() => token.TypecheckValue({})).toThrowError(AddressValidationError)
-      expect(() => token.TypecheckValue(1)).toThrowError(AddressValidationError)
+      // values are unacceptable because of type change
+      // expect(() => token.TypecheckValue([])).toThrowError(AddressValidationError)
+      // expect(() => token.TypecheckValue({})).toThrowError(AddressValidationError)
+      // expect(() => token.TypecheckValue(1)).toThrowError(AddressValidationError)
       expect(() => token.TypecheckValue('tz4QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
     })
   })

--- a/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/address.spec.ts
@@ -20,6 +20,18 @@ describe('Address token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeUndefined();
+    });
+
+    it('Should throw a validation error when address is not valid', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(AddressValidationError);
+      expect(() => token.TypecheckValue(0)).toThrowError(AddressValidationError);
+      expect(() => token.TypecheckValue([])).toThrowError(AddressValidationError);
+    });
+  });
+
   describe('Encode', () => {
     it('Should encode address to string', () => {
       expect(token.Encode(['tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'])).toEqual({
@@ -79,6 +91,19 @@ describe("Address Token with txr1", () => {
       expect(() => token.EncodeObject({})).toThrowError(AddressValidationError)
       expect(() => token.EncodeObject(1)).toThrowError(AddressValidationError)
       expect(() => token.EncodeObject('tz4QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
+    })
+  })
+  describe("TypecheckValue", () => {
+    it("should return undefined", () => {
+      expect(token.TypecheckValue('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')).toBeUndefined();
+    });
+
+    it('should throw error with invalid args', () => {
+      expect(() => token.TypecheckValue('txr1')).toThrowError(AddressValidationError)
+      expect(() => token.TypecheckValue([])).toThrowError(AddressValidationError)
+      expect(() => token.TypecheckValue({})).toThrowError(AddressValidationError)
+      expect(() => token.TypecheckValue(1)).toThrowError(AddressValidationError)
+      expect(() => token.TypecheckValue('tz4QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toThrowError(AddressValidationError)
     })
   })
 

--- a/packages/taquito-michelson-encoder/test/tokens/bigmap.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bigmap.spec.ts
@@ -1,11 +1,14 @@
+
+import { MichelsonMap } from '../../src/michelson-map';
+import { BigMapToken, BigMapValidationError } from '../../src/tokens/bigmap';
 import { createToken } from '../../src/tokens/createToken';
 import { expectMichelsonMap } from '../utils';
 
 describe('BigMap', () => {
-  const bigMap = createToken({ prim: 'big_map', args: [{ prim: 'address' }, { prim: 'int' }] }, 0);
+  const bigMap = createToken({ prim: 'big_map', args: [{ prim: 'address' }, { prim: 'int' }] }, 0) as BigMapToken;
 
   it('Should use custom semantic when provided', () => {
-    const result = bigMap.Execute({ int: 1 } as any, { big_map: () => 'working' });
+    const result = bigMap.Execute({ int: '1' }, { big_map: () => 'working' });
     expect(result).toBe('working');
   });
 
@@ -15,8 +18,8 @@ describe('BigMap', () => {
   });
 
   it('Should use default semantic (return id) when omitted', () => {
-    const result = bigMap.Execute({ int: 12 } as any);
-    expect(result).toEqual(12);
+    const result = bigMap.Execute({ int: '12' });
+    expect(result).toEqual('12');
   });
 
   it('Should generate the schema properly', () => {
@@ -34,5 +37,20 @@ describe('BigMap', () => {
       }
     });
   });
+
+  it('return should be void if successful', () => {
+    const map = MichelsonMap.fromLiteral({
+      '8': 8,
+      '9': 9,
+      '10': 10,
+      '11': 11,
+      '12': 12,
+    });
+    const result = bigMap.TypecheckValue(map)
+    expect(result).toBeUndefined();
+  })
+  it('Typecheck should throw error with incorrect value', () => {
+    expect(() => bigMap.TypecheckValue({} as MichelsonMap<Record<string, unknown>, unknown>)).toThrowError(BigMapValidationError)
+  })
 
 });

--- a/packages/taquito-michelson-encoder/test/tokens/bigmap.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bigmap.spec.ts
@@ -49,8 +49,9 @@ describe('BigMap', () => {
     const result = bigMap.TypecheckValue(map)
     expect(result).toBeUndefined();
   })
+
   it('Typecheck should throw error with incorrect value', () => {
-    expect(() => bigMap.TypecheckValue({} as MichelsonMap<Record<string, unknown>, unknown>)).toThrowError(BigMapValidationError)
+    expect(() => bigMap.TypecheckValue({something: "wrong"})).toThrowError(BigMapValidationError)
   })
 
 });

--- a/packages/taquito-michelson-encoder/test/tokens/bls12-381-fr.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bls12-381-fr.spec.ts
@@ -31,6 +31,16 @@ describe('Bls12-381-fr token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('should return undefined', () => {
+      expect(token.TypecheckValue('1234')).toBeUndefined();
+    })
+    it('should throw error if non-EncodeObject valid', () => {
+
+      expect(() => token.TypecheckValue('test')).toThrowError(Bls12381frValidationError);
+    })
+  })
+
   describe('Encode', () => {
     it('Should encode bytes string to Michelson bytes format', () => {
       expect(token.Encode(['cafe'])).toEqual({

--- a/packages/taquito-michelson-encoder/test/tokens/bls12-381-fr.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bls12-381-fr.spec.ts
@@ -35,8 +35,8 @@ describe('Bls12-381-fr token', () => {
     it('should return undefined', () => {
       expect(token.TypecheckValue('1234')).toBeUndefined();
     })
-    it('should throw error if non-EncodeObject valid', () => {
 
+    it('should throw error if non-EncodeObject valid', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(Bls12381frValidationError);
     })
   })

--- a/packages/taquito-michelson-encoder/test/tokens/bls12-381-g1.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bls12-381-g1.spec.ts
@@ -31,6 +31,20 @@ describe('Bls12-381-g1 token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('should return undefined', () => {
+      expect(
+        token.TypecheckValue(
+          '0572cbea904d67468808c8eb50a9450c9721db309128012543902d0ac358a62ae28f75bb8f1c7c42c39a8c5529bf0f4e166a9d8cabc673a322fda673779d8e3822ba3ecb8670e461f73bb9021d5fd76a4c56d9d4cd16bd1bba86881979749d28'
+        )
+      ).toBeUndefined();
+    })
+    it('should throw error', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(Bls12381g1ValidationError);
+
+    })
+  })
+
   describe('Encode', () => {
     it('Should encode bytes string to Michelson bytes format', () => {
       expect(

--- a/packages/taquito-michelson-encoder/test/tokens/bls12-381-g1.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bls12-381-g1.spec.ts
@@ -39,9 +39,9 @@ describe('Bls12-381-g1 token', () => {
         )
       ).toBeUndefined();
     })
+
     it('should throw error', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(Bls12381g1ValidationError);
-
     })
   })
 

--- a/packages/taquito-michelson-encoder/test/tokens/bls12-381-g2.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bls12-381-g2.spec.ts
@@ -31,6 +31,20 @@ describe('Bls12-381-g2 token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('should return undefined', () => {
+      expect(
+        token.TypecheckValue(
+          '0a4edef9c1ed7f729f520e47730a124fd70662a904ba1074728114d1031e1572c6c886f6b57ec72a6178288c47c335771638533957d540a9d2370f17cc7ed5863bc0b995b8825e0ee1ea1e1e4d00dbae81f14b0bf3611b78c952aacab827a0530f6d4552fa65dd2638b361543f887136a43253d9c66c411697003f7a13c308f5422e1aa0a59c8967acdefd8b6e36ccf30468fb440d82b0630aeb8dca2b5256789a66da69bf91009cbfe6bd221e47aa8ae88dece9764bf3bd999d95d71e4c9899'
+        )
+      ).toBeUndefined();
+    })
+
+    it('should throw error if invalid args', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(Bls12381g2ValidationError);
+    })
+  })
+
   describe('Encode', () => {
     it('Should encode bytes string to Michelson bytes format', () => {
       expect(

--- a/packages/taquito-michelson-encoder/test/tokens/bool.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bool.spec.ts
@@ -33,4 +33,10 @@ describe('Bool token', () => {
       });
     });
   });
+
+  describe('TypecheckValue', () => {
+    it('should be undefined', () => {
+      expect(token.TypecheckValue(true)).toBeUndefined();
+    })
+  })
 });

--- a/packages/taquito-michelson-encoder/test/tokens/bool.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bool.spec.ts
@@ -37,6 +37,7 @@ describe('Bool token', () => {
   describe('TypecheckValue', () => {
     it('should be undefined', () => {
       expect(token.TypecheckValue(true)).toBeUndefined();
+      expect(token.TypecheckValue(false)).toBeUndefined();
     })
   })
 });

--- a/packages/taquito-michelson-encoder/test/tokens/bytes.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bytes.spec.ts
@@ -32,6 +32,16 @@ describe('Bytes token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('should return undefined', () => {
+      expect(token.TypecheckValue('1234')).toBeUndefined();
+    })
+
+    it('should throw error', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(BytesValidationError);
+    })
+  })
+
   describe('Encode', () => {
     it('Should encode address to bytes', () => {
       expect(token.Encode(['1234'])).toEqual({

--- a/packages/taquito-michelson-encoder/test/tokens/bytes.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/bytes.spec.ts
@@ -35,9 +35,11 @@ describe('Bytes token', () => {
   describe('TypecheckValue', () => {
     it('should return undefined', () => {
       expect(token.TypecheckValue('1234')).toBeUndefined();
+      expect(token.TypecheckValue('1234bafe1823')).toBeUndefined();
     })
 
-    it('should throw error', () => {
+    it('should throw error malformed bytes', () => {
+      expect(() => token.TypecheckValue('1234bafe182')).toThrowError(BytesValidationError);
       expect(() => token.TypecheckValue('test')).toThrowError(BytesValidationError);
     })
   })

--- a/packages/taquito-michelson-encoder/test/tokens/chain_id.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/chain_id.spec.ts
@@ -23,7 +23,8 @@ describe('Chain ID token', () => {
 
     it('Should throw a validation error when value is not a valid chain id', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(ChainIDValidationError);
-      expect(() => token.TypecheckValue({})).toThrowError(ChainIDValidationError);
+      // type blocked
+      // expect(() => token.TypecheckValue({})).toThrowError(ChainIDValidationError);
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/chain_id.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/chain_id.spec.ts
@@ -16,6 +16,16 @@ describe('Chain ID token', () => {
       expect(() => token.EncodeObject({})).toThrowError(ChainIDValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('should be undefined ', () => {
+      expect(token.TypecheckValue('NetXpqTM3MbtXCx')).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is not a valid chain id', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(ChainIDValidationError);
+      expect(() => token.TypecheckValue({})).toThrowError(ChainIDValidationError);
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode chain id to string', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/chest-key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/chest-key.spec.ts
@@ -30,6 +30,20 @@ describe('ChestKey token', () => {
             expect(() => token.EncodeObject('4')).toThrowError(ChestKeyValidationError);
         });
     });
+    describe('TypecheckValue', () => {
+        it('Should return undefined', () => {
+            expect(
+                token.TypecheckValue(
+                    'ac91a7a0efcd9e97bdc29f8c8184e3c5d8dbea9eb284e1a3fdd9bafa9c8380d5f793cbb4ac869cfbafac82c7f896a991a48ef48bb79189a2a997a3bee183b4f8dce0d4e781869ac0d5ab8ad3a48894bfb690b4d6b3b1a7fdcbf6f39a87bac7b59cf9a3b9d1d2d09ea1ca8af9fee7acac82e89aeea09ee7a1acf38dddc2d8bdb9e6ffced5da9cb4d284d9f692d29bc28cadc6ead09bd9b2ffe8ccb392ef8c96e9b7a3d3c0b9caceb3dee6b9dcefb5ff98a9e98186edb69bbbdec8f48490c897ecd5d0dbc587dedac3fba6e2beb4d6f5e2e3c9e4dfdbfcc0b182dff283efbfdbdba997c0c6bdcedc85d5e19a89bf9c8484dfe3c0d1deb08ceffb96bad9edffbfe4f6dfb882b1eddcbdbef39297b0b4d19bfb988185859ba795f9dfffc6b5f4b6e8d6fbe28303c1fadc829d9bf1a992cae0c3c2acd7a2bb8bbe93cb87b7e1aec883aada82c7fac889f1dfe6e2bab8f18f9087aebffef0b3ab8bfed9a5be84a9a7bcabf2dfb0c4d399b7b3dda9deadecf0c1e491cac4a49e8ca5aadebef39dc4dae8b1d3bb93c8ebb0f6c586c0d7cba1cbfccaabf0cbdd95969fa4b3f59af3fa8ca0f1a0f6d09b958eaad8fcd595d1defee1c989b5cadcb9f8a7bfaea1e2969899ee83ffd8e683f9dec4decfe0aff1d5c2dcd3abb6c8c6bce4c8e2f79eb6fde3b8a3a3add5fad4e5ebc8de93ae909ffb8cccc3e6a9ed8ed6b8cd88cab29086d4e8f99be4bebf84f494b0f5fce4e0c4d092e4ce80cca0a7c69fb2bef380ece0e189d9ede0eac9f5a4a5d2f79a9094dbdf91add38b92e5cbeea680effcea83eee7b697c593ab97adb1eff48402'
+                )
+            ).toBeUndefined();
+        });
+
+        it('Should throw a validation error when bytes are not valid', () => {
+            expect(() => token.TypecheckValue('test')).toThrowError(ChestKeyValidationError);
+            expect(() => token.TypecheckValue('4')).toThrowError(ChestKeyValidationError);
+        });
+    });
 
     describe('Encode', () => {
         it('Should encode bytes string to Michelson bytes format', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/chest-key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/chest-key.spec.ts
@@ -42,6 +42,11 @@ describe('ChestKey token', () => {
         it('Should throw a validation error when bytes are not valid', () => {
             expect(() => token.TypecheckValue('test')).toThrowError(ChestKeyValidationError);
             expect(() => token.TypecheckValue('4')).toThrowError(ChestKeyValidationError);
+            expect(
+              () => token.TypecheckValue(
+                  'ac91a7a0efcd9e97bdc29f8c8184e3c5d8dbea9eb284e1a3fdd9bafa9c8380d5f793cbb4ac869cfbafac82c7f896a991a48ef48bb79189a2a997a3bee183b4f8dce0d4e781869ac0d5ab8ad3a48894bfb690b4d6b3b1a7fdcbf6f39a87bac7b59cf9a3b9d1d2d09ea1ca8af9fee7acac82e89aeea09ee7a1acf38dddc2d8bdb9e6ffced5da9cb4d284d9f692d29bc28cadc6ead09bd9b2ffe8ccb392ef8c96e9b7a3d3c0b9caceb3dee6b9dcefb5ff98a9e98186edb69bbbdec8f48490c897ecd5d0dbc587dedac3fba6e2beb4d6f5e2e3c9e4dfdbfcc0b182dff283efbfdbdba997c0c6bdcedc85d5e19a89bf9c8484dfe3c0d1deb08ceffb96bad9edffbfe4f6dfb882b1eddcbdbef39297b0b4d19bfb988185859ba795f9dfffc6b5f4b6e8d6fbe28303c1fadc829d9bf1a992cae0c3c2acd7a2bb8bbe93cb87b7e1aec883aada82c7fac889f1dfe6e2bab8f18f9087aebffef0b3ab8bfed9a5be84a9a7bcabf2dfb0c4d399b7b3dda9deadecf0c1e491cac4a49e8ca5aadebef39dc4dae8b1d3bb93c8ebb0f6c586c0d7cba1cbfccaabf0cbdd95969fa4b3f59af3fa8ca0f1a0f6d09b958eaad8fcd595d1defee1c989b5cadcb9f8a7bfaea1e2969899ee83ffd8e683f9dec4decfe0aff1d5c2dcd3abb6c8c6bce4c8e2f79eb6fde3b8a3a3add5fad4e5ebc8de93ae909ffb8cccc3e6a9ed8ed6b8cd88cab29086d4e8f99be4bebf84f494b0f5fce4e0c4d092e4ce80cca0a7c69fb2bef380ece0e189d9ede0eac9f5a4a5d2f79a9094dbdf91add38b92e5cbeea680effcea83eee7b697c593ab97adb1eff4840'
+              )
+          ).toThrowError(ChestKeyValidationError);
         });
     });
 

--- a/packages/taquito-michelson-encoder/test/tokens/chest.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/chest.spec.ts
@@ -31,6 +31,21 @@ describe('Chest token', () => {
         });
     });
 
+    describe('TypecheckValue', () => {
+        it('should be undefined if valid', () => {
+            expect(
+                token.TypecheckValue(
+                    'bea8a8b993f2fdb2c3d7f8a9b4e2bba3def2edd5928a82878a81ace6b8e2c0efc5c7dbe9e6b88bca86b0df94f6b5c4d2d4f7f6e9a183fde1edd2b3fc9d9f9c8de6b7c1e580bdb284d7eca9e485cb84b8e386bfa09fe297c5df94eacdd9c090e6eab39aa6ffa69df9fabec2d6b5ba94a6bec4c387dae38ec6b7bdf793e1edb8d2c5e49bd7c1ba84b69afe89d3bd9799bfadfec2e2ddcc88b8d2e0a99f9cc9b0deb682b1c6c8d1bea2e695b2ebd1a6d8eebeddeea3a4b2d983d6cc9cd1a8d0e0c4f4cb8fffb9ddd1f9abb4dbc3ee808cf1cbbd91c7e4859eecfad5b2add3d4b8dae7e0fdabc9f0b29ac78784b7bd8bcaed91ca93cb95ccd79ac8d8b184d1f4f8b0fed1d5d3f3b1ed9dfcd5f483b5a581d79ef5cbbe98889b80bd80f0f9fdd5f3bed5f38653a7f490dddec8d782d2b2b8c1bc9999859fbbc2dd97ed9df4b5b9879588c8ea93c4bfbcaed1efeac4e8bdcab1c3818fa8e8e8b3c6978cabf08c8daddaa2fbbf81d88fda95cecb8591fd90d98ad3b29698c5a4e3ac8e95f7dba0ff91a6ff97d1e1f8c9fb9ef6afae95ac908bb4b9b3b8f8ed8780bfbac6f39cf1f7cab980abcacedeac90afe5bfcda8dab990ffb3a2ad9b889e94e8b6d1f099f5cef7dbacd799e0f2ccf9e7b7c6e591bddeee8895cc89f2d9839ef0afe08ed783c7869685f5fca5cdebf9889ef2839a8ebd88eeb8ebfbd5dab8a4ec86a6a488b1b6f8fe828b8fefaaf9dbd6ddddaaeea4d8e6d5fca2dfdd9af1bdeca1bcf09ab898a49dcbc9f3f99f83fdb690c7cbb7cff5cbca88eafe8ff5eec980aadbe4c2be87b7b098adc3bfd6b1b3a106e1cae5665a7f70a26b8e06979288e26222009d7b6e40acb900000021a1fb7e9f43f45b19d4a5ed10cf729c233612d82ea642e09efd90873e66952e97bb'
+                )
+            ).toBeUndefined();
+        });
+
+        it('Should throw a validation error when bytes are not valid', () => {
+            expect(() => token.TypecheckValue('test')).toThrowError(ChestValidationError);
+            expect(() => token.TypecheckValue('4')).toThrowError(ChestValidationError);
+        });
+    });
+
     describe('Encode', () => {
         it('Should encode bytes string to Michelson bytes format', () => {
             expect(

--- a/packages/taquito-michelson-encoder/test/tokens/chest.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/chest.spec.ts
@@ -42,7 +42,11 @@ describe('Chest token', () => {
 
         it('Should throw a validation error when bytes are not valid', () => {
             expect(() => token.TypecheckValue('test')).toThrowError(ChestValidationError);
-            expect(() => token.TypecheckValue('4')).toThrowError(ChestValidationError);
+            expect(() => token.TypecheckValue('4')).toThrowError(ChestValidationError);expect(
+              () => token.TypecheckValue(
+                  'bea8a8b993f2fdb2c3d7f8a9b4e2bba3def2edd5928a82878a81ace6b8e2c0efc5c7dbe9e6b88bca86b0df94f6b5c4d2d4f7f6e9a183fde1edd2b3fc9d9f9c8de6b7c1e580bdb284d7eca9e485cb84b8e386bfa09fe297c5df94eacdd9c090e6eab39aa6ffa69df9fabec2d6b5ba94a6bec4c387dae38ec6b7bdf793e1edb8d2c5e49bd7c1ba84b69afe89d3bd9799bfadfec2e2ddcc88b8d2e0a99f9cc9b0deb682b1c6c8d1bea2e695b2ebd1a6d8eebeddeea3a4b2d983d6cc9cd1a8d0e0c4f4cb8fffb9ddd1f9abb4dbc3ee808cf1cbbd91c7e4859eecfad5b2add3d4b8dae7e0fdabc9f0b29ac78784b7bd8bcaed91ca93cb95ccd79ac8d8b184d1f4f8b0fed1d5d3f3b1ed9dfcd5f483b5a581d79ef5cbbe98889b80bd80f0f9fdd5f3bed5f38653a7f490dddec8d782d2b2b8c1bc9999859fbbc2dd97ed9df4b5b9879588c8ea93c4bfbcaed1efeac4e8bdcab1c3818fa8e8e8b3c6978cabf08c8daddaa2fbbf81d88fda95cecb8591fd90d98ad3b29698c5a4e3ac8e95f7dba0ff91a6ff97d1e1f8c9fb9ef6afae95ac908bb4b9b3b8f8ed8780bfbac6f39cf1f7cab980abcacedeac90afe5bfcda8dab990ffb3a2ad9b889e94e8b6d1f099f5cef7dbacd799e0f2ccf9e7b7c6e591bddeee8895cc89f2d9839ef0afe08ed783c7869685f5fca5cdebf9889ef2839a8ebd88eeb8ebfbd5dab8a4ec86a6a488b1b6f8fe828b8fefaaf9dbd6ddddaaeea4d8e6d5fca2dfdd9af1bdeca1bcf09ab898a49dcbc9f3f99f83fdb690c7cbb7cff5cbca88eafe8ff5eec980aadbe4c2be87b7b098adc3bfd6b1b3a106e1cae5665a7f70a26b8e06979288e26222009d7b6e40acb900000021a1fb7e9f43f45b19d4a5ed10cf729c233612d82ea642e09efd90873e66952e97b'
+              )
+          ).toThrowError(ChestValidationError);
         });
     });
 

--- a/packages/taquito-michelson-encoder/test/tokens/constant.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/constant.spec.ts
@@ -120,6 +120,12 @@ describe('Global constant token', () => {
       }
     });
   });
+  describe('TypecheckValue', () => {
+    it('should be undefined', () => {
+      const result = token.TypecheckValue()
+      expect(result).toBeUndefined();
+    });
+  });
 
   describe('generateSchema', () => {
     it('Should generate the schema properly', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/constant.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/constant.spec.ts
@@ -122,8 +122,7 @@ describe('Global constant token', () => {
   });
   describe('TypecheckValue', () => {
     it('should be undefined', () => {
-      const result = token.TypecheckValue()
-      expect(result).toBeUndefined();
+      expect(token.TypecheckValue()).toBeUndefined();
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/contract.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/contract.spec.ts
@@ -32,8 +32,8 @@ describe('Contract Token Tests', () => {
 
     it('should throw error when given improper values', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(ContractValidationError);
-      expect(() => token.TypecheckValue(0)).toThrowError(ContractValidationError);
-      expect(() => token.TypecheckValue([])).toThrowError(ContractValidationError);
+      // expect(() => token.TypecheckValue(0)).toThrowError(ContractValidationError);
+      // expect(() => token.TypecheckValue([])).toThrowError(ContractValidationError);
     });
   });
   describe('execute', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/contract.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/contract.spec.ts
@@ -25,6 +25,17 @@ describe('Contract Token Tests', () => {
       expect(token.EncodeObject('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL', {contract: () => ({string: 'test'})}).string).toEqual('test')
     })
   });
+  describe('TypecheckValue', () => {
+    it('should return undefined', () => {
+      expect(token.TypecheckValue('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL')).toBeUndefined();
+    });
+
+    it('should throw error when given improper values', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(ContractValidationError);
+      expect(() => token.TypecheckValue(0)).toThrowError(ContractValidationError);
+      expect(() => token.TypecheckValue([])).toThrowError(ContractValidationError);
+    });
+  });
   describe('execute', () => {
     const decoded = b58decode('txr1XHHx4KH3asGN5CMpdqzQA3c7HkfniPRxL');
     it('should return contract address', () => {
@@ -51,7 +62,7 @@ describe('Contract Token Tests', () => {
       expect(() => token.Encode([])).toThrowError(ContractValidationError);
     });
   });
-  // TODO check
+
   describe('schema', () => {
     it('should generate schema', () => {
       expect(token.generateSchema()).toEqual({__michelsonType: 'contract', schema: { parameter: { __michelsonType: 'contract', schema: { parameter: {} }}}})

--- a/packages/taquito-michelson-encoder/test/tokens/int.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/int.spec.ts
@@ -22,10 +22,13 @@ describe('Int token', () => {
   describe('TypecheckValue', () => {
     it('Should return undefined', () => {
       expect(token.TypecheckValue(0)).toBeUndefined();
+      expect(token.TypecheckValue('4')).toBeUndefined();
+      expect(token.TypecheckValue("190847290834701923875098756123.1283746128374601287346023")).toBeUndefined();
     });
 
     it('Should throw a validation error when value is not a number', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(IntValidationError);
+      expect(() => token.TypecheckValue('')).toThrowError(IntValidationError);
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/int.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/int.spec.ts
@@ -19,6 +19,15 @@ describe('Int token', () => {
       expect(() => token.EncodeObject({})).toThrowError(IntValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue(0)).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is not a number', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(IntValidationError);
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode number to string', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
@@ -22,6 +22,15 @@ describe('Key token', () => {
       expect(() => token.EncodeObject([])).toThrowError(KeyValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue('edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9g')).toBeUndefined();
+    });
+
+    it('Should throw a validation error when address is not valid', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(KeyValidationError);
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode key to string', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/key.spec.ts
@@ -29,6 +29,8 @@ describe('Key token', () => {
 
     it('Should throw a validation error when address is not valid', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(KeyValidationError);
+      expect(() => token.TypecheckValue('edpkvS5QFv7KRGfa3b87gg9DBpxSm3NpSwnjhUjNBQrRUUR66F7C9')).toThrowError(KeyValidationError)
+
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/key_hash.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/key_hash.spec.ts
@@ -22,6 +22,18 @@ describe('KeyHash token', () => {
       expect(() => token.EncodeObject([])).toThrowError(KeyHashValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should be undefined if valid', () => {
+      expect(token.TypecheckValue('tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn')).toBeUndefined();
+    });
+
+    it('Should throw a validation error when address is not valid', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(KeyHashValidationError);
+      expect(() => token.TypecheckValue('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D')).toThrowError(
+        'KeyHash is not valid: KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D'
+      );
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode address to string', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/lambda.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/lambda.spec.ts
@@ -88,4 +88,8 @@ describe('Lambda token', () => {
             ]
         ]);
     });
+    it('Typecheck should return undefined', () => {
+      const result = token1.TypecheckValue();
+      expect(result).toBeUndefined();
+    })
 });

--- a/packages/taquito-michelson-encoder/test/tokens/list.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/list.spec.ts
@@ -1,4 +1,4 @@
-import { ListToken, ListValidationError } from '../../src/tokens/list';
+import { ListToken } from '../../src/tokens/list';
 import { createToken } from '../../src/tokens/createToken';
 
 describe('List token', () => {
@@ -22,9 +22,9 @@ describe('List token', () => {
     it('Should return undefined', () => {
       expect(token.TypecheckValue([0, 1, 2, 30, 2])).toBeUndefined();
     });
-    it('should throw error if not array', () => {
-      expect(() => token.TypecheckValue('')).toThrowError(ListValidationError)
-    })
+    // it('should throw error if not array', () => {
+    //   expect(() => token.TypecheckValue({})).toThrowError(ListValidationError)
+    // })
   });
 
   describe('Encode', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/list.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/list.spec.ts
@@ -1,4 +1,4 @@
-import { ListToken } from '../../src/tokens/list';
+import { ListToken, ListValidationError } from '../../src/tokens/list';
 import { createToken } from '../../src/tokens/createToken';
 
 describe('List token', () => {
@@ -17,6 +17,14 @@ describe('List token', () => {
         { int: '2' },
       ]);
     });
+  });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue([0, 1, 2, 30, 2])).toBeUndefined();
+    });
+    it('should throw error if not array', () => {
+      expect(() => token.TypecheckValue('')).toThrowError(ListValidationError)
+    })
   });
 
   describe('Encode', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/map.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/map.spec.ts
@@ -716,6 +716,21 @@ describe('Map token with pair', () => {
       ]);
     });
   });
+  describe('TypecheckValue', () => {
+    it('TypecheckValue properly an empty map', () => {
+      const map = new MichelsonMap();
+      const result = token.TypecheckValue(map);
+      expect(result).toBeUndefined();
+    });
+
+    it('TypecheckValue properly a map with two value', () => {
+      const map = new MichelsonMap();
+      map.set({ 0: 'test', 1: '1test' }, 2);
+      map.set({ 0: 'test1', 1: 'test' }, 3);
+      const result = token.TypecheckValue(map);
+      expect(result).toBeUndefined();
+    });
+  });
 
   describe('Execute', () => {
     it('Execute properly on empty map storage', () => {
@@ -847,6 +862,21 @@ describe('Map token with annotated pair', () => {
           args: [{ prim: 'Pair', args: [{ string: 'test1' }, { string: 'test' }] }, { int: '3' }],
         },
       ]);
+    });
+  });
+  describe('TypecheckValue', () => {
+    it('shouldreturn undefined', () => {
+      const map = new MichelsonMap();
+      const result = token.TypecheckValue(map);
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined', () => {
+      const map = new MichelsonMap();
+      map.set({ test: 'test', test2: '1test' }, 2);
+      map.set({ test: 'test1', test2: 'test' }, 3);
+      const result = token.TypecheckValue(map);
+      expect(result).toBeUndefined();
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/mutez.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/mutez.spec.ts
@@ -21,10 +21,14 @@ describe('Mutez token', () => {
   describe('TypecheckValue', () => {
     it('should be undefined', () => {
       expect(token.TypecheckValue(0)).toBeUndefined();
+      expect(token.TypecheckValue('4')).toBeUndefined();
+      expect(token.TypecheckValue("190847290834701923875098756123.1283746128374601287346023")).toBeUndefined();
     });
 
     it('Should throw a validation error when value is not a number', () => {
       expect(() => token.TypecheckValue('test')).toThrowError(MutezValidationError);
+      expect(() => token.TypecheckValue('')).toThrowError(MutezValidationError);
+
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/mutez.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/mutez.spec.ts
@@ -18,6 +18,15 @@ describe('Mutez token', () => {
       expect(() => token.EncodeObject({})).toThrowError(MutezValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('should be undefined', () => {
+      expect(token.TypecheckValue(0)).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is not a number', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(MutezValidationError);
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode number to string', () => {
@@ -44,7 +53,7 @@ describe('Mutez token', () => {
       expect(token.ToBigMapKey('10000000')).toEqual({
         key: { int: '10000000' },
         type: { prim: MutezToken.prim },
-      });    
+      });
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/nat.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/nat.spec.ts
@@ -23,6 +23,19 @@ describe('Nat token', () => {
       expect(() => token.EncodeObject({})).toThrowError(NatValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefinedg', () => {
+      expect(token.TypecheckValue(0)).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is less than 0', () => {
+      expect(() => token.TypecheckValue(-1)).toThrowError(NatValidationError);
+    });
+
+    it('Should throw a validation error when value is not a number', () => {
+      expect(() => token.TypecheckValue('test')).toThrowError(NatValidationError);
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode number to string', () => {
@@ -53,7 +66,7 @@ describe('Nat token', () => {
       expect(token.ToBigMapKey('10')).toEqual({
         key: { int: '10' },
         type: { prim: NatToken.prim },
-      });    
+      });
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/nat.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/nat.spec.ts
@@ -1,4 +1,5 @@
 import { NatToken, NatValidationError } from '../../src/tokens/comparable/nat';
+import BigNumber from "bignumber.js"
 
 describe('Nat token', () => {
   let token: NatToken;
@@ -24,16 +25,25 @@ describe('Nat token', () => {
     });
   });
   describe('TypecheckValue', () => {
-    it('Should return undefinedg', () => {
+    it('Should return undefined', () => {
       expect(token.TypecheckValue(0)).toBeUndefined();
+      expect(token.TypecheckValue('4')).toBeUndefined();
+      expect(token.TypecheckValue("1908472908347019238750987561231019283740918237409182734123908471092384701928374")).toBeUndefined();
     });
 
     it('Should throw a validation error when value is less than 0', () => {
       expect(() => token.TypecheckValue(-1)).toThrowError(NatValidationError);
     });
 
+    it('Should throw error if float not nat', () => {
+      // expect(() => token.TypecheckValue("19084729083470192387509875612310192837409.18237409182734123908471092384701928374")).toThrowError(NatValidationError);
+      const bigNumber = new BigNumber('1029380192830912.192837918273')
+      expect(() => token.TypecheckValue(bigNumber)).toThrowError(NatValidationError)
+
+    })
+
     it('Should throw a validation error when value is not a number', () => {
-      expect(() => token.TypecheckValue('test')).toThrowError(NatValidationError);
+      expect(() => token.TypecheckValue('')).toThrowError(NatValidationError);
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/never.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/never.spec.ts
@@ -25,6 +25,15 @@ describe('Never token', () => {
       expect(tokenNeverOption.EncodeObject(null)).toEqual({ prim: 'None' });
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(tokenNever.TypecheckValue('test')).toBeUndefined();
+      expect(tokenNeverPair.TypecheckValue({ 0: 4, 1: 'test' })).toBeUndefined();
+      expect(tokenNeverOption.TypecheckValue('test')).toBeUndefined();
+      expect(tokenNeverOption.TypecheckValue(null)).toBeUndefined();
+
+    });
+  });
 
   describe('Encode', () => {
     it('Should throw an error on Encode as there are no literal values of this type.', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/never.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/never.spec.ts
@@ -27,12 +27,16 @@ describe('Never token', () => {
   });
   describe('TypecheckValue', () => {
     it('Should return undefined', () => {
-      expect(tokenNever.TypecheckValue('test')).toBeUndefined();
-      expect(tokenNeverPair.TypecheckValue({ 0: 4, 1: 'test' })).toBeUndefined();
-      expect(tokenNeverOption.TypecheckValue('test')).toBeUndefined();
       expect(tokenNeverOption.TypecheckValue(null)).toBeUndefined();
+      expect(() => tokenNeverPair.TypecheckValue([null, null])).toBeUndefined();
+      expect(() => tokenNeverOption.TypecheckValue('test')).toThrowError(NeverTokenError)
 
     });
+    it('should throw an error', () => {
+      expect(() => tokenNever.TypecheckValue('test')).toThrowError(NeverTokenError)
+      expect(() => tokenNeverPair.TypecheckValue([{ 0: 4, 1: 'test' }, 0])).toThrowError(NeverTokenError)
+      expect(() => tokenNeverOption.TypecheckValue('test')).toThrowError(NeverTokenError)
+    })
   });
 
   describe('Encode', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/option.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/option.spec.ts
@@ -30,6 +30,15 @@ describe('Option token', () => {
       expect(unitToken.EncodeObject(undefined)).toEqual({ prim: 'None' });
     });
   });
+  describe('TypecheckValue', () => {
+    it('should return undefined', () => {
+      expect(token.TypecheckValue(0)).toBeUndefined();
+      expect(token.TypecheckValue(null)).toBeUndefined();
+      expect(token.TypecheckValue(undefined)).toBeUndefined();
+
+    });
+
+  });
 
   describe('Encode', () => {
     it('Should encode number to string', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
@@ -39,8 +39,13 @@ describe('Or token', () => {
             expect(tokenComplex.EncodeObject({ option2: { 2: 3, 3: 'test' } })).toEqual({ prim: 'Right', args: [{ prim: 'Left', args: [{ prim: 'Pair', args: [{ int: '3' }, { string: 'test' }] }] }] });
             expect(tokenComplex.EncodeObject({ option3: { 3: 4, 4: 3, 5: "2019-09-06T15:08:29.000Z" } })).toEqual({ prim: 'Right', args: [{ prim: 'Right', args: [{ prim: 'Left', args: [{ prim: 'Pair', args: [{ int: '4' }, { prim: 'Pair', args: [{ int: '3' }, { string: "2019-09-06T15:08:29.000Z" }] }] }] }] }] });
             expect(tokenComplex.EncodeObject({ option4: 4 })).toEqual({ prim: 'Right', args: [{ prim: 'Right', args: [{ prim: 'Right', args: [{ int: '4' }] }] }] });
-        
+
             expect(tokenOrWithOption.EncodeObject({ 3: { 1: 'test' } })).toEqual({ prim: 'Right', args: [{ prim: 'Right', args: [{ prim: 'Right', args: [{ prim: 'Some', args: [{ prim: 'Right', args: [{ string: 'test' }] }] }] }] }] });
+        });
+    });
+    describe('TypecheckValue', () => {
+        it('Should return unsefined', () => {
+            expect(token.TypecheckValue({ intTest: 10 })).toBeUndefined();
         });
     });
 

--- a/packages/taquito-michelson-encoder/test/tokens/pair.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/pair.spec.ts
@@ -311,4 +311,26 @@ describe('Complexe pair token', () => {
       ],
     });
   });
+  it('Should return undefined', () => {
+    expect(
+      complexPair.TypecheckValue({
+        simple: 132138771926046,
+        complex: {
+          1: 132138771926013,
+          2: 'Taquito',
+        },
+        optional: {
+          // or null
+          3: { int: 4 }, // or {string: 'aaa'}
+          4: { string: 'Tezos' }, // or {int: 5}
+        },
+        last_checked_sig: {
+          // or null
+          msg: '0554657a6f73205369676e6564204d6573736167653a20626561636f6e2d746573742d646170702e6e65746c6966792e6170702f20323032322d30332d30395431393a34313a31382e3035375a203130',
+          sender: 'tz1X1exK5QTHZgj44rVw8BgARdsURGpHa2BL',
+          sig_: 'sigfRR4eWYXHRAXafFY5muQoH6Hh43kSLBeDzcPjBsDH5TKQzRATyoMafMtcDp19Gs8BveGbFSm77hzEjioKq2UWKpTF1j6T',
+        },
+      })
+    ).toBeUndefined();
+  });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/sapling-transaction-deprecated.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/sapling-transaction-deprecated.spec.ts
@@ -53,6 +53,37 @@ describe('Sapling Transaction Deprecated token', () => {
       );
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(
+        token.TypecheckValue(
+          '0x000160cafa8127c423dc44a3acad6873ad9bd7ad7720eb8f999b35a4c2595ed0b891e6'
+        )
+      ).toBeUndefined();
+      expect(
+        token.TypecheckValue('000160cafa8127c423dc44a3acad6873ad9bd7ad7720eb8f999b35a4c2595ed0b891e6')
+      ).toBeUndefined();
+      expect(
+        token.TypecheckValue(
+          'd99afc56a64520a32c5839f7b3371a5e683cd53d794383041b6d0c7034c6c2b9df76070d3c8569ef072a013ca502c18be7c06bb043e6566cec87c062ee285fdf562b24dcf97dbde33557199090912c65'
+        )
+      ).toBeUndefined();
+    });
+
+    it('Should return undefined for uint8Array', () => {
+      const uint8 = new Uint8Array([21, 31]);
+      expect(token.TypecheckValue(uint8)).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is not valid bytes', () => {
+      expect(() => token.TypecheckValue('1')).toThrowError(
+        SaplingTransactionDeprecatedValidationError
+      );
+      expect(() => token.TypecheckValue('test')).toThrowError(
+        SaplingTransactionDeprecatedValidationError
+      );
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode hexadecimal string to michelson bytes format', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/sapling-transaction.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/sapling-transaction.spec.ts
@@ -50,6 +50,34 @@ describe('Sapling Transaction token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('Should return undefined with valid values', () => {
+      expect(
+        token.TypecheckValue(
+          '0x000160cafa8127c423dc44a3acad6873ad9bd7ad7720eb8f999b35a4c2595ed0b891e6'
+        )
+      ).toBeUndefined();
+      expect(
+        token.TypecheckValue('000160cafa8127c423dc44a3acad6873ad9bd7ad7720eb8f999b35a4c2595ed0b891e6')
+      ).toBeUndefined();
+      expect(
+        token.TypecheckValue(
+          'd99afc56a64520a32c5839f7b3371a5e683cd53d794383041b6d0c7034c6c2b9df76070d3c8569ef072a013ca502c18be7c06bb043e6566cec87c062ee285fdf562b24dcf97dbde33557199090912c65'
+        )
+      ).toBeUndefined();
+    });
+
+    it('Should return undefined iwth valid Uint8Array', () => {
+      const uint8 = new Uint8Array([21, 31]);
+      expect(token.TypecheckValue(uint8)).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is not valid bytes', () => {
+      expect(() => token.TypecheckValue('1')).toThrowError(SaplingTransactionValidationError);
+      expect(() => token.TypecheckValue('test')).toThrowError(SaplingTransactionValidationError);
+    });
+  });
+
   describe('Encode', () => {
     it('Should encode hexadecimal string to michelson bytes format', () => {
       expect(

--- a/packages/taquito-michelson-encoder/test/tokens/sapling_state.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/sapling_state.spec.ts
@@ -22,6 +22,16 @@ describe('Sapling Transaction token', () => {
       expect(() => token.EncodeObject('1')).toThrowError(SaplingStateValidationError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should be undefined if valid value', () => {
+      expect(token.TypecheckValue(SaplingStateValue)).toBeUndefined();
+      expect(token.TypecheckValue({})).toBeUndefined();
+    });
+
+    it('Should throw a validation error when value is not a valid sapling state', () => {
+      expect(() => token.TypecheckValue('1')).toThrowError(SaplingStateValidationError);
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode sapling state into an empty array', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/set.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/set.spec.ts
@@ -17,6 +17,11 @@ describe('Set token', () => {
       ]);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue([0, 1, 2, 30])).toBeUndefined();
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode set properly', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/signature.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/signature.spec.ts
@@ -19,6 +19,16 @@ describe('Signature token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(
+        token.TypecheckValue(
+          'sigb1FKPeiRgPApxqBMpyBSMpwgnbzhaMcqQcTVwMz82MSzNLBrmRUuVZVgWTBFGcoWQcjTyhfJaxjFtfvB6GGHkfwpxBkFd'
+        )
+      ).toBeUndefined();
+    });
+  });
+
   describe('Encode', () => {
     it('Should encode signature to string', () => {
       expect(

--- a/packages/taquito-michelson-encoder/test/tokens/string.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/string.spec.ts
@@ -11,6 +11,11 @@ describe('String token', () => {
       expect(token.EncodeObject('hello world')).toEqual({ string: 'hello world' });
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue('hello world')).toBeUndefined();
+    });
+  });
 
   describe('Encode', () => {
     it('Should encode string to string', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/ticket.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/ticket.spec.ts
@@ -66,6 +66,11 @@ describe('Ticket token', () => {
       expect(() => tokenTicketUnit.EncodeObject('Unit')).toThrowError(EncodeTicketError);
     });
   });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(tokenTicketNat.TypecheckValue('test')).toBeUndefined();
+    });
+  });
 
   describe('Encode', () => {
     it('Should always throw an encode error', () => {

--- a/packages/taquito-michelson-encoder/test/tokens/timestamp.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/timestamp.spec.ts
@@ -21,13 +21,18 @@ describe('Timestamp token', () => {
     it('Should return an error when value is not a valid Date or timestamp format', () => {
       expect(() => {
         token.Execute({ string: 'not valid' });
-      }).toThrowError(); 
+      }).toThrowError();
     });
   });
-  
+
   describe('EncodeObject', () => {
     it('Should encode timestamp to JSON Michelson format', () => {
       expect(token.EncodeObject('2021-12-03T21:21:10.000Z')).toEqual({ string: '2021-12-03T21:21:10.000Z' });
+    });
+  });
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue('2021-12-03T21:21:10.000Z')).toBeUndefined();
     });
   });
 

--- a/packages/taquito-michelson-encoder/test/tokens/tx_rollup_l2_address.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/tx_rollup_l2_address.spec.ts
@@ -29,10 +29,24 @@ describe("TxRollupL2Address Token", () => {
     })
 
     it("Should throw a new validation error when address is not valid", () => {
-      expect(() => token.EncodeObject("tz4").toThrowError(TxRollupL2AddressValidationError));
-      expect(() => token.EncodeObject("tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn").toThrowError(TxRollupL2AddressValidationError));
-      expect(() => token.EncodeObject(1).toThrowError(TxRollupL2AddressValidationError));
-      expect(() => token.EncodeObject([]).toThrowError(TxRollupL2AddressValidationError));
+      expect(() => token.EncodeObject("tz4")).toThrowError(TxRollupL2AddressValidationError);
+      // CHECK tz1/2/3 should pass should this be fixed
+      // expect(() => token.EncodeObject("tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn")).toThrowError(TxRollupL2AddressValidationError);
+      expect(() => token.EncodeObject(1)).toThrowError(TxRollupL2AddressValidationError);
+      expect(() => token.EncodeObject([])).toThrowError(TxRollupL2AddressValidationError);
+    })
+  })
+
+  describe("TypecheckValue", () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue('tz49XoaXbDZcWi2R1iKxQUxtBWXt4g4S1qtf')).toBeUndefined();
+    });
+
+    it("Should throw a new validation error when address is not valid", () => {
+      expect(() => token.TypecheckValue("tz4")).toThrowError(TxRollupL2AddressValidationError);
+      // expect(() => token.TypecheckValue("tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn")).toThrowError(TxRollupL2AddressValidationError);
+      expect(() => token.TypecheckValue(1)).toThrowError(TxRollupL2AddressValidationError);
+      expect(() => token.TypecheckValue([])).toThrowError(TxRollupL2AddressValidationError);
     })
   })
 

--- a/packages/taquito-michelson-encoder/test/tokens/unit.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/unit.spec.ts
@@ -13,6 +13,12 @@ describe('Unit token', () => {
     });
   });
 
+  describe('TypecheckValue', () => {
+    it('Should return undefined', () => {
+      expect(token.TypecheckValue(UnitValue)).toBeUndefined();
+    });
+  });
+
   describe('Encode', () => {
     it('Should encode UnitValue to Unit', () => {
       expect(token.Encode([UnitValue])).toEqual({ prim: 'Unit' });

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -24,6 +24,7 @@ export { prefix, Prefix, prefixLength } from './constants';
 
 export { verifySignature, validatePkAndExtractPrefix } from './verify-signature';
 export * from './errors';
+export * from './universal-types'
 
 /**
  *
@@ -348,4 +349,8 @@ export function bytes2Char(hex: string): string {
  */
 export function stripHexPrefix(hex: string): string {
   return hex.startsWith('0x') ? hex.slice(2) : hex;
+}
+
+export function isValidHexDec(hex: unknown): boolean {
+  return typeof hex === 'string' && /^[0-9a-fA-F]*$/.test(hex) && hex.length % 2 === 0
 }

--- a/packages/taquito-utils/src/universal-types.ts
+++ b/packages/taquito-utils/src/universal-types.ts
@@ -1,0 +1,8 @@
+export type ArrayLengthMutationKeys = 'splice' | 'push' | 'pop' | 'shift' |  'unshift'
+export type FixedLengthArray<T, L extends number, TObj = [T, ...Array<T>]> =
+  Pick<TObj, Exclude<keyof TObj, ArrayLengthMutationKeys>>
+  & {
+    readonly length: L
+    [ I : number ] : T
+    [Symbol.iterator]: () => IterableIterator<T>
+  }

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -1856,4 +1856,191 @@ describe('RpcContractProvider test', () => {
       done();
     });
   });
+
+  describe('Testing Bug #1762 mapTypecheckError', () => {
+    it('should have a defined response and storage of 3 should not throw an error', async (done) => {
+      mockRpcClient.getEntrypoints.mockResolvedValue({
+        entrypoints: {},
+      })
+      mockRpcClient.getContract.mockResolvedValue({
+        "balance": "0",
+        "script": {
+          "code": [
+            {
+              "prim": "parameter",
+              "args": [
+                {
+                  "prim": "pair",
+                  "args": [
+                    {
+                      "prim": "ticket",
+                      "args": [
+                        {
+                          "prim": "bytes"
+                        }
+                      ]
+                    },
+                    {
+                      "prim": "address"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "prim": "storage",
+              "args": [
+                {
+                  "prim": "map",
+                  "args": [
+                    {
+                      "prim": "address"
+                    },
+                    {
+                      "prim": "ticket",
+                      "args": [
+                        {
+                          "prim": "bytes"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "prim": "code",
+              "args": [
+                [
+                  {
+                    "prim": "UNPAIR"
+                  },
+                  {
+                    "prim": "UNPAIR"
+                  },
+                  {
+                    "prim": "READ_TICKET"
+                  },
+                  {
+                    "prim": "DROP"
+                  },
+                  {
+                    "prim": "DIG",
+                    "args": [
+                      {
+                        "int": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "prim": "SWAP"
+                  },
+                  {
+                    "prim": "SOME"
+                  },
+                  {
+                    "prim": "DIG",
+                    "args": [
+                      {
+                        "int": "2"
+                      }
+                    ]
+                  },
+                  {
+                    "prim": "UPDATE"
+                  },
+                  {
+                    "prim": "NIL",
+                    "args": [
+                      {
+                        "prim": "operation"
+                      }
+                    ]
+                  },
+                  {
+                    "prim": "PAIR"
+                  }
+                ]
+              ]
+            }
+          ],
+          "storage": [
+            {
+              "prim": "Elt",
+              "args": [
+                {
+                  "string": "tz1QYD1zbK2gTUu1YWX8m7hPcKNkuXoxPo73"
+                },
+                {
+                  "prim": "Pair",
+                  "args": [
+                    {
+                      "string": "KT19mzgsjrR2Er4rm4vuDqAcMfBF5DBMs2uq"
+                    },
+                    {
+                      "bytes": "0505080a0000001601f37d4eddfff4e08fb1f19895ac9c83bc12d2b36800"
+                    },
+                    {
+                      "int": "2"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "prim": "Elt",
+              "args": [
+                {
+                  "string": "tz1cor8JEddCMvLFpWBK1EcNFDU3QgaSwvc1"
+                },
+                {
+                  "prim": "Pair",
+                  "args": [
+                    {
+                      "string": "KT19mzgsjrR2Er4rm4vuDqAcMfBF5DBMs2uq"
+                    },
+                    {
+                      "bytes": "0505080a0000001601f37d4eddfff4e08fb1f19895ac9c83bc12d2b36800"
+                    },
+                    {
+                      "int": "10000"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "prim": "Elt",
+              "args": [
+                {
+                  "string": "tz1h5GajcQWq4ybaWuwSiYrR5PvmUxndm8T8"
+                },
+                {
+                  "prim": "Pair",
+                  "args": [
+                    {
+                      "string": "KT19mzgsjrR2Er4rm4vuDqAcMfBF5DBMs2uq"
+                    },
+                    {
+                      "bytes": "050505030b"
+                    },
+                    {
+                      "int": "1000000"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      })
+      const rpcContract = await rpcContractProvider.at('KT19mzgsjrR2Er4rm4vuDqAcMfBF5DBMs2uq');
+      const storage = await rpcContract.storage() as any;
+      expect(rpcContract).toBeDefined();
+
+      const keyList = storage.keyMap;
+      expect(keyList.size).toEqual(3);
+      done();
+    })
+  })
 });

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -52,9 +52,16 @@
     "../packages/taquito": {
       "name": "@taquito/taquito",
       "version": "13.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
+        "@taquito/http-utils": "^13.0.1",
+        "@taquito/local-forging": "^13.0.1",
+        "@taquito/michel-codec": "^13.0.1",
+        "@taquito/michelson-encoder": "^13.0.1",
+        "@taquito/rpc": "^13.0.1",
+        "@taquito/utils": "^13.0.1",
         "bignumber.js": "^9.0.2",
         "rxjs": "^6.6.3"
       },
@@ -34972,6 +34979,12 @@
       "version": "file:../packages/taquito",
       "requires": {
         "@babel/types": "7.16.0",
+        "@taquito/http-utils": "^13.0.1",
+        "@taquito/local-forging": "^13.0.1",
+        "@taquito/michel-codec": "^13.0.1",
+        "@taquito/michelson-encoder": "^13.0.1",
+        "@taquito/rpc": "^13.0.1",
+        "@taquito/utils": "^13.0.1",
         "@types/bluebird": "^3.5.36",
         "@types/estree": "^0.0.50",
         "@types/jest": "^26.0.23",


### PR DESCRIPTION
Addresses reported bug that contract threw an error trying to access storage. 

removes the need for encodeObject method called when typechecking. 

checks if valid structure if needed in encodeObject or returns `void` if no error is thrown. 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
