### PR TITLE
feat(sapling): support proof generation from provingkey

### DIFF
--- a/docs/sapling.md
+++ b/docs/sapling.md
@@ -14,6 +14,10 @@ The spending key is used to spend tokens. It must be handled securely to prevent
 
 Taquito offers support for encrypted/unencrypted spending keys and mnemonics. Refer to the following link for more information: [InMemorySpendingKey](./sapling_in_memory_spending_key.md)
 
+**Proving key**
+
+The proving key can be used to generate proof without allowing tokens to be spent. Zero-knowledge proofs can be created with either the spending or the proving key. In cases where the device holding the spending key is computationally or memory-limited, such as a hardware wallet, proofs can be produced on a separate device using the proving key.
+
 **Viewing key**
 
 The viewing key is derived from the spending key. This key can be used to view all incoming and outgoing transactions. It must be handled securely to prevent a loss of privacy, as anyone accessing it can see the transaction history and the balance.
@@ -32,7 +36,9 @@ Here is an example on how to retrieve addresses: [InMemoryViewingKey](./sapling_
 The `@taquito/sapling` package provides a `SaplingToolkit` class that surfaces all of the Sapling capabilities, allowing it to read from a Sapling state and prepare transactions. 
 
 The constructor of the `SaplingToolkit` takes the following properties:
-- an instance of `InMemorySpendingKey` as the spending key is needed to prepare and sign transactions that spend tokens
+- the first parameter is an object containing:
+  - a `saplingSigner` property, an instance of `InMemorySpendingKey` as the spending key is needed to prepare and sign transactions that spend tokens.
+  - an optional `saplingProver` property which can be an instance of `InMemoryProvingKey` if you want to generate the proofs from a proving key rather than the spending key.
 - the second parameter is an object containing:
   - the address of the Sapling contract (string)
   - the size of the memo of the corresponding Sapling contract (number)
@@ -54,7 +60,7 @@ const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tE
 const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');
 
 const saplingToolkit = new SaplingToolkit(
-    inMemorySpendingKey, 
+    { saplingSigner: inMemorySpendingKey }, 
     { contractAddress: saplingContract.address, memoSize: 8 }, 
     readProvider
 )
@@ -83,7 +89,7 @@ const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 const readProvider = new RpcReadAdapter(new RpcClient('https://jakartanet.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
-    inMemorySpendingKey, 
+    { saplingSigner: inMemorySpendingKey }, 
     { contractAddress: 'KT1PMzy26CoN8B66ZQyAfVMgtcMR3ZuHnvJ9', memoSize: 8 }, 
     readProvider
 );
@@ -116,7 +122,7 @@ const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 const readProvider = new RpcReadAdapter(new RpcClient('https://jakartanet.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
-    inMemorySpendingKey, 
+    { saplingSigner: inMemorySpendingKey }, 
     { contractAddress: 'KT1PMzy26CoN8B66ZQyAfVMgtcMR3ZuHnvJ9', memoSize: 8 }, 
     readProvider
 );
@@ -161,12 +167,12 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
 const saplingToolkit = new SaplingToolkit(
-    inMemorySpendingKey, 
+    { saplingSigner: inMemorySpendingKey }, 
     { contractAddress: saplingContractAddress, memoSize: 8 }, 
     readProvider
 );
 
-inMemorySpendingKey.getInMemoryViewingKey()
+inMemorySpendingKey.getSaplingViewingKeyProvider()
   .then((inMemoryViewingKey) => {
     println(`Fetching a payment address for Alice (zet)...`);
     return inMemoryViewingKey.getAddress();
@@ -233,7 +239,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
 const saplingToolkit = new SaplingToolkit(
-    inMemorySpendingKey, 
+    { saplingSigner: inMemorySpendingKey }, 
     { contractAddress: saplingContractAddress, memoSize: 8 }, 
     readProvider
 );
@@ -291,7 +297,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
 const saplingToolkit = new SaplingToolkit(
-    inMemorySpendingKey, 
+    { saplingSigner: inMemorySpendingKey }, 
     { contractAddress: saplingContractAddress, memoSize: 8 }, 
     readProvider
 );
@@ -337,7 +343,7 @@ import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const tezos = new TezosToolkit('https://jakartanet.ecadinfra.com/');
-// Note: you need to set up your signer on the TezosToolkit as usual
+
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/docs/sapling_in_memory_viewing_key.md
+++ b/docs/sapling_in_memory_viewing_key.md
@@ -16,44 +16,47 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js
+```js live noInline
 import { InMemoryViewingKey } from '@taquito/sapling';
 
-const inMemoryViewingKey = await InMemoryViewingKey.fromSpendingKey(
-    'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L'
-)
+InMemoryViewingKey.fromSpendingKey(
+    'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L',
+).then((inMemoryViewingKey) => {
+    const viewingKey = inMemoryViewingKey.getFullViewingKey()
+    println(`The viewing key is ${viewingKey.toString('hex')}`);
+})
+.catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 
-const viewingKey = inMemoryViewingKey.getFullViewingKey()
 ```
 
 ### Instantiation from an encrypted spending key:
 
-```js
+```js live noInline
 import { InMemoryViewingKey } from '@taquito/sapling';
 
-const inMemoryViewingKey = await InMemoryViewingKey.fromSpendingKey(
+InMemoryViewingKey.fromSpendingKey(
     'MMXjN99mhomTm1Y5nQt8NfwEKTHWugsLtucX7oWrpsJd99qxGYJWP5aMb3t8zZaoKHQ898bLu9dwpog71bnjiDZfS9J9hWnTLCGm4fAjKKYeRuwTgCRjSdsP9znCPBUpCvyxeEFvUfamA5URrp8c7AaooAkobLW1PjNh2vjHobtiyNVTEtyTUWTLcjdxaiPbQWs3NaWvcb5Qr6z9MHhKrYNBHmsd9HBeRB2rVnvvL7pMc8f8zqyuXtmAuzMhiqPz3B4BRzuc8a2jkkoL14',
     'test' // password
-)
+).then((inMemoryViewingKey) => {
+    const viewingKey = inMemoryViewingKey.getFullViewingKey()
+    println(`The viewing key is ${viewingKey.toString('hex')}`);
+})
+.catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 
-const viewingKey = inMemoryViewingKey.getFullViewingKey()
 ```
 
 ## How to retrieve payment addresses from the viewing key
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js 
+```js live noInline 
 import { InMemoryViewingKey } from '@taquito/sapling';
+
 const inMemoryViewingKey = new InMemoryViewingKey(
     '000000000000000000977d725fc96387e8ec1e603e7ae60c6e63529fb84e36e126770e9db9899d7f2344259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed96271740b1d6fd523d71b15cd0b3d75644afbe9abfedb6883e299165665ab692c14ca5c835c61a0e53de553a751c78fbc42d5e7eca807fd441206651c84bf88de803efba837583145a5f338b1a7af8a5f9bec4783054f9d063d365f2352f72cbced95e0a'
 );
 
-const addressIndex0 = await viewingKeyProvider.getAddress();
-
-/* response is:
-{
-    address: 'zet12mVvzJ4QJhnNQetGHzdwTMcLgNrdC4SFact6BB5jpeqGAefWip3iGgEjvDA9z7b9Y',
-    addressIndex: 0,
-} */
+inMemoryViewingKey.getAddress()
+.then((address) => println(`The address is ${JSON.stringify(address, null, 2)}`))
+.catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```

--- a/integration-tests/sapling-batched-transactions.spec.ts
+++ b/integration-tests/sapling-batched-transactions.spec.ts
@@ -93,6 +93,9 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       const op = await saplingContract.methods.default([shieldedTx]).send({ amount: 6 });
       await op.confirmation();
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       done();
     });
@@ -190,6 +193,9 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       const op = await saplingContract.methods.default([tx]).send();
       await op.confirmation();
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       done();
     });

--- a/integration-tests/sapling-batched-transactions.spec.ts
+++ b/integration-tests/sapling-batched-transactions.spec.ts
@@ -47,23 +47,23 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       const mnemonic1: string = bip39.generateMnemonic();
       inMemorySpendingKey1 = await InMemorySpendingKey.fromMnemonic(mnemonic1);
-      inMemoryViewingKey1 = await inMemorySpendingKey1.getInMemoryViewingKey();
-      saplingToolkit1 = new SaplingToolkit(inMemorySpendingKey1, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      inMemoryViewingKey1 = await inMemorySpendingKey1.getSaplingViewingKeyProvider();
+      saplingToolkit1 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey1 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer1 = await saplingToolkit1.getSaplingTransactionViewer();
       paymentAddress1Index0 = (await inMemoryViewingKey1.getAddress(0)).address;
 
       const mnemonic2: string = bip39.generateMnemonic();
       inMemorySpendingKey2 = await InMemorySpendingKey.fromMnemonic(mnemonic2);
-      inMemoryViewingKey2 = await inMemorySpendingKey2.getInMemoryViewingKey();
-      saplingToolkit2 = new SaplingToolkit(inMemorySpendingKey2, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      inMemoryViewingKey2 = await inMemorySpendingKey2.getSaplingViewingKeyProvider();
+      saplingToolkit2 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey2 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer2 = await saplingToolkit2.getSaplingTransactionViewer();
       paymentAddress2Index0 = (await inMemoryViewingKey2.getAddress(0)).address;
       paymentAddress2Index5 = (await inMemoryViewingKey2.getAddress(5)).address;
       paymentAddress2Index8 = (await inMemoryViewingKey2.getAddress(8)).address;
 
       inMemorySpendingKey3 = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
-      inMemoryViewingKey3 = await inMemorySpendingKey3.getInMemoryViewingKey();
-      saplingToolkit3 = new SaplingToolkit(inMemorySpendingKey3, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      inMemoryViewingKey3 = await inMemorySpendingKey3.getSaplingViewingKeyProvider();
+      saplingToolkit3 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey3 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer3 = await saplingToolkit3.getSaplingTransactionViewer();
       paymentAddress3Index0 = (await inMemoryViewingKey3.getAddress(0)).address;
       paymentAddress3Index5 = (await inMemoryViewingKey3.getAddress(5)).address;

--- a/integration-tests/sapling-transactions-contract-with-multiple-sapling-states.spec.ts
+++ b/integration-tests/sapling-transactions-contract-with-multiple-sapling-states.spec.ts
@@ -76,7 +76,12 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
         left: shieldedTxLeft,
         right: shieldedTxRight
       }).send({ amount: 3 * 2 });
+      
       await op.confirmation();
+      
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       done();
     });

--- a/integration-tests/sapling-transactions-contract-with-multiple-sapling-states.spec.ts
+++ b/integration-tests/sapling-transactions-contract-with-multiple-sapling-states.spec.ts
@@ -47,9 +47,9 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       // When a contract has multiple sapling states, the `saplingId` parameter in the constructor of the `SaplingToolkit` must be defined
       // The `saplingId` parameter indicates which sapling pool we want to interact with
-      const aliceSaplingToolkitLeft = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdLeft }, new RpcReadAdapter(Tezos.rpc));
-      const aliceSaplingToolkitRight = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdRight }, new RpcReadAdapter(Tezos.rpc));
-      const aliceInMemoryViewingKey = await aliceInmemorySpendingKey.getInMemoryViewingKey();
+      const aliceSaplingToolkitLeft = new SaplingToolkit({ saplingSigner: aliceInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdLeft }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkitRight = new SaplingToolkit({ saplingSigner: aliceInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdRight }, new RpcReadAdapter(Tezos.rpc));
+      const aliceInMemoryViewingKey = await aliceInmemorySpendingKey.getSaplingViewingKeyProvider();
 
       // Fetch a payment address (zet) for Alice
       alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress()).address;
@@ -72,7 +72,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       // The amount MUST be specified in the send method in order to transfer the 6 tez to the shielded pool
       // In this contract, if the bool param is set to true, the "left" state is updated, if the bool is set to false, the "right" state is updated
       const op = await saplingContract.methodsObject.default({
-        0: true, 
+        0: true,
         left: shieldedTxLeft,
         right: shieldedTxRight
       }).send({ amount: 3 * 2 });
@@ -82,8 +82,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it("Verify that Alice's balance in the 'left' pool updated after the shielded tx", async (done) => {
-      const aliceSaplingToolkitLeft = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdLeft }, new RpcReadAdapter(Tezos.rpc));
-      const aliceSaplingToolkitRight = new SaplingToolkit(aliceInmemorySpendingKey, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdRight }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkitLeft = new SaplingToolkit({ saplingSigner: aliceInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdLeft }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkitRight = new SaplingToolkit({ saplingSigner: aliceInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize, saplingId: saplingStateIdRight }, new RpcReadAdapter(Tezos.rpc));
 
       const aliceTxViewerLeft = await aliceSaplingToolkitLeft.getSaplingTransactionViewer();
       const aliceBalanceLeft = await aliceTxViewerLeft.getBalance();

--- a/integration-tests/sapling-transactions-contract-with-single-state.spec.ts
+++ b/integration-tests/sapling-transactions-contract-with-single-state.spec.ts
@@ -74,6 +74,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const op = await saplingContract.methods.default([shieldedTx]).send({ amount: amountToAlice });
       await op.confirmation();
 
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+
       done();
     });
 
@@ -116,6 +120,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([tx]).send();
       await op.confirmation();
+
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       done();
     });
@@ -195,6 +203,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([unshieldedTx]).send();
       await op.confirmation(2);
+
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       const tezosUpdatedBalance = await Tezos.tz.getBalance(tezosAddress1);
       expect(tezosUpdatedBalance).toEqual(tezosInitialBalance.plus(new BigNumber(1000000)));

--- a/integration-tests/sapling-transactions-contract-with-single-state.spec.ts
+++ b/integration-tests/sapling-transactions-contract-with-single-state.spec.ts
@@ -32,7 +32,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const mnemonic: string = bip39.generateMnemonic();
       bobInmemorySpendingKey = await InMemorySpendingKey.fromMnemonic(mnemonic);
 
-      // Instanciate an InMemorySpendingKey from a spending key for Alice
+      // Instantiate an InMemorySpendingKey from a spending key for Alice
       aliceInMemorySpendingKey = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
 
       done();

--- a/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
@@ -63,6 +63,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const op = await saplingContract.methods.default([shieldedTx]).send({ amount: amountToAlice });
       await op.confirmation();
 
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+
       done();
     });
 
@@ -113,6 +117,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([tx]).send();
       await op.confirmation();
+
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       done();
     });
@@ -200,6 +208,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([unshieldedTx]).send();
       await op.confirmation(2);
+
+      expect(op.status).toEqual('applied');
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       const tezosUpdatedBalance = await Tezos.tz.getBalance(tezosAddress1);
       expect(tezosUpdatedBalance).toEqual(tezosInitialBalance.plus(new BigNumber(1000000)));

--- a/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
@@ -33,7 +33,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const mnemonic: string = bip39.generateMnemonic();
       bobInmemorySpendingKey = await InMemorySpendingKey.fromMnemonic(mnemonic);
 
-      // Instanciate an InMemorySpendingKey from a spending key for Alice
+      // Instantiate an InMemorySpendingKey from a spending key for Alice
       aliceInMemorySpendingKey = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
       aliceInMemoryProvingKey = new InMemoryProvingKey('44259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed962717403f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb709');
       

--- a/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
@@ -1,6 +1,6 @@
 import { ContractAbstraction, ContractProvider, RpcReadAdapter } from '@taquito/taquito';
 import { CONFIGS } from './config';
-import { InMemorySpendingKey, SaplingToolkit } from '@taquito/sapling';
+import { InMemorySpendingKey, SaplingToolkit, InMemoryProvingKey } from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from './data/single_sapling_state_contract_jakarta_michelson';
 import * as bip39 from 'bip39';
@@ -11,11 +11,12 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
   let bobInmemorySpendingKey: InMemorySpendingKey;
   let bobPaymentAddress: string
   let aliceInMemorySpendingKey: InMemorySpendingKey;
+  let aliceInMemoryProvingKey: InMemoryProvingKey;
   let alicePaymentAddress: string;
   const tezosAddress1 = 'tz1hDFKpVkT7jzYncaLma4vxh4Gg6JNqvdtB';
   const memoSize = 8;
 
-  describe(`Test interaction with sapling contract having a single sapling state using: ${rpc}`, () => {
+  describe(`Test producing proofs with a proving key rather than a spending key: ${rpc}`, () => {
 
     beforeAll(async (done) => {
       await setup();
@@ -34,31 +35,19 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       // Instanciate an InMemorySpendingKey from a spending key for Alice
       aliceInMemorySpendingKey = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
-
-      done();
-    });
-
-    it('Verify that the initial balance for Alice and Bob are 0 in the sapling contract', async (done) => {
-
-      const bobSaplingToolkit = new SaplingToolkit({ saplingSigner: bobInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
-      const bobTxViewer = await bobSaplingToolkit.getSaplingTransactionViewer();
-      const bobInitialBalance = await bobTxViewer.getBalance();
-
-      expect(bobInitialBalance).toEqual(new BigNumber(0));
-
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
-      const aliceInitialBalance = await aliceTxViewer.getBalance();
-
-      expect(aliceInitialBalance).toEqual(new BigNumber(0));
-
+      aliceInMemoryProvingKey = new InMemoryProvingKey('44259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed962717403f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb709');
+      
       done();
     });
 
     it('Verify that Alice can shield tokens', async (done) => {
 
       const amountToAlice = 3;
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey }, 
+        { contractAddress: saplingContract.address, memoSize }, 
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const aliceInMemoryViewingKey = await aliceInMemorySpendingKey.getSaplingViewingKeyProvider();
       // Fetch a payment address (zet) for Alice
       alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress()).address;
@@ -78,7 +67,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the shielded tx", async (done) => {
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey }, 
+        { contractAddress: saplingContract.address, memoSize }, 
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
@@ -106,7 +99,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const bobInMemoryViewingKey = await bobInmemorySpendingKey.getSaplingViewingKeyProvider();
       bobPaymentAddress = (await bobInMemoryViewingKey.getAddress()).address;
 
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey }, 
+        { contractAddress: saplingContract.address, memoSize }, 
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const tx = await aliceSaplingToolkit.prepareSaplingTransaction([{
         to: bobPaymentAddress,
         amount: amountToBob,
@@ -121,7 +118,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the sapling tx", async (done) => {
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey }, 
+        { contractAddress: saplingContract.address, memoSize }, 
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
@@ -184,7 +185,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Verify that Alice can unshield tokens', async (done) => {
 
       const amount = 1;
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey }, 
+        { contractAddress: saplingContract.address, memoSize }, 
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const tezosInitialBalance = await Tezos.tz.getBalance(tezosAddress1);
 
       const unshieldedTx = await aliceSaplingToolkit.prepareUnshieldedTransaction({
@@ -203,7 +208,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the unshielded tx", async (done) => {
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey }, 
+        { contractAddress: saplingContract.address, memoSize }, 
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 

--- a/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/sapling-transactions-proof-using-proving-key.spec.ts
@@ -13,7 +13,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
   let aliceInMemorySpendingKey: InMemorySpendingKey;
   let aliceInMemoryProvingKey: InMemoryProvingKey;
   let alicePaymentAddress: string;
-  const tezosAddress1 = 'tz1hDFKpVkT7jzYncaLma4vxh4Gg6JNqvdtB';
+  const tezosAddress = 'tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9m';
   const memoSize = 8;
 
   describe(`Test producing proofs with a proving key rather than a spending key: ${rpc}`, () => {
@@ -198,10 +198,10 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
         { contractAddress: saplingContract.address, memoSize }, 
         new RpcReadAdapter(Tezos.rpc)
       );
-      const tezosInitialBalance = await Tezos.tz.getBalance(tezosAddress1);
+      const tezosInitialBalance = await Tezos.tz.getBalance(tezosAddress);
 
       const unshieldedTx = await aliceSaplingToolkit.prepareUnshieldedTransaction({
-        to: tezosAddress1,
+        to: tezosAddress,
         amount
       })
 
@@ -213,7 +213,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
-      const tezosUpdatedBalance = await Tezos.tz.getBalance(tezosAddress1);
+      const tezosUpdatedBalance = await Tezos.tz.getBalance(tezosAddress);
       expect(tezosUpdatedBalance).toEqual(tezosInitialBalance.plus(new BigNumber(1000000)));
 
       done();

--- a/packages/taquito-sapling/src/sapling-forger/sapling-forger.ts
+++ b/packages/taquito-sapling/src/sapling-forger/sapling-forger.ts
@@ -57,7 +57,7 @@ export class SaplingForger {
     return Buffer.concat([
       desc.commitmentValue,
       desc.nullifier,
-      desc.randomizedPublicKey,
+      desc.publicKeyReRandomization,
       desc.proof,
       desc.signature,
     ]);
@@ -99,7 +99,7 @@ export class SaplingForger {
     return Buffer.concat([
       unsignedSpendDescription.commitmentValue,
       unsignedSpendDescription.nullifier,
-      unsignedSpendDescription.randomizedPublicKey,
+      unsignedSpendDescription.publicKeyReRandomization,
       unsignedSpendDescription.proof,
     ]);
   }

--- a/packages/taquito-sapling/src/sapling-keys/helpers.ts
+++ b/packages/taquito-sapling/src/sapling-keys/helpers.ts
@@ -1,0 +1,32 @@
+import { InvalidSpendingKey } from '../error';
+import toBuffer from 'typedarray-to-buffer';
+import { openSecretBox } from '@stablelib/nacl';
+import pbkdf2 from 'pbkdf2';
+import { Prefix, prefix, b58cdecode } from '@taquito/utils';
+
+export function decryptKey(spendingKey: string, password?: string) {
+  const keyArr = b58cdecode(spendingKey, prefix[Prefix.SASK]);
+  // exit first if no password and key is encrypted
+  if (!password && spendingKey.slice(0, 4) !== 'sask') {
+    throw new InvalidSpendingKey(spendingKey, 'no password Provided to decrypt');
+  }
+
+  if (password && spendingKey.slice(0, 4) !== 'sask') {
+    const salt = toBuffer(keyArr.slice(0, 8));
+    const encryptedSk = toBuffer(keyArr.slice(8));
+
+    const encryptionKey = pbkdf2.pbkdf2Sync(password, salt, 32768, 32, 'sha512');
+    const decrypted = openSecretBox(
+      new Uint8Array(encryptionKey),
+      new Uint8Array(24),
+      new Uint8Array(encryptedSk)
+    );
+    if (!decrypted) {
+      throw new InvalidSpendingKey(spendingKey, 'Encrypted Spending Key or Password Incorrect');
+    }
+
+    return toBuffer(decrypted);
+  } else {
+    return toBuffer(keyArr);
+  }
+}

--- a/packages/taquito-sapling/src/sapling-keys/in-memory-proving-key.ts
+++ b/packages/taquito-sapling/src/sapling-keys/in-memory-proving-key.ts
@@ -1,0 +1,67 @@
+import * as sapling from '@airgap/sapling-wasm';
+import { ParametersSpendProof, SaplingSpendDescription } from '../types';
+import { decryptKey } from './helpers';
+
+/**
+ * @description holds the proving key, create proof for spend descriptions
+ * The class can be instantiated from a proving key or a spending key
+ */
+export class InMemoryProvingKey {
+  #provingKey: Buffer;
+
+  constructor(provingKey: string) {
+    this.#provingKey = Buffer.from(provingKey, 'hex');
+  }
+
+  /**
+   * @description Allows to instantiate the InMemoryProvingKey from an encrypted/unencrypted spending key
+   *
+   * @param spendingKey Base58Check-encoded spending key
+   * @param password Optional password to decrypt the spending key
+   * @example
+   * ```
+   * await InMemoryProvingKey.fromSpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
+   * ```
+   *
+   */
+  static async fromSpendingKey(spendingKey: string, password?: string) {
+    const decodedSpendingKey = decryptKey(spendingKey, password);
+    const provingKey = await sapling.getProofAuthorizingKey(decodedSpendingKey);
+    return new InMemoryProvingKey(provingKey.toString('hex'));
+  }
+
+  /**
+   * @description Prepare an unsigned sapling spend description using the proving key
+   *
+   * @param parametersSpendProof.saplingContext The sapling proving context
+   * @param parametersSpendProof.address The address of the input
+   * @param parametersSpendProof.randomCommitmentTrapdoor The randomness of the commitment
+   * @param parametersSpendProof.publicKeyReRandomization The re-randomization of the public key
+   * @param parametersSpendProof.amount The value of the input
+   * @param parametersSpendProof.root The root of the merkle tree
+   * @param parametersSpendProof.witness The path of the commitment in the tree
+   * @param derivationPath tezos current standard 'm/'
+   * @returns The unsinged spend description
+   */
+  async prepareSpendDescription(
+    parametersSpendProof: Omit<ParametersSpendProof, 'spendingKey'>
+  ): Promise<Omit<SaplingSpendDescription, 'signature'>> {
+    const spendDescription = await sapling.prepareSpendDescriptionWithAuthorizingKey(
+      parametersSpendProof.saplingContext,
+      this.#provingKey,
+      parametersSpendProof.address,
+      parametersSpendProof.randomCommitmentTrapdoor,
+      parametersSpendProof.publicKeyReRandomization,
+      parametersSpendProof.amount,
+      parametersSpendProof.root,
+      parametersSpendProof.witness
+    );
+    return {
+      commitmentValue: spendDescription.cv,
+      nullifier: spendDescription.nf,
+      publicKeyReRandomization: spendDescription.rk,
+      rtAnchor: spendDescription.rt,
+      proof: spendDescription.proof,
+    };
+  }
+}

--- a/packages/taquito-sapling/src/sapling-keys/in-memory-viewing-key.ts
+++ b/packages/taquito-sapling/src/sapling-keys/in-memory-viewing-key.ts
@@ -24,7 +24,7 @@ export class InMemoryViewingKey {
    */
   static async fromSpendingKey(spendingKey: string, password?: string) {
     const inMemorySpendingkey = new InMemorySpendingKey(spendingKey, password);
-    return inMemorySpendingkey.getInMemoryViewingKey();
+    return inMemorySpendingkey.getSaplingViewingKeyProvider();
   }
 
   /**

--- a/packages/taquito-sapling/src/sapling-module-wrapper.ts
+++ b/packages/taquito-sapling/src/sapling-module-wrapper.ts
@@ -1,12 +1,6 @@
 import * as sapling from '@airgap/sapling-wasm';
 import { randomBytes } from '@stablelib/random';
-import {
-  ParametersOutputProof,
-  ParametersSpendProof,
-  ParametersSpendSig,
-  SaplingSpendDescription,
-  SaplingTransactionInput,
-} from './types';
+import { ParametersOutputProof } from './types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const saplingOutputParams = require('../saplingOutputParams');
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -45,28 +39,6 @@ export class SaplingWrapper {
     };
   }
 
-  async prepareSpendDescription(
-    parametersSpendProof: ParametersSpendProof
-  ): Promise<Omit<SaplingSpendDescription, 'signature'>> {
-    const spendDescription = await sapling.prepareSpendDescriptionWithSpendingKey(
-      parametersSpendProof.saplingContext,
-      parametersSpendProof.spendingKey,
-      parametersSpendProof.address,
-      parametersSpendProof.randomCommitmentTrapdoor,
-      parametersSpendProof.publicKeyReRandomization,
-      parametersSpendProof.amount,
-      parametersSpendProof.root,
-      parametersSpendProof.witness
-    );
-    return {
-      commitmentValue: spendDescription.cv,
-      nullifier: spendDescription.nf,
-      randomizedPublicKey: spendDescription.rk,
-      rtAnchor: spendDescription.rt,
-      proof: spendDescription.proof,
-    };
-  }
-
   async getDiversifiedFromRawPaymentAddress(decodedDestination: Uint8Array) {
     return sapling.getDiversifiedFromRawPaymentAddress(decodedDestination);
   }
@@ -75,40 +47,12 @@ export class SaplingWrapper {
     return sapling.deriveEphemeralPublicKey(diversifier, esk);
   }
 
-  async signSpendDescription(
-    parametersSpendSig: ParametersSpendSig
-  ): Promise<SaplingTransactionInput> {
-    const signedSpendDescription = await sapling.signSpendDescription(
-      {
-        cv: parametersSpendSig.unsignedSpendDescription.commitmentValue,
-        rt: parametersSpendSig.unsignedSpendDescription.rtAnchor,
-        nf: parametersSpendSig.unsignedSpendDescription.nullifier,
-        rk: parametersSpendSig.unsignedSpendDescription.randomizedPublicKey,
-        proof: parametersSpendSig.unsignedSpendDescription.proof,
-      },
-      parametersSpendSig.spendingKey,
-      parametersSpendSig.publicKeyReRandomization,
-      parametersSpendSig.hash
-    );
-    return {
-      commitmentValue: signedSpendDescription.cv,
-      nullifier: signedSpendDescription.nf,
-      randomizedPublicKey: signedSpendDescription.rk,
-      proof: signedSpendDescription.proof,
-      signature: signedSpendDescription.spendAuthSig,
-    };
-  }
-
   async getPkdFromRawPaymentAddress(destination: Uint8Array) {
     return sapling.getPkdFromRawPaymentAddress(destination);
   }
 
   async keyAgreement(p: Buffer, sk: Buffer) {
     return sapling.keyAgreement(p, sk);
-  }
-
-  async getPaymentAddressFromViewingKey(vk: Buffer) {
-    return (await sapling.getPaymentAddressFromViewingKey(vk)).raw;
   }
 
   async createBindingSignature(

--- a/packages/taquito-sapling/src/taquito-sapling.ts
+++ b/packages/taquito-sapling/src/taquito-sapling.ts
@@ -41,12 +41,12 @@ export { InMemoryProvingKey } from './sapling-keys/in-memory-proving-key';
  * @description Class that surfaces all of the sapling capability allowing to read from a sapling state and prepare transactions
  *
  * @param keys.saplingSigner Holds the sapling spending key
- * @param keys.saplingProver Optional Allows to generate the proofs with the proving key rather than the spending key
+ * @param keys.saplingProver (Optional) Allows to generate the proofs with the proving key rather than the spending key
  * @param saplingContractDetails Contains the address of the sapling contract, the memo size, and an optional sapling id that must be defined if the sapling contract contains more than one sapling state
  * @param readProvider Allows to read data from the blockchain
- * @param packer Optional. Allows packing data. Use the `MichelCodecPacker` by default.
- * @param saplingForger Optional. Allows serializing the sapling transactions. Use the `SaplingForger` by default.
- * @param saplingTxBuilder Optional. Allows to prepare the sapling transactions. Use the `SaplingTransactionBuilder` by default.
+ * @param packer (Optional) Allows packing data. Use the `MichelCodecPacker` by default.
+ * @param saplingForger (Optional) Allows serializing the sapling transactions. Use the `SaplingForger` by default.
+ * @param saplingTxBuilder (Optional) Allows to prepare the sapling transactions. Use the `SaplingTransactionBuilder` by default.
  * @example
  * ```
  * const inMemorySpendingKey = await InMemorySpendingKey.fromMnemonic('YOUR_MNEMONIC');

--- a/packages/taquito-sapling/src/types.ts
+++ b/packages/taquito-sapling/src/types.ts
@@ -39,7 +39,7 @@ export interface Ciphertext {
 export interface SaplingTransactionInput {
   commitmentValue: Buffer;
   nullifier: Buffer;
-  randomizedPublicKey: Buffer;
+  publicKeyReRandomization: Buffer;
   proof: Buffer;
   signature: Buffer;
 }
@@ -65,7 +65,6 @@ export type ParametersUnshieldedTransaction = Omit<ParametersSaplingTransaction,
 
 export interface ParametersSpendProof {
   saplingContext: number;
-  spendingKey: Uint8Array;
   address: Uint8Array;
   randomCommitmentTrapdoor: Uint8Array;
   publicKeyReRandomization: Buffer;
@@ -75,7 +74,6 @@ export interface ParametersSpendProof {
 }
 
 export interface ParametersSpendSig {
-  spendingKey: Uint8Array;
   publicKeyReRandomization: Buffer;
   unsignedSpendDescription: Omit<SaplingSpendDescription, 'signature'>;
   hash: Uint8Array;

--- a/packages/taquito-sapling/test/data/sapling_test_data.ts
+++ b/packages/taquito-sapling/test/data/sapling_test_data.ts
@@ -194,7 +194,7 @@ export const spendDescription = [
       '208c4e296a95c34bf3886f62b3eaabc3c28feaf8067bf493030ae1f689fc4d85',
       'hex'
     ),
-    randomizedPublicKey: Buffer.from(
+    publicKeyReRandomization: Buffer.from(
       '2658565805aeb044d7a5c7cc1b65fe967e4b5fcd8f3ae42758bf014150c24c5e',
       'hex'
     ),

--- a/packages/taquito-sapling/test/sapling-keys/in-memory-proving-key.spec.ts
+++ b/packages/taquito-sapling/test/sapling-keys/in-memory-proving-key.spec.ts
@@ -1,0 +1,28 @@
+import { InMemoryProvingKey } from '../../src/sapling-keys/in-memory-proving-key';
+
+describe('InMemoryProvingKey', () => {
+  it('Should be instantiable with provingKey key', async (done) => {
+    const inMemoryProvingKey = new InMemoryProvingKey(
+      '44259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed962717403f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb709'
+    );
+    expect(inMemoryProvingKey).toBeDefined();
+    done();
+  });
+
+  it('Should be instantiable with encrypted spending key', async (done) => {
+    const inMemoryProvingKey = await InMemoryProvingKey.fromSpendingKey(
+      'MMXjN99mhomTm1Y5nQt8NfwEKTHWugsLtucX7oWrpsJd99qxGYJWP5aMb3t8zZaoKHQ898bLu9dwpog71bnjiDZfS9J9hWnTLCGm4fAjKKYeRuwTgCRjSdsP9znCPBUpCvyxeEFvUfamA5URrp8c7AaooAkobLW1PjNh2vjHobtiyNVTEtyTUWTLcjdxaiPbQWs3NaWvcb5Qr6z9MHhKrYNBHmsd9HBeRB2rVnvvL7pMc8f8zqyuXtmAuzMhiqPz3B4BRzuc8a2jkkoL14',
+      'test'
+    );
+    expect(inMemoryProvingKey).toBeDefined();
+    done();
+  });
+
+  it('Should be instantiable with unencrypted spending key', async (done) => {
+    const inMemoryProvingKey = await InMemoryProvingKey.fromSpendingKey(
+      'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L'
+    );
+    expect(inMemoryProvingKey).toBeDefined();
+    done();
+  });
+});

--- a/packages/taquito-sapling/test/sapling-keys/in-memory-spending-key.spec.ts
+++ b/packages/taquito-sapling/test/sapling-keys/in-memory-spending-key.spec.ts
@@ -7,7 +7,7 @@ describe('InMemorySpendingKey', () => {
       'MMXjN99mhomTm1Y5nQt8NfwEKTHWugsLtucX7oWrpsJd99qxGYJWP5aMb3t8zZaoKHQ898bLu9dwpog71bnjiDZfS9J9hWnTLCGm4fAjKKYeRuwTgCRjSdsP9znCPBUpCvyxeEFvUfamA5URrp8c7AaooAkobLW1PjNh2vjHobtiyNVTEtyTUWTLcjdxaiPbQWs3NaWvcb5Qr6z9MHhKrYNBHmsd9HBeRB2rVnvvL7pMc8f8zqyuXtmAuzMhiqPz3B4BRzuc8a2jkkoL14',
       'test'
     );
-    const viewerKeyProvider = await SaplingKeyProvider.getInMemoryViewingKey();
+    const viewerKeyProvider = await SaplingKeyProvider.getSaplingViewingKeyProvider();
     expect(viewerKeyProvider.getFullViewingKey().toString('hex')).toEqual(
       '000000000000000000977d725fc96387e8ec1e603e7ae60c6e63529fb84e36e126770e9db9899d7f2344259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed96271740b1d6fd523d71b15cd0b3d75644afbe9abfedb6883e299165665ab692c14ca5c835c61a0e53de553a751c78fbc42d5e7eca807fd441206651c84bf88de803efba837583145a5f338b1a7af8a5f9bec4783054f9d063d365f2352f72cbced95e0a'
     );
@@ -55,48 +55,13 @@ describe('InMemorySpendingKey', () => {
       ].join(' '),
       'm/'
     );
-    const viewer = await SaplingKeyProvider.getInMemoryViewingKey();
+    const viewer = await SaplingKeyProvider.getSaplingViewingKeyProvider();
     expect(viewer.getFullViewingKey().toString('hex')).toEqual(
       '000000000000000000977d725fc96387e8ec1e603e7ae60c6e63529fb84e36e126770e9db9899d7f2344259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed96271740b1d6fd523d71b15cd0b3d75644afbe9abfedb6883e299165665ab692c14ca5c835c61a0e53de553a751c78fbc42d5e7eca807fd441206651c84bf88de803efba837583145a5f338b1a7af8a5f9bec4783054f9d063d365f2352f72cbced95e0a'
     );
     done();
   });
-  it('should return base 58 encoded spending key with appended prefix of the decrypted spending key', async (done) => {
-    const SaplingKeyProvider = await InMemorySpendingKey.fromMnemonic(
-      [
-        'leopard',
-        'crouch',
-        'simple',
-        'blind',
-        'castle',
-        'they',
-        'elder',
-        'enact',
-        'slow',
-        'rate',
-        'mad',
-        'blanket',
-        'saddle',
-        'tail',
-        'silk',
-        'fury',
-        'quarter',
-        'obscure',
-        'interest',
-        'exact',
-        'veteran',
-        'volcano',
-        'fabric',
-        'cherry',
-      ].join(' '),
-      'm/'
-    );
-    const sk = SaplingKeyProvider.getSpendingKey();
-    expect(sk).toEqual(
-      'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L'
-    );
-    done();
-  });
+
   it('should throw error if encrypted with no password', (done) => {
     expect(
       () =>
@@ -104,6 +69,18 @@ describe('InMemorySpendingKey', () => {
           'MMXjN99mhomTm1Y5nQt8NfwEKTHWugsLtucX7oWrpsJd99qxGYJWP5aMb3t8zZaoKHQ898bLu9dwpog71bnjiDZfS9J9hWnTLCGm4fAjKKYeRuwTgCRjSdsP9znCPBUpCvyxeEFvUfamA5URrp8c7AaooAkobLW1PjNh2vjHobtiyNVTEtyTUWTLcjdxaiPbQWs3NaWvcb5Qr6z9MHhKrYNBHmsd9HBeRB2rVnvvL7pMc8f8zqyuXtmAuzMhiqPz3B4BRzuc8a2jkkoL14'
         )
     ).toThrowError(InvalidSpendingKey);
+    done();
+  });
+
+  it('Should return the proving key', async (done) => {
+    const SaplingKeyProvider = new InMemorySpendingKey(
+      'MMXjN99mhomTm1Y5nQt8NfwEKTHWugsLtucX7oWrpsJd99qxGYJWP5aMb3t8zZaoKHQ898bLu9dwpog71bnjiDZfS9J9hWnTLCGm4fAjKKYeRuwTgCRjSdsP9znCPBUpCvyxeEFvUfamA5URrp8c7AaooAkobLW1PjNh2vjHobtiyNVTEtyTUWTLcjdxaiPbQWs3NaWvcb5Qr6z9MHhKrYNBHmsd9HBeRB2rVnvvL7pMc8f8zqyuXtmAuzMhiqPz3B4BRzuc8a2jkkoL14',
+      'test'
+    );
+    const viewerKeyProvider = await SaplingKeyProvider.getProvingKey();
+    expect(viewerKeyProvider).toEqual(
+      '44259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed962717403f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb709'
+    );
     done();
   });
 });

--- a/packages/taquito-sapling/test/sapling-tx-builder/sapling-module-wrapper.spec.ts
+++ b/packages/taquito-sapling/test/sapling-tx-builder/sapling-module-wrapper.spec.ts
@@ -8,11 +8,11 @@ describe('SaplingWrapper', () => {
     expect(bytes.length).toEqual(24);
   });
 
-  /* it('randR', async (done) => {
+  it('randR', async (done) => {
     const randR = await saplingWrapper.randR();
     expect(randR.length).toEqual(32);
     done();
-  }); */
+  });
 
   it('getOutgoingViewingKey', async (done) => {
     const vk = Buffer.from(
@@ -71,57 +71,6 @@ describe('SaplingWrapper', () => {
     const epk = await saplingWrapper.deriveEphemeralPublicKey(diversifier, esk);
     expect(epk.toString('hex')).toEqual(
       '623f1e9caa60c50d4342edaaf55a71782256f125f7d3e178c8540843be892d56'
-    );
-    done();
-  });
-
-  /* it('signSpendDescription', async (done) => {
-    const spendDescription = {
-      commitmentValue: Buffer.from('a61b321b9b3c12d31a8f1cadad2fec37e219bea726998d9c3f311fd91092f859', 'hex'),
-      proof: Buffer.from(
-        'b5a14dae39e36166c41ce84282cad0452dcc822caa12752f039a8b3d5c27a3624307081fec681dc0a8c8a14f5bbe897085ffc156196f1ee17655a9f3a48c412f36bb694227c81dcb5e514842f4a1259f7a8daf52c5512ea5e5fd810d9618b90e00fd8883a36575781aa468bfe5dada63c9139926a78d083edef99d1a1f13280e0ba9c90d6cbd4d9ffe46767a0573a8dfa989c95bb1c213808a617f4c2a0f026c802523db6d90fb3e5f0ac48d6dbe55437339ec4547f0fb93ee6be672c1b8b541',
-        'hex'
-      ),
-      nullifier: Buffer.from('a0678d948b2f39c8fe723dc0ab2302107de48ec746adb2fac636c3a5dec50de3', 'hex'),
-      randomizedPublicKey: Buffer.from('75a3311108abd110c767d19cca8e657cd6b58412868f48e05da04d0903ab95d3', 'hex'),
-      rtAnchor: Buffer.from('25fa83c26fdb118353e9442c7cedd6919147d0029bc4bef236638396c2824557', 'hex'),
-    };
-    const spendingKey = Buffer.from(
-      '000000000000000000977d725fc96387e8ec1e603e7ae60c6e63529fb84e36e126770e9db9899d7f233fe1deabce96fe39efe6cbe315755ad2938b3a7e112c61305a0ba1ed7ed561053f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb70935c61a0e53de553a751c78fbc42d5e7eca807fd441206651c84bf88de803efba837583145a5f338b1a7af8a5f9bec4783054f9d063d365f2352f72cbced95e0a',
-      'hex'
-    );
-    const publicKeyReRandomization = Buffer.from(
-      'f2e0532579a9f484b94cfe536a649b82d48d38f398d013eebd9fd6aa12d79204',
-      'hex'
-    );
-    const sighash = Buffer.from(
-      '14bf34283c865524157102962a1d58051b0ce026b5e29824114b023fc82dd9fa',
-      'hex'
-    );
-    const signedSpendDesc = await saplingWrapper.signSpendDescription({
-      spendingKey,
-      publicKeyReRandomization,
-      hash: sighash,
-      unsignedSpendDescription: spendDescription,
-    });
-
-    expect(signedSpendDesc.signature.length).toEqual(64); // the returned value is changing
-    expect(signedSpendDesc.commitmentValue).toEqual(spendDescription.commitmentValue);
-    expect(signedSpendDesc.proof).toEqual(spendDescription.proof);
-    expect(signedSpendDesc.randomizedPublicKey).toEqual(spendDescription.randomizedPublicKey);
-    expect(signedSpendDesc.nullifier).toEqual(spendDescription.nullifier);
-
-    done();
-  }); */
-
-  it('getPaymentAddressFromViewingKey', async (done) => {
-    const vk = Buffer.from(
-      '000000000000000000977d725fc96387e8ec1e603e7ae60c6e63529fb84e36e126770e9db9899d7f2344259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed96271740b1d6fd523d71b15cd0b3d75644afbe9abfedb6883e299165665ab692c14ca5c835c61a0e53de553a751c78fbc42d5e7eca807fd441206651c84bf88de803efba837583145a5f338b1a7af8a5f9bec4783054f9d063d365f2352f72cbced95e0a',
-      'hex'
-    );
-    const paymentAddress = await saplingWrapper.getPaymentAddressFromViewingKey(vk);
-    expect(paymentAddress.toString('hex')).toEqual(
-      '2c8e683029bd1c1ff25882bb0353379487fcf142bbaef37d2b21dc3836f929c6fa9181e2a0d7b72406c148'
     );
     done();
   });

--- a/packages/taquito-sapling/test/taquito-sapling.spec.ts
+++ b/packages/taquito-sapling/test/taquito-sapling.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { MichelCodecPacker } from '@taquito/taquito';
 import BigNumber from 'bignumber.js';
 import { SaplingForger } from '../src/sapling-forger/sapling-forger';
@@ -62,7 +63,7 @@ describe('SaplingToolkit', () => {
     });
 
     saplingToolkit = new SaplingToolkit(
-      inMemorySpendingKey,
+      { saplingSigner: inMemorySpendingKey },
       {
         contractAddress: 'KT1G2kvdfPoavgR6Fjdd68M2vaPk14qJ8bhC',
         saplingId: '0',
@@ -78,7 +79,7 @@ describe('SaplingToolkit', () => {
   it('should be instantiable', async (done) => {
     expect(
       new SaplingToolkit(
-        inMemorySpendingKey,
+        { saplingSigner: inMemorySpendingKey },
         {
           contractAddress: 'KT1G2kvdfPoavgR6Fjdd68M2vaPk14qJ8bhC',
           saplingId: '0',
@@ -102,7 +103,7 @@ describe('SaplingToolkit', () => {
 
   it('should return an instance of SaplingTransactionViewer based on contract address', async (done) => {
     const saplingToolkit2 = new SaplingToolkit(
-      inMemorySpendingKey,
+      { saplingSigner: inMemorySpendingKey },
       {
         contractAddress: 'KT1G2kvdfPoavgR6Fjdd68M2vaPk14qJ8bhC',
         memoSize: 8,
@@ -181,7 +182,7 @@ describe('SaplingToolkit', () => {
 
   it('Should prepare a valid shielded transaction based on contractAddress', async (done) => {
     const saplingToolkit2 = new SaplingToolkit(
-      inMemorySpendingKey,
+      { saplingSigner: inMemorySpendingKey },
       {
         contractAddress: 'KT1G2kvdfPoavgR6Fjdd68M2vaPk14qJ8bhC',
         memoSize: 8,
@@ -300,7 +301,7 @@ describe('SaplingToolkit', () => {
             '8b4c7f168dc6775f1e74fff11b977261451655eb586d499487d95d56e750f4576f2ca3d28e60250dddbdc8e7442348feab1ad28b05a34861ec537595e047841d1181f90839bc5a13e3fbc7761e7daf4a2837893854f9d90a0368c9e616b20e5f17e78a9a8a8e0edf6325c78610e51315c14a36f2b2ec74ade40ab26819d98fa9fbd01bc7749c83dc76bd6e450693b1ffa91aa2dae3cb98cd6642e90b0b600ff69dbb44b9fbbfde8e31fffce88b05da332718e10f1b08c5fd53e826202b298d22',
             'hex'
           ),
-          randomizedPublicKey: Buffer.from(
+          publicKeyReRandomization: Buffer.from(
             'a2a5df5089012f50daaf9d5a1e37c9d6fa07b136c33c799dbfb685ba9632ba39',
             'hex'
           ),
@@ -375,7 +376,7 @@ describe('SaplingToolkit', () => {
             '95a16310de04873148debfcf1b0c673f704646d1dc374d60dea4eebfef2bf6f8bec192f5159a79a06e1d482af2466536abb424b8f261325606040a91e828b4f2fe1d1a6f87dceb65e0adfe5f0c1ca9a1f2548a9c53fe95b04f1523233e8a215f0178ba36283f0729421c8d422a047961b343ec57ecc54f212bc74e33582258da748f48910919a1fe33fcedfd6a3f1ffcab0ca7f8f5133c02ee62264e359f30f649c9ef74512aa768f822ecbfa083e841003e8d705cccf0e776f4a9c7ca27ebb7',
             'hex'
           ),
-          randomizedPublicKey: Buffer.from(
+          publicKeyReRandomization: Buffer.from(
             'e262c46c3371de572b54fbd37d578df69cf9f299bea2d7ee94fc0435603559bb',
             'hex'
           ),
@@ -450,7 +451,7 @@ describe('SaplingToolkit', () => {
             '832f43780d521fec8c39d7dc19ddc33ec1be89e357aece1a9c6414f352eeb79b920b66e373fb869b16acad8ff52ea4858d701f2bf0a2b0e6ee2ef29b54191a32c951c7b66e24f9ebb680c6d69a7098ecc892623f8c2d99bb5ee91b7225268c6e0e02bd671a0669770aca4b905aa33a3139cbb62e92a5a57ef4d11251b7ba09980e3e7ce384366d366296fc9e67581edaa638fe89c61ad92350a7141266533e73966c6c0760870c357f1a5227bf10e04d12e362d23d1d90ce3d6320ffabf991d2',
             'hex'
           ),
-          randomizedPublicKey: Buffer.from(
+          publicKeyReRandomization: Buffer.from(
             '9122255f466c87a4f33806b34ee182fc984f1016b577fe0264d2121daf8514af',
             'hex'
           ),
@@ -551,7 +552,7 @@ describe('SaplingToolkit', () => {
             '87201838d863e025e9f51ed5a93c633d87ab07d4b24661a66f8cb56e3ab890244c063f4c371a40297f79f903e014f68991a1341b33129a6a5058ea6babd12df993e6e5e9a43f284b1c6df95b1764648c69604ae09e1b3170e71d395097d6739311b942cecde7c95ff25f3cf5a35b0ba8e794cc4351d7bdb8c3b59412a8daa57ab24966cf572c60e3082bd0edcd54ce79ae7f54bb1502bad403e882f53a060d12baacd1bf08ef4f9a641a6c105cfb8c199c8a56186c6d5e2277b9f0a6dae67cf6',
             'hex'
           ),
-          randomizedPublicKey: Buffer.from(
+          publicKeyReRandomization: Buffer.from(
             '4e5013ab2f07f645fb098f21845da78b389328dd0e6554256c9dec0ac74da913',
             'hex'
           ),

--- a/website/src/theme/CodeBlock/index.js
+++ b/website/src/theme/CodeBlock/index.js
@@ -30,7 +30,7 @@ import { Tzip12Module, tzip12 } from "@taquito/tzip12";
 import { Schema, ParameterSchema } from "@taquito/michelson-encoder";
 import { Parser, packDataBytes } from '@taquito/michel-codec';
 import { RpcClient } from '@taquito/rpc';
-import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
+import { SaplingToolkit, InMemorySpendingKey, InMemoryViewingKey } from '@taquito/sapling';
 import { ThanosWallet } from '@thanos-wallet/dapp';
 import TransportWebHID from "@ledgerhq/hw-transport-webhid";
 import Playground from '@theme/Playground';
@@ -134,7 +134,8 @@ export default ({
           RpcReadAdapter,
           SaplingToolkit,
           RpcClient,
-          InMemorySpendingKey
+          InMemorySpendingKey,
+          InMemoryViewingKey
          }}
         code={children.trim()}
         theme={prism.theme || defaultTheme}


### PR DESCRIPTION
Implemented an InMemorySpendingKey class that allows producing proofa independently from the
spending key. Did some refactor and renaming also.

BREAKING CHANGE: The first parameter of the SaplingToolkit class changed for an object accepting an
optional InMemorySpendingKey

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
