### PR TITLE
feat(local-forging): support EMIT instruction

### DIFF
--- a/integration-tests/local-forging.spec.ts
+++ b/integration-tests/local-forging.spec.ts
@@ -1,10 +1,11 @@
 import { CONFIGS } from "./config";
-import { commonCases } from '../packages/taquito-local-forging/test/allTestsCases';
+import { commonCases, kathmanduCases } from '../packages/taquito-local-forging/test/allTestsCases';
 import { LocalForger, ProtocolsHash } from '@taquito/local-forging'
-import { TezosToolkit } from "@taquito/taquito";
+import { Protocols, TezosToolkit } from "@taquito/taquito";
 
 CONFIGS().forEach(({ rpc, protocol }) => {
     const Tezos = new TezosToolkit(rpc);
+    const kathmandunetAndMondaynet = protocol === Protocols.ProtoALpha || protocol === Protocols.PtKathman ? test: test.skip;
 
     describe(`Test local forger: ${rpc}`, () => {
 
@@ -12,6 +13,20 @@ CONFIGS().forEach(({ rpc, protocol }) => {
         commonCases.forEach(({ name, operation, expected }) => {
 
             it(`Should give the same result as when forging with the rpc: ${name} (${rpc})`, async done => {
+                const localForger = new LocalForger(protocol as unknown as ProtocolsHash);
+
+                const result = await localForger.forge(operation);
+                const rpcResult = await Tezos.rpc.forgeOperations(operation);
+                expect(result).toEqual(rpcResult);
+                expect(await localForger.parse(result)).toEqual(expected || operation);
+
+                done();
+            });
+        });
+
+        kathmanduCases.forEach(({ name, operation, expected }) => {
+
+            kathmandunetAndMondaynet(`Should give the same result as when forging with the rpc: ${name} (${rpc})`, async done => {
                 const localForger = new LocalForger(protocol as unknown as ProtocolsHash);
 
                 const result = await localForger.forge(operation);

--- a/packages/taquito-local-forging/src/constants.ts
+++ b/packages/taquito-local-forging/src/constants.ts
@@ -202,6 +202,7 @@ export const opMapping: { [key: string]: string } = {
   '94': 'tx_rollup_l2_address',
   '95': 'MIN_BLOCK_TIME',
   '96': 'sapling_transaction',
+  '97': 'EMIT',
 };
 
 export const opMappingReverse = (() => {

--- a/packages/taquito-local-forging/test/allTestsCases.ts
+++ b/packages/taquito-local-forging/test/allTestsCases.ts
@@ -31,6 +31,7 @@ import {
 import { codeViewsTopLevel, storageViewsTopLevel } from './data/contract_views_top_level';
 import { ForgeParams } from '../src/interface';
 import { MichelsonV1Expression, OpKind } from '@taquito/rpc';
+import { emitCode } from './data/code_with_emit';
 
 function extractOp(
   startIndex: number,
@@ -1362,6 +1363,55 @@ export const commonCases: TestCase[] = [
           content: '1234',
         },
       ] as any,
+    },
+  },
+];
+
+export const kathmanduCases: TestCase[] = [
+  ...extractOp(150, 151, opMapping).map((op): TestCase => {
+    return {
+      name: `Origination operation (${op})`,
+      operation: {
+        branch: 'BLzyjjHKEKMULtvkpSHxuZxx6ei6fpntH2BTkYZiLgs8zLVstvX',
+        contents: [
+          {
+            kind: OpKind.ORIGINATION,
+            counter: '1',
+            source: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+            fee: '10000',
+            gas_limit: '10',
+            storage_limit: '10',
+            balance: '0',
+            script: {
+              code: genericCode(op) as MichelsonV1Expression[],
+              storage: genericStorage,
+            },
+          },
+        ],
+      },
+    };
+  }),
+  {
+    name: `Origination of a contract that contains the instructions EMIT`,
+    operation: {
+      branch: 'BMV9bffK5yjWCJgUJBsoTRifb4SsAYbkCVwVkKbJHffJYn7ePBL',
+      contents: [
+        {
+          kind: OpKind.ORIGINATION,
+          counter: '94141',
+          source: 'tz2WH1zahKo2KiS1gcHBhNFTURPfW1Vk7qpE',
+          fee: '603',
+          gas_limit: '1526',
+          storage_limit: '377',
+          balance: '0',
+          script: {
+            code: emitCode,
+            storage: {
+              prim: 'Unit',
+            },
+          },
+        },
+      ],
     },
   },
 ];

--- a/packages/taquito-local-forging/test/data/code_with_emit.ts
+++ b/packages/taquito-local-forging/test/data/code_with_emit.ts
@@ -1,0 +1,115 @@
+export const emitCode = [
+  {
+    prim: 'parameter',
+    args: [
+      {
+        prim: 'unit',
+      },
+    ],
+  },
+  {
+    prim: 'storage',
+    args: [
+      {
+        prim: 'unit',
+      },
+    ],
+  },
+  {
+    prim: 'code',
+    args: [
+      [
+        {
+          prim: 'DROP',
+        },
+        {
+          prim: 'UNIT',
+        },
+        {
+          prim: 'PUSH',
+          args: [
+            {
+              prim: 'string',
+            },
+            {
+              string: 'right',
+            },
+          ],
+        },
+        {
+          prim: 'RIGHT',
+          args: [
+            {
+              prim: 'nat',
+            },
+          ],
+        },
+        {
+          prim: 'EMIT',
+          annots: ['%tag1'],
+        },
+        {
+          prim: 'PUSH',
+          args: [
+            {
+              prim: 'nat',
+            },
+            {
+              int: '2',
+            },
+          ],
+        },
+        {
+          prim: 'LEFT',
+          args: [
+            {
+              prim: 'string',
+            },
+          ],
+        },
+        {
+          prim: 'EMIT',
+          args: [
+            {
+              prim: 'or',
+              args: [
+                {
+                  prim: 'nat',
+                  annots: ['%int'],
+                },
+                {
+                  prim: 'string',
+                  annots: ['%str'],
+                },
+              ],
+            },
+          ],
+          annots: ['%tag2'],
+        },
+        {
+          prim: 'NIL',
+          args: [
+            {
+              prim: 'operation',
+            },
+          ],
+        },
+        {
+          prim: 'SWAP',
+        },
+        {
+          prim: 'CONS',
+        },
+        {
+          prim: 'SWAP',
+        },
+        {
+          prim: 'CONS',
+        },
+        {
+          prim: 'PAIR',
+        },
+      ],
+    ],
+  },
+];

--- a/packages/taquito-local-forging/test/taquito-local-forging.spec.ts
+++ b/packages/taquito-local-forging/test/taquito-local-forging.spec.ts
@@ -1,6 +1,6 @@
 import { LocalForger } from '../src/taquito-local-forging';
 import { ticketCode3, ticketStorage3 } from './data/code_with_ticket';
-import { commonCases } from './allTestsCases';
+import { commonCases, kathmanduCases } from './allTestsCases';
 import {
   InvalidOperationSchemaError,
   InvalidBlockHashError,
@@ -12,6 +12,17 @@ import { InvalidOperationKindError } from '@taquito/utils';
 describe('Forge and parse operations default protocol', () => {
   const localForger = new LocalForger();
   commonCases.forEach(({ name, operation, expected }) => {
+    test(`Common test: ${name}`, async (done) => {
+      const result = await localForger.forge(operation);
+      expect(await localForger.parse(result)).toEqual(expected || operation);
+      done();
+    });
+  });
+});
+
+describe('Forge and parse operations kathmandu protocol', () => {
+  const localForger = new LocalForger();
+  kathmanduCases.forEach(({ name, operation, expected }) => {
     test(`Common test: ${name}`, async (done) => {
       const result = await localForger.forge(operation);
       expect(await localForger.parse(result)).toEqual(expected || operation);


### PR DESCRIPTION
Added support to forge/parse the new EMIT instruction in Kathmandu

re #1742

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
