### PR TITLE
fix(contract operation): replace consumed_gas with consumed_milligas

### DIFF
--- a/integration-tests/contract-batch.spec.ts
+++ b/integration-tests/contract-batch.spec.ts
@@ -25,6 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             const op = await batch.send();
             await op.confirmation();
             expect(op.status).toEqual('applied');
+            expect(Number(op.consumedGas)).toBeGreaterThan(0);
             done();
         });
 

--- a/integration-tests/contract-register-global-constant.spec.ts
+++ b/integration-tests/contract-register-global-constant.spec.ts
@@ -33,6 +33,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       expect(op.gasLimit).toEqual(1400);
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
       expect(op.status).toEqual('applied');
+      expect(Number(op.consumedGas)).toBeGreaterThan(0);
 
       done();
     });

--- a/integration-tests/contract-simple-delegation.spec.ts
+++ b/integration-tests/contract-simple-delegation.spec.ts
@@ -21,8 +21,16 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
         })
         await op.confirmation()
         expect(op.hash).toBeDefined();
-        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
-
+        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+        expect(Number(op.consumedGas)).toBeGreaterThan(0);
+        expect(op.delegate).toEqual(delegate);
+        expect(op.fee).toEqual(DEFAULT_FEE.DELEGATION);
+        expect(op.gasLimit).toEqual(DEFAULT_GAS_LIMIT.DELEGATION);
+        expect(op.storageLimit).toEqual(0);
+        expect(op.isRegisterOperation).toBeFalsy();
+        expect(op.source).toEqual(pkh);
+        expect(op.status).toEqual('applied');
+        
         const account = await Tezos.rpc.getDelegate(pkh)
         expect(account).toEqual(delegate)
       } catch (ex: any) {

--- a/integration-tests/contract-simple-origination.spec.ts
+++ b/integration-tests/contract-simple-origination.spec.ts
@@ -24,7 +24,12 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       })
       await op.confirmation()
       expect(op.hash).toBeDefined();
-      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+      expect(Number(op.consumedGas)).toBeGreaterThan(0);
+      expect(op.contractAddress).toBeDefined();
+      expect(op.status).toEqual('applied');
+      expect(op.storageDiff).toEqual('62');
+
       done();
     });
   });

--- a/integration-tests/contract-simple-reveal.spec.ts
+++ b/integration-tests/contract-simple-reveal.spec.ts
@@ -1,0 +1,32 @@
+import { CONFIGS } from "./config";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+    const Tezos = lib;
+    describe(`Test reveal of account through contract API using: ${rpc}`, () => {
+
+        beforeEach(async (done) => {
+            await setup(true)
+            done()
+        })
+        it('verify that contract.reveal reveals the current account', async (done) => {
+
+            const pkh = await Tezos.signer.publicKeyHash()
+            const pk = await Tezos.signer.publicKey()
+            const op = await Tezos.contract.reveal({})
+            await op.confirmation();
+
+            expect(op.hash).toBeDefined();
+            expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+            expect(Number(op.consumedGas)).toBeGreaterThan(0);
+            expect(op.publicKey).toEqual(pk);
+            expect(op.source).toEqual(pkh);
+            expect(op.status).toEqual('applied');
+            expect(op.storageDiff).toEqual('0');
+
+            // if the account is revealed, it has a manager
+            expect(await Tezos.rpc.getManagerKey(pkh)).toEqual(pk)
+
+            done();
+        });
+    });
+})

--- a/integration-tests/contract-tx-rollup-batch-operation.spec.ts
+++ b/integration-tests/contract-tx-rollup-batch-operation.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { OpKind, Protocols, TezosToolkit } from "@taquito/taquito";
+import { OpKind, Protocols } from "@taquito/taquito";
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
@@ -20,6 +20,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
        expect(op.content).toEqual('626c6f62');
        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
        expect(op.status).toBe('applied');
+       expect(Number(op.consumedGas)).toBeGreaterThan(0);
 
        done();
      });

--- a/integration-tests/contract-tx-wait-2-confirmations.spec.ts
+++ b/integration-tests/contract-tx-wait-2-confirmations.spec.ts
@@ -11,7 +11,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     test('transfers 0.02 tez and waits for 2 confirmations', async (done) => {
       const op = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
       await op.confirmation()
-      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+      expect(Number(op.consumedGas)).toBeGreaterThan(0);
       const [first, second] = await Promise.all([op.confirmation(), op.confirmation(2)])
       expect(second - first).toEqual(1)
       // Retrying another time should be instant

--- a/packages/taquito-michelson-encoder/src/schema/model.ts
+++ b/packages/taquito-michelson-encoder/src/schema/model.ts
@@ -29,7 +29,7 @@ interface Operationresult {
   status: string;
   storage: Storage;
   big_map_diff: Bigmapdiff[];
-  consumed_gas: string;
+  consumed_gas?: string;
   storage_size: string;
   paid_storage_size_diff: string;
   consumed_milligas?: string;

--- a/packages/taquito/src/operations/batch-operation.ts
+++ b/packages/taquito/src/operations/batch-operation.ts
@@ -1,4 +1,5 @@
 import { OperationContentsAndResult, OperationContentsAndResultOrigination } from '@taquito/rpc';
+import BigNumber from 'bignumber.js';
 import { BATCH_KINDS } from '../batch/rpc-batch-provider';
 import { Context } from '../context';
 import { flattenErrors, flattenOperationResult } from './operation-errors';
@@ -75,7 +76,14 @@ export class BatchOperation
   }
 
   get consumedGas() {
-    return String(this.sumProp(flattenOperationResult({ contents: this.results }), 'consumed_gas'));
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return new BigNumber(this.consumedMilliGas).dividedBy(1000).toString();
+  }
+
+  get consumedMilliGas() {
+    return String(
+      this.sumProp(flattenOperationResult({ contents: this.results }), 'consumed_milligas')
+    );
   }
 
   get storageDiff() {

--- a/packages/taquito/src/operations/delegate-operation.ts
+++ b/packages/taquito/src/operations/delegate-operation.ts
@@ -1,4 +1,5 @@
 import { OperationContentsAndResult, OperationContentsAndResultDelegation } from '@taquito/rpc';
+import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { Operation } from './operations';
 import {
@@ -14,8 +15,10 @@ import {
  *
  * @warn Currently support only one delegation per operation
  */
-export class DelegateOperation extends Operation
-  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation {
+export class DelegateOperation
+  extends Operation
+  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation
+{
   constructor(
     hash: string,
     private readonly params: RPCDelegateOperation,
@@ -30,7 +33,7 @@ export class DelegateOperation extends Operation
   get operationResults() {
     const delegationOp =
       Array.isArray(this.results) &&
-      (this.results.find(op => op.kind === 'delegation') as OperationContentsAndResultDelegation);
+      (this.results.find((op) => op.kind === 'delegation') as OperationContentsAndResultDelegation);
     const result = delegationOp && delegationOp.metadata && delegationOp.metadata.operation_result;
     return result ? result : undefined;
   }
@@ -44,8 +47,8 @@ export class DelegateOperation extends Operation
     }
   }
 
-  get delegate(): string {
-    return this.delegate;
+  get delegate(): string | undefined {
+    return this.params.delegate;
   }
 
   get isRegisterOperation(): boolean {
@@ -65,8 +68,15 @@ export class DelegateOperation extends Operation
   }
 
   get consumedGas() {
-    const consumedGas = this.operationResults && this.operationResults.consumed_gas;
-    return consumedGas ? consumedGas : undefined;
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return this.consumedMilliGas
+      ? new BigNumber(this.consumedMilliGas).dividedBy(1000).toString()
+      : undefined;
+  }
+
+  get consumedMilliGas() {
+    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
+    return consumedMilliGas ? consumedMilliGas : undefined;
   }
 
   get errors() {

--- a/packages/taquito/src/operations/delegate-operation.ts
+++ b/packages/taquito/src/operations/delegate-operation.ts
@@ -39,12 +39,7 @@ export class DelegateOperation
   }
 
   get status() {
-    const operationResults = this.operationResults;
-    if (operationResults) {
-      return operationResults.status;
-    } else {
-      return 'unknown';
-    }
+    return this.operationResults?.status ?? 'unknown';
   }
 
   get delegate(): string | undefined {
@@ -75,11 +70,10 @@ export class DelegateOperation
   }
 
   get consumedMilliGas() {
-    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
-    return consumedMilliGas ? consumedMilliGas : undefined;
+    return this.operationResults?.consumed_milligas;
   }
 
   get errors() {
-    return this.operationResults && this.operationResults.errors;
+    return this.operationResults?.errors;
   }
 }

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -1,4 +1,5 @@
 import { OperationContentsAndResult, OperationContentsAndResultOrigination } from '@taquito/rpc';
+import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { DefaultContractType } from '../contract/contract';
 import { RpcContractProvider } from '../contract/rpc-contract-provider';
@@ -79,8 +80,15 @@ export class OriginationOperation<TContract extends DefaultContractType = Defaul
   }
 
   get consumedGas() {
-    const consumedGas = this.operationResults && this.operationResults.consumed_gas;
-    return consumedGas ? consumedGas : undefined;
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return this.consumedMilliGas
+      ? new BigNumber(this.consumedMilliGas).dividedBy(1000).toString()
+      : undefined;
+  }
+
+  get consumedMilliGas() {
+    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
+    return consumedMilliGas ? consumedMilliGas : undefined;
   }
 
   get storageDiff() {

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -45,12 +45,7 @@ export class OriginationOperation<TContract extends DefaultContractType = Defaul
   }
 
   get status() {
-    const operationResults = this.operationResults;
-    if (operationResults) {
-      return operationResults.status;
-    } else {
-      return 'unknown';
-    }
+    return this.operationResults?.status ?? 'unknown';
   }
 
   get operationResults() {
@@ -87,8 +82,7 @@ export class OriginationOperation<TContract extends DefaultContractType = Defaul
   }
 
   get consumedMilliGas() {
-    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
-    return consumedMilliGas ? consumedMilliGas : undefined;
+    return this.operationResults?.consumed_milligas;
   }
 
   get storageDiff() {
@@ -102,7 +96,7 @@ export class OriginationOperation<TContract extends DefaultContractType = Defaul
   }
 
   get errors() {
-    return this.operationResults && this.operationResults.errors;
+    return this.operationResults?.errors;
   }
 
   /**

--- a/packages/taquito/src/operations/register-global-constant-operation.ts
+++ b/packages/taquito/src/operations/register-global-constant-operation.ts
@@ -51,12 +51,7 @@ export class RegisterGlobalConstantOperation
   }
 
   get status() {
-    const operationResults = this.operationResults;
-    if (operationResults) {
-      return operationResults.status;
-    } else {
-      return 'unknown';
-    }
+    return this.operationResults?.status ?? 'unknown';
   }
 
   get registeredExpression() {
@@ -76,7 +71,7 @@ export class RegisterGlobalConstantOperation
   }
 
   get errors() {
-    return this.operationResults && this.operationResults.errors;
+    return this.operationResults?.errors;
   }
 
   get consumedGas() {
@@ -87,7 +82,6 @@ export class RegisterGlobalConstantOperation
   }
 
   get consumedMilliGas() {
-    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
-    return consumedMilliGas ? consumedMilliGas : undefined;
+    return this.operationResults?.consumed_milligas;
   }
 }

--- a/packages/taquito/src/operations/register-global-constant-operation.ts
+++ b/packages/taquito/src/operations/register-global-constant-operation.ts
@@ -1,71 +1,93 @@
-import { OperationContentsAndResult, OperationContentsAndResultRegisterGlobalConstant } from '@taquito/rpc';
+import {
+  OperationContentsAndResult,
+  OperationContentsAndResultRegisterGlobalConstant,
+} from '@taquito/rpc';
+import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { Operation } from './operations';
 import {
-    FeeConsumingOperation,
-    ForgedBytes,
-    GasConsumingOperation,
-    RPCRegisterGlobalConstantOperation,
-    StorageConsumingOperation,
+  FeeConsumingOperation,
+  ForgedBytes,
+  GasConsumingOperation,
+  RPCRegisterGlobalConstantOperation,
+  StorageConsumingOperation,
 } from './types';
 
 /**
  * @description RegisterGlobalConstantOperation provides utility functions to fetch a newly issued operation of kind register_global_constant
  */
-export class RegisterGlobalConstantOperation extends Operation
-    implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation {
+export class RegisterGlobalConstantOperation
+  extends Operation
+  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation
+{
+  /**
+   * @description Hash (index) of the newly registered constant
+   */
+  public readonly globalConstantHash?: string;
+  constructor(
+    hash: string,
+    private readonly params: RPCRegisterGlobalConstantOperation,
+    public readonly source: string,
+    raw: ForgedBytes,
+    results: OperationContentsAndResult[],
+    context: Context
+  ) {
+    super(hash, raw, results, context);
 
-    /**
-     * @description Hash (index) of the newly registered constant
-     */
-    public readonly globalConstantHash?: string;
-    constructor(
-        hash: string,
-        private readonly params: RPCRegisterGlobalConstantOperation,
-        public readonly source: string,
-        raw: ForgedBytes,
-        results: OperationContentsAndResult[],
-        context: Context
-    ) {
-        super(hash, raw, results, context);
+    this.globalConstantHash = this.operationResults && this.operationResults.global_address;
+  }
 
-        this.globalConstantHash = this.operationResults && this.operationResults.global_address;
+  get operationResults() {
+    const registerGlobalConstantOp =
+      Array.isArray(this.results) &&
+      (this.results.find(
+        (op) => op.kind === 'register_global_constant'
+      ) as OperationContentsAndResultRegisterGlobalConstant);
+    const result =
+      registerGlobalConstantOp &&
+      registerGlobalConstantOp.metadata &&
+      registerGlobalConstantOp.metadata.operation_result;
+    return result ? result : undefined;
+  }
+
+  get status() {
+    const operationResults = this.operationResults;
+    if (operationResults) {
+      return operationResults.status;
+    } else {
+      return 'unknown';
     }
+  }
 
-    get operationResults() {
-        const registerGlobalConstantOp =
-            Array.isArray(this.results) &&
-            (this.results.find(op => op.kind === 'register_global_constant') as OperationContentsAndResultRegisterGlobalConstant);
-        const result = registerGlobalConstantOp && registerGlobalConstantOp.metadata && registerGlobalConstantOp.metadata.operation_result;
-        return result ? result : undefined;
-    }
+  get registeredExpression() {
+    return this.params.value;
+  }
 
-    get status() {
-        const operationResults = this.operationResults;
-        if (operationResults) {
-            return operationResults.status;
-        } else {
-            return 'unknown';
-        }
-    }
+  get fee() {
+    return this.params.fee;
+  }
 
-    get registeredExpression() {
-        return this.params.value;
-    }
+  get gasLimit() {
+    return this.params.gas_limit;
+  }
 
-    get fee() {
-        return this.params.fee;
-    }
+  get storageLimit() {
+    return this.params.storage_limit;
+  }
 
-    get gasLimit() {
-        return this.params.gas_limit;
-    }
+  get errors() {
+    return this.operationResults && this.operationResults.errors;
+  }
 
-    get storageLimit() {
-        return this.params.storage_limit;
-    }
+  get consumedGas() {
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return this.consumedMilliGas
+      ? new BigNumber(this.consumedMilliGas).dividedBy(1000).toString()
+      : undefined;
+  }
 
-    get errors() {
-        return this.operationResults && this.operationResults.errors;
-    }
+  get consumedMilliGas() {
+    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
+    return consumedMilliGas ? consumedMilliGas : undefined;
+  }
 }

--- a/packages/taquito/src/operations/reveal-operation.ts
+++ b/packages/taquito/src/operations/reveal-operation.ts
@@ -1,4 +1,5 @@
 import { OperationContentsAndResult, OperationContentsAndResultReveal } from '@taquito/rpc';
+import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { flattenErrors, flattenOperationResult } from './operation-errors';
 import { Operation } from './operations';
@@ -13,8 +14,10 @@ import {
 /**
  * @description Reveal operation provides utility functions to fetch a newly issued revelation
  */
-export class RevealOperation extends Operation
-  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation {
+export class RevealOperation
+  extends Operation
+  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation
+{
   constructor(
     hash: string,
     private readonly params: RPCRevealOperation,
@@ -29,7 +32,7 @@ export class RevealOperation extends Operation
   get operationResults() {
     const revealOp =
       Array.isArray(this.results) &&
-      (this.results.find(op => op.kind === 'reveal') as OperationContentsAndResultReveal);
+      (this.results.find((op) => op.kind === 'reveal') as OperationContentsAndResultReveal);
     return revealOp ? [revealOp] : [];
   }
 
@@ -66,8 +69,13 @@ export class RevealOperation extends Operation
   }
 
   get consumedGas() {
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return new BigNumber(this.consumedMilliGas).dividedBy(1000).toString();
+  }
+
+  get consumedMilliGas() {
     return String(
-      this.sumProp(flattenOperationResult({ contents: this.operationResults }), 'consumed_gas')
+      this.sumProp(flattenOperationResult({ contents: this.operationResults }), 'consumed_milligas')
     );
   }
 

--- a/packages/taquito/src/operations/transaction-operation.ts
+++ b/packages/taquito/src/operations/transaction-operation.ts
@@ -16,8 +16,10 @@ import {
  *
  * @warn Currently supports one transaction per operation
  */
-export class TransactionOperation extends Operation
-  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation {
+export class TransactionOperation
+  extends Operation
+  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation
+{
   constructor(
     hash: string,
     private readonly params: RPCTransferOperation,
@@ -32,7 +34,9 @@ export class TransactionOperation extends Operation
   get operationResults() {
     const transactionOp =
       Array.isArray(this.results) &&
-      (this.results.find(op => op.kind === 'transaction') as OperationContentsAndResultTransaction);
+      (this.results.find(
+        (op) => op.kind === 'transaction'
+      ) as OperationContentsAndResultTransaction);
     return transactionOp ? [transactionOp] : [];
   }
 
@@ -66,7 +70,6 @@ export class TransactionOperation extends Operation
     return this.params.storage_limit;
   }
 
-
   private sumProp(arr: MergedOperationResult[], prop: keyof MergedOperationResult) {
     return arr.reduce((prev, current) => {
       return prop in current ? Number(current[prop]) + prev : prev;
@@ -74,8 +77,13 @@ export class TransactionOperation extends Operation
   }
 
   get consumedGas() {
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return new BigNumber(this.consumedMilliGas).dividedBy(1000).toString();
+  }
+
+  get consumedMilliGas() {
     return String(
-      this.sumProp(flattenOperationResult({ contents: this.operationResults }), 'consumed_gas')
+      this.sumProp(flattenOperationResult({ contents: this.operationResults }), 'consumed_milligas')
     );
   }
 

--- a/packages/taquito/src/operations/transfer-ticket-operation.ts
+++ b/packages/taquito/src/operations/transfer-ticket-operation.ts
@@ -46,12 +46,7 @@ export class TransferTicketOperation
   }
 
   get status() {
-    const operationResults = this.operationResults;
-    if (operationResults) {
-      return operationResults.status;
-    } else {
-      return 'unknown';
-    }
+    return this.operationResults?.status ?? 'unknown';
   }
 
   get fee() {
@@ -74,7 +69,6 @@ export class TransferTicketOperation
   }
 
   get consumedMilliGas() {
-    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
-    return consumedMilliGas ? consumedMilliGas : undefined;
+    return this.operationResults?.consumed_milligas;
   }
 }

--- a/packages/taquito/src/operations/tx-rollup-batch-operation.ts
+++ b/packages/taquito/src/operations/tx-rollup-batch-operation.ts
@@ -43,12 +43,7 @@ export class TxRollupBatchOperation
   }
 
   get status() {
-    const operationResults = this.operationResults;
-    if (operationResults) {
-      return operationResults.status;
-    } else {
-      return 'unknown';
-    }
+    return this.operationResults?.status ?? 'unknown';
   }
 
   get content() {
@@ -68,7 +63,7 @@ export class TxRollupBatchOperation
   }
 
   get errors() {
-    return this.operationResults && this.operationResults.errors;
+    return this.operationResults?.errors;
   }
 
   get consumedGas() {
@@ -79,7 +74,6 @@ export class TxRollupBatchOperation
   }
 
   get consumedMilliGas() {
-    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
-    return consumedMilliGas ? consumedMilliGas : undefined;
+    return this.operationResults?.consumed_milligas;
   }
 }

--- a/packages/taquito/src/operations/tx-rollup-batch-operation.ts
+++ b/packages/taquito/src/operations/tx-rollup-batch-operation.ts
@@ -2,6 +2,7 @@ import {
   OperationContentsAndResult,
   OperationContentsAndResultTxRollupSubmitBatch,
 } from '@taquito/rpc';
+import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { Operation } from './operations';
 import {
@@ -68,5 +69,17 @@ export class TxRollupBatchOperation
 
   get errors() {
     return this.operationResults && this.operationResults.errors;
+  }
+
+  get consumedGas() {
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return this.consumedMilliGas
+      ? new BigNumber(this.consumedMilliGas).dividedBy(1000).toString()
+      : undefined;
+  }
+
+  get consumedMilliGas() {
+    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
+    return consumedMilliGas ? consumedMilliGas : undefined;
   }
 }

--- a/packages/taquito/src/operations/tx-rollup-origination-operation.ts
+++ b/packages/taquito/src/operations/tx-rollup-origination-operation.ts
@@ -2,6 +2,7 @@ import {
   OperationContentsAndResult,
   OperationContentsAndResultTxRollupOrigination,
 } from '@taquito/rpc';
+import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { Operation } from './operations';
 import {
@@ -72,5 +73,17 @@ export class TxRollupOriginationOperation
 
   get errors() {
     return this.operationResults && this.operationResults.errors;
+  }
+
+  get consumedGas() {
+    BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
+    return this.consumedMilliGas
+      ? new BigNumber(this.consumedMilliGas).dividedBy(1000).toString()
+      : undefined;
+  }
+
+  get consumedMilliGas() {
+    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
+    return consumedMilliGas ? consumedMilliGas : undefined;
   }
 }

--- a/packages/taquito/src/operations/tx-rollup-origination-operation.ts
+++ b/packages/taquito/src/operations/tx-rollup-origination-operation.ts
@@ -51,12 +51,7 @@ export class TxRollupOriginationOperation
   }
 
   get status() {
-    const operationResults = this.operationResults;
-    if (operationResults) {
-      return operationResults.status;
-    } else {
-      return 'unknown';
-    }
+    return this.operationResults?.status ?? 'unknown';
   }
 
   get fee() {
@@ -72,7 +67,7 @@ export class TxRollupOriginationOperation
   }
 
   get errors() {
-    return this.operationResults && this.operationResults.errors;
+    return this.operationResults?.errors;
   }
 
   get consumedGas() {
@@ -83,7 +78,6 @@ export class TxRollupOriginationOperation
   }
 
   get consumedMilliGas() {
-    const consumedMilliGas = this.operationResults && this.operationResults.consumed_milligas;
-    return consumedMilliGas ? consumedMilliGas : undefined;
+    return this.operationResults?.consumed_milligas;
   }
 }

--- a/packages/taquito/test/contract/helper.ts
+++ b/packages/taquito/test/contract/helper.ts
@@ -81,7 +81,7 @@ const errorBuilder = (result: any) => {
       result[0].contents[0].metadata.operation_result = {
         status: 'backtracked',
         storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
-        consumed_gas: '15953',
+        consumed_milligas: '15953000',
         storage_size: '232',
       };
       (result[0].contents[0].metadata as any).internal_operation_results = [
@@ -1240,7 +1240,7 @@ export const registerGlobalConstantWithReveal = {
             change: '1420',
           },
         ],
-        operation_result: { status: 'applied', consumed_gas: '10000' },
+        operation_result: { status: 'applied', consumed_milligas: '10000000' },
       },
     },
     registerGlobalConstantNoReveal.contents[0],
@@ -1358,7 +1358,6 @@ export const txRollupOriginateWithReveal = {
         ],
         operation_result: {
           status: 'applied',
-          consumed_gas: '1000',
           consumed_milligas: '1000000',
         },
       },
@@ -1402,7 +1401,6 @@ export const txRollupOriginateWithReveal = {
               origin: 'block',
             },
           ],
-          consumed_gas: '1421',
           consumed_milligas: '1420108',
           originated_rollup: 'txr1gJDqppanLyZJ5Yw9VCNqnHswtv9fQ9brL',
         },
@@ -1479,7 +1477,6 @@ export const txRollupSubmitBatchWithReveal = {
         ],
         operation_result: {
           status: 'applied',
-          consumed_gas: '1000',
           consumed_milligas: '1000000',
         },
       },
@@ -1511,7 +1508,6 @@ export const txRollupSubmitBatchWithReveal = {
         operation_result: {
           status: 'applied',
           balance_updates: [],
-          consumed_gas: '2769',
           consumed_milligas: '2768514',
           paid_storage_size_diff: '0',
         },
@@ -1588,7 +1584,7 @@ export const TransferTicketWithReveal = {
       storage_limit: '0',
       public_key: 'sppk7aqSksZan1AGXuKtCz9UBLZZ77e3ZWGpFxR7ig1Z17GneEhSSbH',
       metadata: {
-        operation_result: { status: 'applied', consumed_gas: '1000' },
+        operation_result: { status: 'applied', consumed_milligas: '1000000' },
       },
     },
     {

--- a/packages/taquito/test/data/batch-results.ts
+++ b/packages/taquito/test/data/batch-results.ts
@@ -21,7 +21,6 @@ export const resultOriginations = [
         status: 'applied',
         balance_updates: [],
         originated_contracts: ['KT1Wr1xjQAzb44AcPRV9F9oyPurkFz7y2otC'],
-        consumed_gas: '1470',
         consumed_milligas: '1469767',
         storage_size: '314',
         paid_storage_size_diff: '314',
@@ -48,7 +47,6 @@ export const resultOriginations = [
         status: 'applied',
         balance_updates: [],
         originated_contracts: ['KT1SG1LfkoMoEqR5srtiYeYcciaZfBTGzTgY'],
-        consumed_gas: '1470',
         consumed_milligas: '1469767',
         storage_size: '314',
         paid_storage_size_diff: '314',
@@ -93,7 +91,7 @@ export const successfulResult = [
             change: '1000000',
           },
         ],
-        consumed_gas: '15285',
+        consumed_milligas: '15285000',
         storage_size: '232',
       },
     },
@@ -137,7 +135,7 @@ export const successfulResult = [
       operation_result: {
         status: 'applied',
         storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
-        consumed_gas: '15953',
+        consumed_milligas: '15953000',
         storage_size: '232',
       },
       internal_operation_results: [
@@ -161,7 +159,7 @@ export const successfulResult = [
                 change: '50',
               },
             ],
-            consumed_gas: '10207',
+            consumed_milligas: '10207000',
           },
         },
       ],
@@ -204,7 +202,7 @@ export const successfulResult = [
       operation_result: {
         status: 'applied',
         storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
-        consumed_gas: '15794',
+        consumed_milligas: '15794000',
         storage_size: '232',
       },
       internal_operation_results: [
@@ -213,7 +211,7 @@ export const successfulResult = [
           source: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
           nonce: 1,
           delegate: 'tz1aWXP237BLwNHJcCD4b3DutCevhqq2T1Z9',
-          result: { status: 'applied', consumed_gas: '10000' },
+          result: { status: 'applied', consumed_milligas: '10000000' },
         },
       ],
     },
@@ -251,7 +249,7 @@ export const successfulResult = [
       operation_result: {
         status: 'applied',
         storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
-        consumed_gas: '15722',
+        consumed_milligas: '15722000',
         storage_size: '232',
       },
       internal_operation_results: [
@@ -259,7 +257,7 @@ export const successfulResult = [
           kind: 'delegation',
           source: 'KT1UMZuZRzgS9iZGC2LTQad6PHPaF3fmSo4p',
           nonce: 2,
-          result: { status: 'applied', consumed_gas: '10000' },
+          result: { status: 'applied', consumed_milligas: '10000000' },
         },
       ],
     },
@@ -283,7 +281,6 @@ export const resultWithoutOrigination = [
       operation_result: {
         status: 'applied',
         balance_updates: [],
-        consumed_gas: '1470',
         consumed_milligas: '1469767',
         storage_size: '314',
         paid_storage_size_diff: '314',
@@ -306,7 +303,6 @@ export const resultWithoutOrigination = [
       operation_result: {
         status: 'applied',
         balance_updates: [],
-        consumed_gas: '1470',
         consumed_milligas: '1469767',
         storage_size: '314',
         paid_storage_size_diff: '314',
@@ -330,7 +326,6 @@ export const resultSingleOrigination = [
       operation_result: {
         status: 'applied',
         balance_updates: [],
-        consumed_gas: '1451',
         consumed_milligas: '1450040',
       },
     },
@@ -349,7 +344,6 @@ export const resultSingleOrigination = [
       operation_result: {
         status: 'applied',
         balance_updates: [],
-        consumed_gas: '1451',
         consumed_milligas: '1450040',
       },
     },
@@ -368,7 +362,6 @@ export const resultSingleOrigination = [
       operation_result: {
         status: 'applied',
         balance_updates: [],
-        consumed_gas: '1451',
         consumed_milligas: '1450040',
       },
     },
@@ -393,7 +386,6 @@ export const resultSingleOrigination = [
         status: 'applied',
         balance_updates: [],
         originated_contracts: ['KT1Em8ALyerHtZd1s5s6quJDZrTRxnmdKcKd'],
-        consumed_gas: '1470',
         consumed_milligas: '1469767',
         storage_size: '314',
         paid_storage_size_diff: '314',

--- a/packages/taquito/test/helpers.ts
+++ b/packages/taquito/test/helpers.ts
@@ -94,17 +94,17 @@ const defaultTransferTicketData = {
   gas_limit: '5009',
   storage_limit: '130',
   counter: '145',
-  ticket_contents: { "string": "foobar" },
-  ticket_ty: { "prim": "string" },
+  ticket_contents: { string: 'foobar' },
+  ticket_ty: { prim: 'string' },
   ticket_ticketer: 'KT1AL8we1Bfajn2M7i3gQM5PJEuyD36sXaYb',
   ticket_amount: '2',
   destination: 'KT1SUT2TBFPCknkBxLqM5eJZKoYVY6mB26Fg',
   entrypoint: 'default',
-}
+};
 
 const defaultResult = {
   status: 'applied' as OperationResultStatusEnum,
-  consumed_gas: '15953',
+  consumed_milligas: '15952999',
 };
 
 export class TransferOperationBuilder {
@@ -176,7 +176,12 @@ export class OriginationOperationBuilder {
   withResult(
     result: Partial<OperationContentsAndResultOrigination['metadata']['operation_result']>
   ) {
-    this.result = { ...defaultResult, ...result };
+    this.result = {
+      ...defaultResult,
+      ...result,
+      originated_contracts: ['KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX'],
+      storage_size: '62',
+    };
     return this;
   }
 
@@ -318,7 +323,7 @@ export class TransferTicketOperationBuilder {
   withResult(
     result: Partial<OperationContentsAndResultTransferTicket['metadata']['operation_result']>
   ) {
-    this.result = { ...defaultResult, ...result};
+    this.result = { ...defaultResult, ...result };
     return this;
   }
 
@@ -328,7 +333,7 @@ export class TransferTicketOperationBuilder {
       metadata: {
         balance_updates: [],
         operation_result: this.result,
-      }
-    }
+      },
+    };
   }
 }

--- a/packages/taquito/test/operations/batch-operation.spec.ts
+++ b/packages/taquito/test/operations/batch-operation.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ForgedBytes } from '../../src/operations/types';
 import { BatchOperation } from '../../src/operations/batch-operation';
 import { defaultConfigConfirmation } from '../../src/context';

--- a/packages/taquito/test/operations/delegation-operation.spec.ts
+++ b/packages/taquito/test/operations/delegation-operation.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { defaultConfigConfirmation } from '../../src/context';
 import { DelegateOperation } from '../../src/operations/delegate-operation';
 import { ForgedBytes } from '../../src/operations/types';
@@ -74,5 +75,37 @@ describe('Delegation operation', () => {
     );
     expect(op.revealStatus).toEqual('unknown');
     expect(op.status).toEqual('backtracked');
+  });
+
+  it('should successfully retrieve all members of DelegateOperation', () => {
+    const txBuilder = new DelegationOperationBuilder();
+
+    const op = new DelegateOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {
+        delegate: 'delegate',
+        fee: '2991',
+        gas_limit: '26260',
+        storage_limit: '257',
+      } as any,
+      'source',
+      fakeForgedBytes,
+      [txBuilder.withResult({ status: 'applied' }).build()],
+      fakeContext
+    );
+    expect(op.revealStatus).toEqual('unknown');
+    expect(op.status).toEqual('applied');
+    expect(op.consumedGas).toEqual('15953');
+    expect(op.consumedMilliGas).toEqual('15952999');
+    expect(op.delegate).toEqual('delegate');
+    expect(op.errors).toBeUndefined();
+    expect(op.fee).toEqual('2991');
+    expect(op.gasLimit).toEqual('26260');
+    expect(op.hash).toEqual('ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj');
+    expect(op.isRegisterOperation).toBeFalsy();
+    expect(op.operationResults).toEqual({ consumed_milligas: '15952999', status: 'applied' });
+    expect(op.revealOperation).toBeUndefined();
+    expect(op.source).toEqual('source');
+    expect(op.storageLimit).toEqual('257');
   });
 });

--- a/packages/taquito/test/operations/origination-operation.spec.ts
+++ b/packages/taquito/test/operations/origination-operation.spec.ts
@@ -59,7 +59,7 @@ describe('Origination operation', () => {
             },
           ],
           originated_contracts: ['KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD'],
-          consumed_gas: '11684',
+          consumed_milligas: '11684000',
           storage_size: '62',
           paid_storage_size_diff: '62',
         },
@@ -121,7 +121,7 @@ describe('Origination operation', () => {
       expect(op.contractAddress).toEqual('KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD');
     });
 
-    it('contract address is undefined given an wrong result', () => {
+    it('contract address is undefined given a wrong result', () => {
       const fakeContractProvider: any = {};
       const wrongResults: any[] = [
         {},
@@ -203,5 +203,42 @@ describe('Origination operation', () => {
       );
       done();
     });
+  });
+
+  it('should successfully retrieve all members of OriginationOperation', () => {
+    const originationBuilder = new OriginationOperationBuilder();
+    const fakeContractProvider: any = {};
+    const op = new OriginationOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {
+        fee: '2991',
+        gas_limit: '26260',
+        storage_limit: '257',
+      } as any,
+      fakeForgedBytes,
+      [originationBuilder.withResult({ status: 'applied' }).build()],
+      fakeContext,
+      fakeContractProvider
+    );
+
+    expect(op.revealStatus).toEqual('unknown');
+    expect(op.status).toEqual('applied');
+    expect(op.consumedGas).toEqual('15953');
+    expect(op.consumedMilliGas).toEqual('15952999');
+    expect(op.contractAddress).toEqual('KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX');
+    expect(op.errors).toBeUndefined();
+    expect(op.fee).toEqual('2991');
+    expect(op.gasLimit).toEqual('26260');
+    expect(op.hash).toEqual('ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj');
+    expect(op.storageDiff).toBeFalsy();
+    expect(op.operationResults).toEqual({
+      consumed_milligas: '15952999',
+      status: 'applied',
+      originated_contracts: ['KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX'],
+      storage_size: '62',
+    });
+    expect(op.revealOperation).toBeUndefined();
+    expect(op.storageSize).toEqual('62');
+    expect(op.storageLimit).toEqual('257');
   });
 });

--- a/packages/taquito/test/operations/register-global-constant.spec.ts
+++ b/packages/taquito/test/operations/register-global-constant.spec.ts
@@ -54,7 +54,7 @@ describe('RegisterGlobalConstant operation', () => {
               origin: 'block',
             },
           ],
-          consumed_gas: '1230',
+          consumed_milligas: '1230000',
           storage_size: '73',
           global_address: 'exprvNeeFGy8M7xhmaq7bkQcd3RsXc7ogv2HwL1dciubXdgPHEMRH2',
         },
@@ -144,6 +144,31 @@ describe('RegisterGlobalConstant operation', () => {
     );
     expect(op.gasLimit).toEqual(450);
   });
+
+  it('should return the consumed gas', () => {
+    const op = new RegisterGlobalConstantOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedGas).toEqual('1230');
+  });
+
+  it('should return the consumed milligas', () => {
+    const op = new RegisterGlobalConstantOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedMilliGas).toEqual('1230000');
+  });
+
   it('should return the storageLimit', () => {
     const op = new RegisterGlobalConstantOperation(
       'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',

--- a/packages/taquito/test/operations/register-global-constant.spec.ts
+++ b/packages/taquito/test/operations/register-global-constant.spec.ts
@@ -256,6 +256,22 @@ describe('RegisterGlobalConstant operation', () => {
     expect(op.status).toEqual('backtracked');
   });
 
+  it('status should be unknown if no status', () => {
+    const revealBuilder = new RevealOperationBuilder();
+
+    const op = new RegisterGlobalConstantOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      [
+        revealBuilder.withResult({}).build(),
+      ],
+      fakeContext
+    );
+    expect(op.status).toEqual('unknown');
+  });
+
   it('revealStatus should be unknown when there is no reveal operation', () => {
     const txBuilder = new RegisterGlobalConstantOperationBuilder();
 

--- a/packages/taquito/test/operations/reveal-operation.spec.ts
+++ b/packages/taquito/test/operations/reveal-operation.spec.ts
@@ -1,0 +1,55 @@
+import { defaultConfigConfirmation } from '../../src/context';
+import { ForgedBytes } from '../../src/operations';
+import { RevealOperation } from '../../src/operations/reveal-operation';
+import { RevealOperationBuilder } from '../helpers';
+
+describe('RevealOperation', () => {
+  let fakeContext: any;
+  const fakeForgedBytes = {} as ForgedBytes;
+
+  beforeEach(() => {
+    fakeContext = {
+      rpc: {
+        getBlock: jest.fn(),
+      },
+      config: { ...defaultConfigConfirmation },
+    };
+
+    fakeContext.rpc.getBlock.mockResolvedValue({
+      operations: [[{ hash: 'oo51jb7sEvPkf7BaTSUW49QztcxgxufLVEj2PUfQ2uw6m61CKLc' }], [], [], []],
+      header: {
+        level: 185827,
+      },
+    });
+  });
+  it('should successfully retrieve all members of RevealOperation', () => {
+    const txBuilder = new RevealOperationBuilder();
+
+    const op = new RevealOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {
+        fee: '2991',
+        gas_limit: '26260',
+        storage_limit: '257',
+        public_key: 'p2pk',
+      } as any,
+      'source',
+      fakeForgedBytes,
+      [txBuilder.withResult({ status: 'applied' }).build()],
+      fakeContext
+    );
+
+    expect(op.status).toEqual('applied');
+    expect(op.consumedGas).toEqual('15953');
+    expect(op.consumedMilliGas).toEqual('15952999');
+    expect(op.errors).toEqual([]);
+    expect(op.fee).toEqual('2991');
+    expect(op.gasLimit).toEqual('26260');
+    expect(op.hash).toEqual('ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj');
+    expect(op.source).toEqual('source');
+    expect(op.storageLimit).toEqual('257');
+    expect(op.publicKey).toEqual('p2pk');
+    expect(op.storageDiff).toEqual('0');
+    expect(op.storageSize).toEqual('0');
+  });
+});

--- a/packages/taquito/test/operations/transaction-operation.spec.ts
+++ b/packages/taquito/test/operations/transaction-operation.spec.ts
@@ -48,7 +48,7 @@ describe('Transfer operation', () => {
         operation_result: {
           status: 'applied',
           storage: { bytes: '00b2e19a9e74440d86c59f13dab8a18ff873e889ea' },
-          consumed_gas: '15953',
+          consumed_milligas: '15953000',
           storage_size: '232',
         },
         internal_operation_results: [
@@ -72,7 +72,7 @@ describe('Transfer operation', () => {
                   change: '50',
                 },
               ],
-              consumed_gas: '10207',
+              consumed_milligas: '10207000',
             },
           },
         ],

--- a/packages/taquito/test/operations/transfer-ticket-operation.spec.ts
+++ b/packages/taquito/test/operations/transfer-ticket-operation.spec.ts
@@ -1,8 +1,12 @@
 import { ForgedBytes, RPCTransferTicketOperation } from '../../src/operations/types';
-import { METADATA_BALANCE_UPDATES_CATEGORY, OperationContentsAndResult, OperationContentsAndResultTransferTicket, OpKind } from '@taquito/rpc';
+import {
+  METADATA_BALANCE_UPDATES_CATEGORY,
+  OperationContentsAndResult,
+  OperationContentsAndResultTransferTicket,
+  OpKind,
+} from '@taquito/rpc';
 import { defaultConfigConfirmation } from '../../src/context';
 import { TransferTicketOperation } from '../../src/operations/transfer-ticket-operation';
-
 
 describe('Transfer Operation L2 Tx Rollup', () => {
   let fakeContext: any;
@@ -13,13 +17,13 @@ describe('Transfer Operation L2 Tx Rollup', () => {
     fee: 804,
     gas_limit: 5009,
     storage_limit: 130,
-    ticket_contents: { "string": "foobar" },
-    ticket_ty: { "prim": "string" },
+    ticket_contents: { string: 'foobar' },
+    ticket_ty: { prim: 'string' },
     ticket_ticketer: 'KT1AL8we1Bfajn2M7i3gQM5PJEuyD36sXaYb',
     ticket_amount: 2,
     destination: 'KT1SUT2TBFPCknkBxLqM5eJZKoYVY6mB26Fg',
     entrypoint: 'default',
-    }
+  };
 
   const successfulResult = [
     {
@@ -29,8 +33,8 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       gas_limit: '5009',
       storage_limit: '130',
       counter: '145',
-      ticket_contents: { "string": "foobar" },
-      ticket_ty: { "prim": "string" },
+      ticket_contents: { string: 'foobar' },
+      ticket_ty: { prim: 'string' },
       ticket_ticketer: 'KT1AL8we1Bfajn2M7i3gQM5PJEuyD36sXaYb',
       ticket_amount: '2',
       destination: 'KT1SUT2TBFPCknkBxLqM5eJZKoYVY6mB26Fg',
@@ -42,14 +46,13 @@ describe('Transfer Operation L2 Tx Rollup', () => {
             contract: 'tz1iedjFYksExq8snZK9MNo4AvXHBdXfTsGX',
             change: '-804',
             origin: 'block',
-
           },
           {
             kind: 'accumulator',
             category: METADATA_BALANCE_UPDATES_CATEGORY.BLOCK_FEES,
             change: '804',
             origin: 'block',
-          }
+          },
         ],
         operation_result: {
           status: 'applied',
@@ -65,13 +68,13 @@ describe('Transfer Operation L2 Tx Rollup', () => {
               category: METADATA_BALANCE_UPDATES_CATEGORY.STORAGE_FEES,
               change: '16500',
               origin: 'block',
-            }
+            },
           ],
           consumed_milligas: '2122881',
           paid_storage_size_diff: '66',
         },
-      }
-    }
+      },
+    },
   ] as OperationContentsAndResult[];
 
   const successfulResultWithoutResults = [
@@ -82,8 +85,8 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       gas_limit: '5009',
       storage_limit: '130',
       counter: '145',
-      ticket_contents: { "string": "foobar" },
-      ticket_ty: { "prim": "string" },
+      ticket_contents: { string: 'foobar' },
+      ticket_ty: { prim: 'string' },
       ticket_ticketer: 'KT1AL8we1Bfajn2M7i3gQM5PJEuyD36sXaYb',
       ticket_amount: '2',
       destination: 'KT1SUT2TBFPCknkBxLqM5eJZKoYVY6mB26Fg',
@@ -95,18 +98,17 @@ describe('Transfer Operation L2 Tx Rollup', () => {
             contract: 'tz1iedjFYksExq8snZK9MNo4AvXHBdXfTsGX',
             change: '-804',
             origin: 'block',
-
           },
           {
             kind: 'accumulator',
             category: METADATA_BALANCE_UPDATES_CATEGORY.BLOCK_FEES,
             change: '804',
             origin: 'block',
-          }
+          },
         ],
-      }
-    }
-  ] as OperationContentsAndResult[]
+      },
+    },
+  ] as OperationContentsAndResult[];
 
   beforeEach(() => {
     fakeContext = {
@@ -117,12 +119,12 @@ describe('Transfer Operation L2 Tx Rollup', () => {
     };
 
     fakeContext.rpc.getBlock.mockResolvedValue({
-      operations:[[{hash: 'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz'}], [], [], []],
+      operations: [[{ hash: 'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz' }], [], [], []],
       headers: {
-        level: 1
-      }
-    })
-  })
+        level: 1,
+      },
+    });
+  });
 
   it('should return the fee', () => {
     const op = new TransferTicketOperation(
@@ -132,9 +134,9 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       fakeForgedBytes,
       successfulResult,
       fakeContext
-      )
-    expect(op.fee).toEqual(804)
-  })
+    );
+    expect(op.fee).toEqual(804);
+  });
   it('should return the gas limit', () => {
     const op = new TransferTicketOperation(
       'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
@@ -143,9 +145,34 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       fakeForgedBytes,
       successfulResult,
       fakeContext
-      )
-    expect(op.gasLimit).toEqual(5009)
-  })
+    );
+    expect(op.gasLimit).toEqual(5009);
+  });
+
+  it('should return the consumed gas', () => {
+    const op = new TransferTicketOperation(
+      'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
+      params,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedGas).toEqual('2123');
+  });
+
+  it('should return the consumed milligas', () => {
+    const op = new TransferTicketOperation(
+      'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
+      params,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedMilliGas).toEqual('2122881');
+  });
+
   it('should return the storage limit', () => {
     const op = new TransferTicketOperation(
       'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
@@ -154,9 +181,9 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       fakeForgedBytes,
       successfulResult,
       fakeContext
-      )
-    expect(op.storageLimit).toEqual(130)
-  })
+    );
+    expect(op.storageLimit).toEqual(130);
+  });
   it('should return the content', () => {
     const op = new TransferTicketOperation(
       'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
@@ -165,10 +192,10 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       fakeForgedBytes,
       successfulResult,
       fakeContext
-      )
-    const resultType = successfulResult[0] as OperationContentsAndResultTransferTicket
-    expect(op.operationResults).toEqual(resultType.metadata.operation_result)
-  })
+    );
+    const resultType = successfulResult[0] as OperationContentsAndResultTransferTicket;
+    expect(op.operationResults).toEqual(resultType.metadata.operation_result);
+  });
   it('should return the status with params', () => {
     const op = new TransferTicketOperation(
       'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
@@ -177,10 +204,10 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       fakeForgedBytes,
       successfulResult,
       fakeContext
-      )
-    const resultType = successfulResult[0] as OperationContentsAndResultTransferTicket
-    expect(op.status).toEqual(resultType.metadata.operation_result.status)
-  })
+    );
+    const resultType = successfulResult[0] as OperationContentsAndResultTransferTicket;
+    expect(op.status).toEqual(resultType.metadata.operation_result.status);
+  });
   it('should return the status unknown', () => {
     const op = new TransferTicketOperation(
       'opaUJ25WPbB4D5wR7AB8XPYCn6Q9hTm5ZfkUd43tR2SR4CRCGPz',
@@ -189,7 +216,7 @@ describe('Transfer Operation L2 Tx Rollup', () => {
       fakeForgedBytes,
       successfulResultWithoutResults,
       fakeContext
-      )
-    expect(op.status).toEqual('unknown')
-  })
-})
+    );
+    expect(op.status).toEqual('unknown');
+  });
+});

--- a/packages/taquito/test/operations/tx-rollup-origination-operation.spec.ts
+++ b/packages/taquito/test/operations/tx-rollup-origination-operation.spec.ts
@@ -48,7 +48,6 @@ describe('TxRollupOriginationOperation', () => {
               origin: 'block',
             },
           ],
-          consumed_gas: '1421',
           consumed_milligas: '1420108',
           originated_rollup: 'txr1WAEQXaXsM1n4R77G5BDfr8pwiFS5SEbBE',
         },
@@ -126,6 +125,31 @@ describe('TxRollupOriginationOperation', () => {
     );
     expect(op.gasLimit).toEqual(450);
   });
+
+  it('should return the consumed gas', () => {
+    const op = new TxRollupOriginationOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedGas).toEqual('1421');
+  });
+
+  it('should return the consumed milligas', () => {
+    const op = new TxRollupOriginationOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedMilliGas).toEqual('1420108');
+  });
+
   it('should return the storageLimit', () => {
     const op = new TxRollupOriginationOperation(
       'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',

--- a/packages/taquito/test/operations/tx-rollup-submit-batch.spec.ts
+++ b/packages/taquito/test/operations/tx-rollup-submit-batch.spec.ts
@@ -36,7 +36,6 @@ describe('TxRollupBatchOperation', () => {
         operation_result: {
           status: 'applied',
           balance_updates: [],
-          consumed_gas: '2769',
           consumed_milligas: '2768514',
           paid_storage_size_diff: '0',
         },
@@ -94,6 +93,30 @@ describe('TxRollupBatchOperation', () => {
       fakeContext
     );
     expect(op.gasLimit).toEqual(450);
+  });
+
+  it('should return the consumed gas', () => {
+    const op = new TxRollupBatchOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedGas).toEqual('2769');
+  });
+
+  it('should return the consumed milligas', () => {
+    const op = new TxRollupBatchOperation(
+      'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+      {} as any,
+      '',
+      fakeForgedBytes,
+      successfulResult,
+      fakeContext
+    );
+    expect(op.consumedMilliGas).toEqual('2768514');
   });
   it('should return the storageLimit', () => {
     const op = new TxRollupBatchOperation(


### PR DESCRIPTION
In kathmandu, the property consumed_gas is removed from the RPC responses in favor or
consumed_milligas. Added a getConsumedMilliGas getter on every Operation class from the Contract
API. Adjust the getConsumedGas getter to use the consumed_milligas divided by 1000 and rounded up. Fix
a small bug in the DelegateOperation class.

re #1769 (part 2)

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
