### PR TITLE
fix(wallet receipt): replace consumed_gas with consumed_milligas

### DIFF
--- a/packages/taquito/src/constants.ts
+++ b/packages/taquito/src/constants.ts
@@ -17,6 +17,8 @@ export enum DEFAULT_STORAGE_LIMIT {
   REVEAL = 0,
 }
 
+export const COST_PER_BYTE = 250;
+
 export enum Protocols {
   Pt24m4xi = 'Pt24m4xiPbLDhVgVfABUjirbmda3yohdN82Sp9FeuAXJ4eV9otd',
   PsBABY5H = 'PsBABY5HQTSkA4297zNHfsZNKtxULfL18y95qb3m53QJiXGmrbU',

--- a/packages/taquito/src/wallet/receipt.ts
+++ b/packages/taquito/src/wallet/receipt.ts
@@ -1,8 +1,7 @@
 import { OperationContentsAndResult } from '@taquito/rpc';
 import BigNumber from 'bignumber.js';
+import { COST_PER_BYTE } from '../constants';
 import { flattenOperationResult } from '../operations/operation-errors';
-
-export const COST_PER_BYTE = 250;
 
 export interface Receipt {
   totalFee: BigNumber;

--- a/packages/taquito/src/wallet/receipt.ts
+++ b/packages/taquito/src/wallet/receipt.ts
@@ -2,9 +2,12 @@ import { OperationContentsAndResult } from '@taquito/rpc';
 import BigNumber from 'bignumber.js';
 import { flattenOperationResult } from '../operations/operation-errors';
 
+export const COST_PER_BYTE = 250;
+
 export interface Receipt {
   totalFee: BigNumber;
   totalGas: BigNumber;
+  totalMilliGas: BigNumber;
   totalStorage: BigNumber;
   totalAllocationBurn: BigNumber;
   totalOriginationBurn: BigNumber;
@@ -19,14 +22,15 @@ export const receiptFromOperation = (
     ORIGINATION_BURN: 257,
   }
 ): Receipt => {
+  BigNumber.config({ DECIMAL_PLACES: 0, ROUNDING_MODE: BigNumber.ROUND_UP });
   const operationResults = flattenOperationResult({ contents: op });
-  let totalGas = new BigNumber(0);
+  let totalMilliGas = new BigNumber(0);
   let totalStorage = new BigNumber(0);
   let totalFee = new BigNumber(0);
   let totalOriginationBurn = new BigNumber(0);
   let totalAllocationBurn = new BigNumber(0);
   let totalPaidStorageDiff = new BigNumber(0);
-  operationResults.forEach(result => {
+  operationResults.forEach((result) => {
     totalFee = totalFee.plus(result.fee || 0);
     totalOriginationBurn = totalOriginationBurn.plus(
       Array.isArray(result.originated_contracts)
@@ -36,7 +40,7 @@ export const receiptFromOperation = (
     totalAllocationBurn = totalAllocationBurn.plus(
       'allocated_destination_contract' in result ? ALLOCATION_BURN : 0
     );
-    totalGas = totalGas.plus(result.consumed_gas || 0);
+    totalMilliGas = totalMilliGas.plus(result.consumed_milligas || 0);
     totalPaidStorageDiff = totalPaidStorageDiff.plus(
       'paid_storage_size_diff' in result ? Number(result.paid_storage_size_diff) || 0 : 0
     );
@@ -49,11 +53,12 @@ export const receiptFromOperation = (
 
   return {
     totalFee,
-    totalGas,
+    totalMilliGas,
+    totalGas: totalMilliGas.dividedBy(1000),
     totalStorage,
     totalAllocationBurn,
     totalOriginationBurn,
     totalPaidStorageDiff,
-    totalStorageBurn: new BigNumber(totalStorage.multipliedBy(1000)),
+    totalStorageBurn: new BigNumber(totalStorage.multipliedBy(COST_PER_BYTE)),
   };
 };

--- a/packages/taquito/test/wallet/data.ts
+++ b/packages/taquito/test/wallet/data.ts
@@ -1,0 +1,4837 @@
+export const blockResponse = {
+  protocol: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+  chain_id: 'NetXi2ZagzEsXbZ',
+  hash: 'BM6NRnbjdWqknmErSjMmkh49NjaVqq64TNmKTsdQRaWke5iqHpz',
+  header: {},
+  metadata: {},
+  operations: [
+    [],
+    [],
+    [],
+    [
+      {
+        protocol: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+        chain_id: 'NetXi2ZagzEsXbZ',
+        hash: 'oot9JqetdfF5KtZS7VoepGvB18aQENcQVzJ3G7WsQnCfQo3wmms',
+        branch: 'BKjC4cpfpHQhtMPRSzPcuNqshaHi3CouizZnNjDS4ei9cGFuwUj',
+        contents: [
+          {
+            kind: 'reveal',
+            source: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+            fee: '374',
+            counter: '118358',
+            gas_limit: '1100',
+            storage_limit: '0',
+            public_key: 'sppk7c5ZPpRTeMmf1XCZeZH8KezkqiYozouxjbk4c9ebYjkM4R5tki2',
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                  change: '-374',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '374',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                consumed_milligas: '1000000',
+              },
+            },
+          },
+          {
+            kind: 'origination',
+            source: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+            fee: '5943',
+            counter: '118359',
+            gas_limit: '3156',
+            storage_limit: '5591',
+            balance: '1000000',
+            script: {
+              code: [
+                {
+                  prim: 'parameter',
+                  args: [
+                    {
+                      prim: 'or',
+                      args: [
+                        {
+                          prim: 'pair',
+                          args: [
+                            {
+                              prim: 'address',
+                              annots: [':from'],
+                            },
+                            {
+                              prim: 'pair',
+                              args: [
+                                {
+                                  prim: 'address',
+                                  annots: [':to'],
+                                },
+                                {
+                                  prim: 'nat',
+                                  annots: [':value'],
+                                },
+                              ],
+                            },
+                          ],
+                          annots: ['%transfer'],
+                        },
+                        {
+                          prim: 'or',
+                          args: [
+                            {
+                              prim: 'pair',
+                              args: [
+                                {
+                                  prim: 'address',
+                                  annots: [':spender'],
+                                },
+                                {
+                                  prim: 'nat',
+                                  annots: [':value'],
+                                },
+                              ],
+                              annots: ['%approve'],
+                            },
+                            {
+                              prim: 'or',
+                              args: [
+                                {
+                                  prim: 'pair',
+                                  args: [
+                                    {
+                                      prim: 'pair',
+                                      args: [
+                                        {
+                                          prim: 'address',
+                                          annots: [':owner'],
+                                        },
+                                        {
+                                          prim: 'address',
+                                          annots: [':spender'],
+                                        },
+                                      ],
+                                    },
+                                    {
+                                      prim: 'contract',
+                                      args: [
+                                        {
+                                          prim: 'nat',
+                                          annots: [':remaining'],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                  annots: ['%getAllowance'],
+                                },
+                                {
+                                  prim: 'or',
+                                  args: [
+                                    {
+                                      prim: 'pair',
+                                      args: [
+                                        {
+                                          prim: 'address',
+                                          annots: [':owner'],
+                                        },
+                                        {
+                                          prim: 'contract',
+                                          args: [
+                                            {
+                                              prim: 'nat',
+                                              annots: [':balance'],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      annots: ['%getBalance'],
+                                    },
+                                    {
+                                      prim: 'or',
+                                      args: [
+                                        {
+                                          prim: 'pair',
+                                          args: [
+                                            {
+                                              prim: 'unit',
+                                            },
+                                            {
+                                              prim: 'contract',
+                                              args: [
+                                                {
+                                                  prim: 'nat',
+                                                  annots: [':totalSupply'],
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                          annots: ['%getTotalSupply'],
+                                        },
+                                        {
+                                          prim: 'or',
+                                          args: [
+                                            {
+                                              prim: 'bool',
+                                              annots: ['%setPause'],
+                                            },
+                                            {
+                                              prim: 'or',
+                                              args: [
+                                                {
+                                                  prim: 'address',
+                                                  annots: ['%setAdministrator'],
+                                                },
+                                                {
+                                                  prim: 'or',
+                                                  args: [
+                                                    {
+                                                      prim: 'pair',
+                                                      args: [
+                                                        {
+                                                          prim: 'unit',
+                                                        },
+                                                        {
+                                                          prim: 'contract',
+                                                          args: [
+                                                            {
+                                                              prim: 'address',
+                                                              annots: [':administrator'],
+                                                            },
+                                                          ],
+                                                        },
+                                                      ],
+                                                      annots: ['%getAdministrator'],
+                                                    },
+                                                    {
+                                                      prim: 'or',
+                                                      args: [
+                                                        {
+                                                          prim: 'pair',
+                                                          args: [
+                                                            {
+                                                              prim: 'address',
+                                                              annots: [':to'],
+                                                            },
+                                                            {
+                                                              prim: 'nat',
+                                                              annots: [':value'],
+                                                            },
+                                                          ],
+                                                          annots: ['%mint'],
+                                                        },
+                                                        {
+                                                          prim: 'pair',
+                                                          args: [
+                                                            {
+                                                              prim: 'address',
+                                                              annots: [':from'],
+                                                            },
+                                                            {
+                                                              prim: 'nat',
+                                                              annots: [':value'],
+                                                            },
+                                                          ],
+                                                          annots: ['%burn'],
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  prim: 'storage',
+                  args: [
+                    {
+                      prim: 'pair',
+                      args: [
+                        {
+                          prim: 'big_map',
+                          args: [
+                            {
+                              prim: 'address',
+                            },
+                            {
+                              prim: 'pair',
+                              args: [
+                                {
+                                  prim: 'nat',
+                                },
+                                {
+                                  prim: 'map',
+                                  args: [
+                                    {
+                                      prim: 'address',
+                                    },
+                                    {
+                                      prim: 'nat',
+                                    },
+                                  ],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                        {
+                          prim: 'pair',
+                          args: [
+                            {
+                              prim: 'address',
+                            },
+                            {
+                              prim: 'pair',
+                              args: [
+                                {
+                                  prim: 'bool',
+                                },
+                                {
+                                  prim: 'nat',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  prim: 'code',
+                  args: [
+                    [
+                      {
+                        prim: 'DUP',
+                      },
+                      {
+                        prim: 'CAR',
+                      },
+                      {
+                        prim: 'DIP',
+                        args: [
+                          [
+                            {
+                              prim: 'CDR',
+                            },
+                          ],
+                        ],
+                      },
+                      {
+                        prim: 'IF_LEFT',
+                        args: [
+                          [
+                            {
+                              prim: 'DIP',
+                              args: [
+                                [
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'pair',
+                                              args: [
+                                                {
+                                                  prim: 'string',
+                                                },
+                                                {
+                                                  prim: 'unit',
+                                                },
+                                              ],
+                                            },
+                                            {
+                                              prim: 'Pair',
+                                              args: [
+                                                {
+                                                  string: 'OperationsArePaused',
+                                                },
+                                                {
+                                                  prim: 'Unit',
+                                                },
+                                              ],
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          prim: 'FAILWITH',
+                                        },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                ],
+                              ],
+                            },
+                            {
+                              prim: 'DUP',
+                            },
+                            {
+                              prim: 'CDR',
+                            },
+                            {
+                              prim: 'CAR',
+                            },
+                            {
+                              prim: 'DIP',
+                              args: [
+                                [
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                ],
+                              ],
+                            },
+                            {
+                              prim: 'CAST',
+                              args: [
+                                {
+                                  prim: 'address',
+                                },
+                              ],
+                            },
+                            {
+                              prim: 'COMPARE',
+                            },
+                            {
+                              prim: 'EQ',
+                            },
+                            {
+                              prim: 'IF',
+                              args: [
+                                [
+                                  {
+                                    prim: 'DROP',
+                                  },
+                                ],
+                                [
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SENDER',
+                                  },
+                                  {
+                                    prim: 'COMPARE',
+                                  },
+                                  {
+                                    prim: 'EQ',
+                                  },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DROP',
+                                        },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'bool',
+                                            },
+                                            {
+                                              prim: 'False',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      [
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'SENDER',
+                                        },
+                                        {
+                                          prim: 'COMPARE',
+                                        },
+                                        {
+                                          prim: 'NEQ',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DUP',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                    {
+                                                      prim: 'SENDER',
+                                                    },
+                                                    {
+                                                      prim: 'PAIR',
+                                                    },
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'CDR',
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'CAR',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'GET',
+                                                          },
+                                                          {
+                                                            prim: 'IF_NONE',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'EMPTY_MAP',
+                                                                  args: [
+                                                                    {
+                                                                      prim: 'address',
+                                                                    },
+                                                                    {
+                                                                      prim: 'nat',
+                                                                    },
+                                                                  ],
+                                                                },
+                                                              ],
+                                                              [
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                    {
+                                                      prim: 'GET',
+                                                    },
+                                                    {
+                                                      prim: 'IF_NONE',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'PUSH',
+                                                            args: [
+                                                              {
+                                                                prim: 'nat',
+                                                              },
+                                                              {
+                                                                int: '0',
+                                                              },
+                                                            ],
+                                                          },
+                                                        ],
+                                                        [],
+                                                      ],
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'SENDER',
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DUP',
+                                                          },
+                                                          {
+                                                            prim: 'CDR',
+                                                          },
+                                                          {
+                                                            prim: 'CDR',
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'SWAP',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'SWAP',
+                                                          },
+                                                          {
+                                                            prim: 'SUB',
+                                                          },
+                                                          {
+                                                            prim: 'ISNAT',
+                                                          },
+                                                          {
+                                                            prim: 'IF_NONE',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'SWAP',
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'SWAP',
+                                                                },
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                                {
+                                                                  prim: 'PAIR',
+                                                                },
+                                                                {
+                                                                  prim: 'PUSH',
+                                                                  args: [
+                                                                    {
+                                                                      prim: 'string',
+                                                                    },
+                                                                    {
+                                                                      string: 'NotEnoughAllowance',
+                                                                    },
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'PAIR',
+                                                                },
+                                                                {
+                                                                  prim: 'FAILWITH',
+                                                                },
+                                                              ],
+                                                              [],
+                                                            ],
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'PAIR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DROP',
+                                                    },
+                                                    {
+                                                      prim: 'DROP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'GET',
+                                              },
+                                              {
+                                                prim: 'IF_NONE',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'PUSH',
+                                                      args: [
+                                                        {
+                                                          prim: 'nat',
+                                                        },
+                                                        {
+                                                          int: '0',
+                                                        },
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'EMPTY_MAP',
+                                                            args: [
+                                                              {
+                                                                prim: 'address',
+                                                              },
+                                                              {
+                                                                prim: 'nat',
+                                                              },
+                                                            ],
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'PAIR',
+                                                    },
+                                                    {
+                                                      prim: 'EMPTY_MAP',
+                                                      args: [
+                                                        {
+                                                          prim: 'address',
+                                                        },
+                                                        {
+                                                          prim: 'nat',
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DUP',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'SWAP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'INT',
+                                              },
+                                              {
+                                                prim: 'EQ',
+                                              },
+                                              {
+                                                prim: 'IF',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DROP',
+                                                    },
+                                                    {
+                                                      prim: 'NONE',
+                                                      args: [
+                                                        {
+                                                          prim: 'nat',
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'SOME',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'SWAP',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'SWAP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                              {
+                                                prim: 'UPDATE',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'CAR',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DROP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                              {
+                                                prim: 'SOME',
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DUP',
+                                                          },
+                                                          {
+                                                            prim: 'CAR',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'UPDATE',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'CDR',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DROP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'GET',
+                                  },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'INT',
+                                        },
+                                        {
+                                          prim: 'EQ',
+                                        },
+                                        {
+                                          prim: 'IF',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'NONE',
+                                                args: [
+                                                  {
+                                                    prim: 'pair',
+                                                    args: [
+                                                      {
+                                                        prim: 'nat',
+                                                      },
+                                                      {
+                                                        prim: 'map',
+                                                        args: [
+                                                          {
+                                                            prim: 'address',
+                                                          },
+                                                          {
+                                                            prim: 'nat',
+                                                          },
+                                                        ],
+                                                      },
+                                                    ],
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'EMPTY_MAP',
+                                                      args: [
+                                                        {
+                                                          prim: 'address',
+                                                        },
+                                                        {
+                                                          prim: 'nat',
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                              {
+                                                prim: 'SOME',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'ADD',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'SOME',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'UPDATE',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'INT',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'ADD',
+                                        },
+                                        {
+                                          prim: 'ISNAT',
+                                        },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [
+                                                  {
+                                                    prim: 'string',
+                                                  },
+                                                  {
+                                                    string:
+                                                      'Unexpected failure: Negative total supply\nCallStack (from HasCallStack):\n  failUnexpected, called at src/Lorentz/Contracts/ManagedLedger.hs:313:27 in lorentz-contracts-0.2.0.1-HpDIkWsKofu3zAjntLgs8J:Lorentz.Contracts.ManagedLedger',
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                prim: 'FAILWITH',
+                                              },
+                                            ],
+                                            [],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'GET',
+                                  },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'nat',
+                                            },
+                                            {
+                                              int: '0',
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'string',
+                                            },
+                                            {
+                                              string: 'NotEnoughBalance',
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'FAILWITH',
+                                        },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'SUB',
+                                  },
+                                  {
+                                    prim: 'ISNAT',
+                                  },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'string',
+                                            },
+                                            {
+                                              string: 'NotEnoughBalance',
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'FAILWITH',
+                                        },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DROP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'PAIR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'INT',
+                                        },
+                                        {
+                                          prim: 'EQ',
+                                        },
+                                        {
+                                          prim: 'IF',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'SIZE',
+                                              },
+                                              {
+                                                prim: 'INT',
+                                              },
+                                              {
+                                                prim: 'EQ',
+                                              },
+                                              {
+                                                prim: 'IF',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DROP',
+                                                    },
+                                                    {
+                                                      prim: 'NONE',
+                                                      args: [
+                                                        {
+                                                          prim: 'pair',
+                                                          args: [
+                                                            {
+                                                              prim: 'nat',
+                                                            },
+                                                            {
+                                                              prim: 'map',
+                                                              args: [
+                                                                {
+                                                                  prim: 'address',
+                                                                },
+                                                                {
+                                                                  prim: 'nat',
+                                                                },
+                                                              ],
+                                                            },
+                                                          ],
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'SOME',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                            ],
+                                            [
+                                              {
+                                                prim: 'SOME',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'UPDATE',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'NEG',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'ADD',
+                                        },
+                                        {
+                                          prim: 'ISNAT',
+                                        },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [
+                                                  {
+                                                    prim: 'string',
+                                                  },
+                                                  {
+                                                    string:
+                                                      'Unexpected failure: Negative total supply\nCallStack (from HasCallStack):\n  failUnexpected, called at src/Lorentz/Contracts/ManagedLedger.hs:313:27 in lorentz-contracts-0.2.0.1-HpDIkWsKofu3zAjntLgs8J:Lorentz.Contracts.ManagedLedger',
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                prim: 'FAILWITH',
+                                              },
+                                            ],
+                                            [],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DROP',
+                                  },
+                                ],
+                              ],
+                            },
+                            {
+                              prim: 'NIL',
+                              args: [
+                                {
+                                  prim: 'operation',
+                                },
+                              ],
+                            },
+                            {
+                              prim: 'PAIR',
+                            },
+                          ],
+                          [
+                            {
+                              prim: 'IF_LEFT',
+                              args: [
+                                [
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'IF',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [
+                                                  {
+                                                    prim: 'pair',
+                                                    args: [
+                                                      {
+                                                        prim: 'string',
+                                                      },
+                                                      {
+                                                        prim: 'unit',
+                                                      },
+                                                    ],
+                                                  },
+                                                  {
+                                                    prim: 'Pair',
+                                                    args: [
+                                                      {
+                                                        string: 'OperationsArePaused',
+                                                      },
+                                                      {
+                                                        prim: 'Unit',
+                                                      },
+                                                    ],
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                prim: 'FAILWITH',
+                                              },
+                                            ],
+                                            [],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SENDER',
+                                  },
+                                  {
+                                    prim: 'PAIR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'GET',
+                                        },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'EMPTY_MAP',
+                                                args: [
+                                                  {
+                                                    prim: 'address',
+                                                  },
+                                                  {
+                                                    prim: 'nat',
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                            [
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'GET',
+                                  },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'nat',
+                                            },
+                                            {
+                                              int: '0',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      [],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'INT',
+                                  },
+                                  {
+                                    prim: 'EQ',
+                                  },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DROP',
+                                        },
+                                      ],
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'INT',
+                                        },
+                                        {
+                                          prim: 'EQ',
+                                        },
+                                        {
+                                          prim: 'IF',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DROP',
+                                              },
+                                            ],
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [
+                                                  {
+                                                    prim: 'string',
+                                                  },
+                                                  {
+                                                    string: 'UnsafeAllowanceChange',
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                              {
+                                                prim: 'FAILWITH',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'GET',
+                                  },
+                                  {
+                                    prim: 'IF_NONE',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'PUSH',
+                                          args: [
+                                            {
+                                              prim: 'nat',
+                                            },
+                                            {
+                                              int: '0',
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'EMPTY_MAP',
+                                                args: [
+                                                  {
+                                                    prim: 'address',
+                                                  },
+                                                  {
+                                                    prim: 'nat',
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'EMPTY_MAP',
+                                          args: [
+                                            {
+                                              prim: 'address',
+                                            },
+                                            {
+                                              prim: 'nat',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'DUP',
+                                  },
+                                  {
+                                    prim: 'INT',
+                                  },
+                                  {
+                                    prim: 'EQ',
+                                  },
+                                  {
+                                    prim: 'IF',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DROP',
+                                        },
+                                        {
+                                          prim: 'NONE',
+                                          args: [
+                                            {
+                                              prim: 'nat',
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                      [
+                                        {
+                                          prim: 'SOME',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CDR',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'UPDATE',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DROP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'PAIR',
+                                  },
+                                  {
+                                    prim: 'SOME',
+                                  },
+                                  {
+                                    prim: 'SWAP',
+                                  },
+                                  {
+                                    prim: 'CAR',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'UPDATE',
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'DIP',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DROP',
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                  {
+                                    prim: 'PAIR',
+                                  },
+                                  {
+                                    prim: 'NIL',
+                                    args: [
+                                      {
+                                        prim: 'operation',
+                                      },
+                                    ],
+                                  },
+                                  {
+                                    prim: 'PAIR',
+                                  },
+                                ],
+                                [
+                                  {
+                                    prim: 'IF_LEFT',
+                                    args: [
+                                      [
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'CAR',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CDR',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DUP',
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'GET',
+                                              },
+                                              {
+                                                prim: 'IF_NONE',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'EMPTY_MAP',
+                                                      args: [
+                                                        {
+                                                          prim: 'address',
+                                                        },
+                                                        {
+                                                          prim: 'nat',
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'CDR',
+                                        },
+                                        {
+                                          prim: 'GET',
+                                        },
+                                        {
+                                          prim: 'IF_NONE',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'PUSH',
+                                                args: [
+                                                  {
+                                                    prim: 'nat',
+                                                  },
+                                                  {
+                                                    int: '0',
+                                                  },
+                                                ],
+                                              },
+                                            ],
+                                            [],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'DIP',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'AMOUNT',
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                        {
+                                          prim: 'TRANSFER_TOKENS',
+                                        },
+                                        {
+                                          prim: 'NIL',
+                                          args: [
+                                            {
+                                              prim: 'operation',
+                                            },
+                                          ],
+                                        },
+                                        {
+                                          prim: 'SWAP',
+                                        },
+                                        {
+                                          prim: 'CONS',
+                                        },
+                                        {
+                                          prim: 'PAIR',
+                                        },
+                                      ],
+                                      [
+                                        {
+                                          prim: 'IF_LEFT',
+                                          args: [
+                                            [
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DUP',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'SWAP',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                              {
+                                                prim: 'DUP',
+                                              },
+                                              {
+                                                prim: 'CAR',
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'GET',
+                                              },
+                                              {
+                                                prim: 'IF_NONE',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'PUSH',
+                                                      args: [
+                                                        {
+                                                          prim: 'nat',
+                                                        },
+                                                        {
+                                                          int: '0',
+                                                        },
+                                                      ],
+                                                    },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'DIP',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'AMOUNT',
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                              {
+                                                prim: 'TRANSFER_TOKENS',
+                                              },
+                                              {
+                                                prim: 'NIL',
+                                                args: [
+                                                  {
+                                                    prim: 'operation',
+                                                  },
+                                                ],
+                                              },
+                                              {
+                                                prim: 'SWAP',
+                                              },
+                                              {
+                                                prim: 'CONS',
+                                              },
+                                              {
+                                                prim: 'PAIR',
+                                              },
+                                            ],
+                                            [
+                                              {
+                                                prim: 'IF_LEFT',
+                                                args: [
+                                                  [
+                                                    {
+                                                      prim: 'DUP',
+                                                    },
+                                                    {
+                                                      prim: 'CAR',
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'CDR',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'SWAP',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'PAIR',
+                                                    },
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                    {
+                                                      prim: 'CDR',
+                                                    },
+                                                    {
+                                                      prim: 'DIP',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'AMOUNT',
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'TRANSFER_TOKENS',
+                                                    },
+                                                    {
+                                                      prim: 'NIL',
+                                                      args: [
+                                                        {
+                                                          prim: 'operation',
+                                                        },
+                                                      ],
+                                                    },
+                                                    {
+                                                      prim: 'SWAP',
+                                                    },
+                                                    {
+                                                      prim: 'CONS',
+                                                    },
+                                                    {
+                                                      prim: 'PAIR',
+                                                    },
+                                                  ],
+                                                  [
+                                                    {
+                                                      prim: 'IF_LEFT',
+                                                      args: [
+                                                        [
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                                {
+                                                                  prim: 'CAR',
+                                                                },
+                                                                {
+                                                                  prim: 'SENDER',
+                                                                },
+                                                                {
+                                                                  prim: 'COMPARE',
+                                                                },
+                                                                {
+                                                                  prim: 'EQ',
+                                                                },
+                                                                {
+                                                                  prim: 'IF',
+                                                                  args: [
+                                                                    [],
+                                                                    [
+                                                                      {
+                                                                        prim: 'PUSH',
+                                                                        args: [
+                                                                          {
+                                                                            prim: 'pair',
+                                                                            args: [
+                                                                              {
+                                                                                prim: 'string',
+                                                                              },
+                                                                              {
+                                                                                prim: 'unit',
+                                                                              },
+                                                                            ],
+                                                                          },
+                                                                          {
+                                                                            prim: 'Pair',
+                                                                            args: [
+                                                                              {
+                                                                                string:
+                                                                                  'SenderIsNotAdmin',
+                                                                              },
+                                                                              {
+                                                                                prim: 'Unit',
+                                                                              },
+                                                                            ],
+                                                                          },
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'FAILWITH',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'CAR',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'CDR',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'CAR',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DROP',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'PAIR',
+                                                          },
+                                                          {
+                                                            prim: 'SWAP',
+                                                          },
+                                                          {
+                                                            prim: 'PAIR',
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DUP',
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'CAR',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'CDR',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'DIP',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DROP',
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'SWAP',
+                                                          },
+                                                          {
+                                                            prim: 'PAIR',
+                                                          },
+                                                          {
+                                                            prim: 'NIL',
+                                                            args: [
+                                                              {
+                                                                prim: 'operation',
+                                                              },
+                                                            ],
+                                                          },
+                                                          {
+                                                            prim: 'PAIR',
+                                                          },
+                                                        ],
+                                                        [
+                                                          {
+                                                            prim: 'IF_LEFT',
+                                                            args: [
+                                                              [
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CDR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CAR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'SENDER',
+                                                                      },
+                                                                      {
+                                                                        prim: 'COMPARE',
+                                                                      },
+                                                                      {
+                                                                        prim: 'EQ',
+                                                                      },
+                                                                      {
+                                                                        prim: 'IF',
+                                                                        args: [
+                                                                          [],
+                                                                          [
+                                                                            {
+                                                                              prim: 'PUSH',
+                                                                              args: [
+                                                                                {
+                                                                                  prim: 'pair',
+                                                                                  args: [
+                                                                                    {
+                                                                                      prim: 'string',
+                                                                                    },
+                                                                                    {
+                                                                                      prim: 'unit',
+                                                                                    },
+                                                                                  ],
+                                                                                },
+                                                                                {
+                                                                                  prim: 'Pair',
+                                                                                  args: [
+                                                                                    {
+                                                                                      string:
+                                                                                        'SenderIsNotAdmin',
+                                                                                    },
+                                                                                    {
+                                                                                      prim: 'Unit',
+                                                                                    },
+                                                                                  ],
+                                                                                },
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'FAILWITH',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CDR',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                      {
+                                                                        prim: 'DIP',
+                                                                        args: [
+                                                                          [
+                                                                            {
+                                                                              prim: 'CDR',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'CAR',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DROP',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'PAIR',
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                      {
+                                                                        prim: 'DIP',
+                                                                        args: [
+                                                                          [
+                                                                            {
+                                                                              prim: 'CAR',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'CDR',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'DIP',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DROP',
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'SWAP',
+                                                                },
+                                                                {
+                                                                  prim: 'PAIR',
+                                                                },
+                                                                {
+                                                                  prim: 'NIL',
+                                                                  args: [
+                                                                    {
+                                                                      prim: 'operation',
+                                                                    },
+                                                                  ],
+                                                                },
+                                                                {
+                                                                  prim: 'PAIR',
+                                                                },
+                                                              ],
+                                                              [
+                                                                {
+                                                                  prim: 'IF_LEFT',
+                                                                  args: [
+                                                                    [
+                                                                      {
+                                                                        prim: 'DUP',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CAR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'DIP',
+                                                                        args: [
+                                                                          [
+                                                                            {
+                                                                              prim: 'CDR',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'DIP',
+                                                                        args: [
+                                                                          [
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'PAIR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CDR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CDR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CAR',
+                                                                      },
+                                                                      {
+                                                                        prim: 'DIP',
+                                                                        args: [
+                                                                          [
+                                                                            {
+                                                                              prim: 'AMOUNT',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'TRANSFER_TOKENS',
+                                                                      },
+                                                                      {
+                                                                        prim: 'NIL',
+                                                                        args: [
+                                                                          {
+                                                                            prim: 'operation',
+                                                                          },
+                                                                        ],
+                                                                      },
+                                                                      {
+                                                                        prim: 'SWAP',
+                                                                      },
+                                                                      {
+                                                                        prim: 'CONS',
+                                                                      },
+                                                                      {
+                                                                        prim: 'PAIR',
+                                                                      },
+                                                                    ],
+                                                                    [
+                                                                      {
+                                                                        prim: 'IF_LEFT',
+                                                                        args: [
+                                                                          [
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SENDER',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'COMPARE',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'EQ',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'IF',
+                                                                                    args: [
+                                                                                      [],
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'PUSH',
+                                                                                          args: [
+                                                                                            {
+                                                                                              prim: 'pair',
+                                                                                              args: [
+                                                                                                {
+                                                                                                  prim: 'string',
+                                                                                                },
+                                                                                                {
+                                                                                                  prim: 'unit',
+                                                                                                },
+                                                                                              ],
+                                                                                            },
+                                                                                            {
+                                                                                              prim: 'Pair',
+                                                                                              args: [
+                                                                                                {
+                                                                                                  string:
+                                                                                                    'SenderIsNotAdmin',
+                                                                                                },
+                                                                                                {
+                                                                                                  prim: 'Unit',
+                                                                                                },
+                                                                                              ],
+                                                                                            },
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'FAILWITH',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'CAR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'CAR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'GET',
+                                                                            },
+                                                                            {
+                                                                              prim: 'IF_NONE',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'INT',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'EQ',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'IF',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'NONE',
+                                                                                          args: [
+                                                                                            {
+                                                                                              prim: 'pair',
+                                                                                              args: [
+                                                                                                {
+                                                                                                  prim: 'nat',
+                                                                                                },
+                                                                                                {
+                                                                                                  prim: 'map',
+                                                                                                  args: [
+                                                                                                    {
+                                                                                                      prim: 'address',
+                                                                                                    },
+                                                                                                    {
+                                                                                                      prim: 'nat',
+                                                                                                    },
+                                                                                                  ],
+                                                                                                },
+                                                                                              ],
+                                                                                            },
+                                                                                          ],
+                                                                                        },
+                                                                                      ],
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'EMPTY_MAP',
+                                                                                                args: [
+                                                                                                  {
+                                                                                                    prim: 'address',
+                                                                                                  },
+                                                                                                  {
+                                                                                                    prim: 'nat',
+                                                                                                  },
+                                                                                                ],
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'PAIR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'SOME',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                ],
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CAR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'ADD',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CDR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CAR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SOME',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CAR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DUP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'UPDATE',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CDR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CAR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DUP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'INT',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'ADD',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'ISNAT',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'IF_NONE',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'PUSH',
+                                                                                          args: [
+                                                                                            {
+                                                                                              prim: 'string',
+                                                                                            },
+                                                                                            {
+                                                                                              string:
+                                                                                                'Unexpected failure: Negative total supply\nCallStack (from HasCallStack):\n  failUnexpected, called at src/Lorentz/Contracts/ManagedLedger.hs:313:27 in lorentz-contracts-0.2.0.1-HpDIkWsKofu3zAjntLgs8J:Lorentz.Contracts.ManagedLedger',
+                                                                                            },
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'FAILWITH',
+                                                                                        },
+                                                                                      ],
+                                                                                      [],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DROP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'NIL',
+                                                                              args: [
+                                                                                {
+                                                                                  prim: 'operation',
+                                                                                },
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'PAIR',
+                                                                            },
+                                                                          ],
+                                                                          [
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SENDER',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'COMPARE',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'EQ',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'IF',
+                                                                                    args: [
+                                                                                      [],
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'PUSH',
+                                                                                          args: [
+                                                                                            {
+                                                                                              prim: 'pair',
+                                                                                              args: [
+                                                                                                {
+                                                                                                  prim: 'string',
+                                                                                                },
+                                                                                                {
+                                                                                                  prim: 'unit',
+                                                                                                },
+                                                                                              ],
+                                                                                            },
+                                                                                            {
+                                                                                              prim: 'Pair',
+                                                                                              args: [
+                                                                                                {
+                                                                                                  string:
+                                                                                                    'SenderIsNotAdmin',
+                                                                                                },
+                                                                                                {
+                                                                                                  prim: 'Unit',
+                                                                                                },
+                                                                                              ],
+                                                                                            },
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'FAILWITH',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'CAR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'CAR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'GET',
+                                                                            },
+                                                                            {
+                                                                              prim: 'IF_NONE',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PUSH',
+                                                                                    args: [
+                                                                                      {
+                                                                                        prim: 'nat',
+                                                                                      },
+                                                                                      {
+                                                                                        int: '0',
+                                                                                      },
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PUSH',
+                                                                                    args: [
+                                                                                      {
+                                                                                        prim: 'string',
+                                                                                      },
+                                                                                      {
+                                                                                        string:
+                                                                                          'NotEnoughBalance',
+                                                                                      },
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'FAILWITH',
+                                                                                  },
+                                                                                ],
+                                                                                [],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DUP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'CAR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'CDR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'SUB',
+                                                                            },
+                                                                            {
+                                                                              prim: 'ISNAT',
+                                                                            },
+                                                                            {
+                                                                              prim: 'IF_NONE',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PUSH',
+                                                                                    args: [
+                                                                                      {
+                                                                                        prim: 'string',
+                                                                                      },
+                                                                                      {
+                                                                                        string:
+                                                                                          'NotEnoughBalance',
+                                                                                      },
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'FAILWITH',
+                                                                                  },
+                                                                                ],
+                                                                                [],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DROP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'PAIR',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'SWAP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'DUP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'INT',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'EQ',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'IF',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'SIZE',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'INT',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'EQ',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'IF',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'DROP',
+                                                                                              },
+                                                                                              {
+                                                                                                prim: 'NONE',
+                                                                                                args: [
+                                                                                                  {
+                                                                                                    prim: 'pair',
+                                                                                                    args: [
+                                                                                                      {
+                                                                                                        prim: 'nat',
+                                                                                                      },
+                                                                                                      {
+                                                                                                        prim: 'map',
+                                                                                                        args: [
+                                                                                                          {
+                                                                                                            prim: 'address',
+                                                                                                          },
+                                                                                                          {
+                                                                                                            prim: 'nat',
+                                                                                                          },
+                                                                                                        ],
+                                                                                                      },
+                                                                                                    ],
+                                                                                                  },
+                                                                                                ],
+                                                                                              },
+                                                                                            ],
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'SOME',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                      ],
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'SOME',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'CAR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'DUP',
+                                                                                              },
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'UPDATE',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CDR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CAR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DUP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'DIP',
+                                                                              args: [
+                                                                                [
+                                                                                  {
+                                                                                    prim: 'CDR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'NEG',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'ADD',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'ISNAT',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'IF_NONE',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'PUSH',
+                                                                                          args: [
+                                                                                            {
+                                                                                              prim: 'string',
+                                                                                            },
+                                                                                            {
+                                                                                              string:
+                                                                                                'Unexpected failure: Negative total supply\nCallStack (from HasCallStack):\n  failUnexpected, called at src/Lorentz/Contracts/ManagedLedger.hs:313:27 in lorentz-contracts-0.2.0.1-HpDIkWsKofu3zAjntLgs8J:Lorentz.Contracts.ManagedLedger',
+                                                                                            },
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'FAILWITH',
+                                                                                        },
+                                                                                      ],
+                                                                                      [],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DUP',
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'DIP',
+                                                                                          args: [
+                                                                                            [
+                                                                                              {
+                                                                                                prim: 'CAR',
+                                                                                              },
+                                                                                            ],
+                                                                                          ],
+                                                                                        },
+                                                                                        {
+                                                                                          prim: 'CDR',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'DIP',
+                                                                                    args: [
+                                                                                      [
+                                                                                        {
+                                                                                          prim: 'DROP',
+                                                                                        },
+                                                                                      ],
+                                                                                    ],
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'SWAP',
+                                                                                  },
+                                                                                  {
+                                                                                    prim: 'PAIR',
+                                                                                  },
+                                                                                ],
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'DROP',
+                                                                            },
+                                                                            {
+                                                                              prim: 'NIL',
+                                                                              args: [
+                                                                                {
+                                                                                  prim: 'operation',
+                                                                                },
+                                                                              ],
+                                                                            },
+                                                                            {
+                                                                              prim: 'PAIR',
+                                                                            },
+                                                                          ],
+                                                                        ],
+                                                                      },
+                                                                    ],
+                                                                  ],
+                                                                },
+                                                              ],
+                                                            ],
+                                                          },
+                                                        ],
+                                                      ],
+                                                    },
+                                                  ],
+                                                ],
+                                              },
+                                            ],
+                                          ],
+                                        },
+                                      ],
+                                    ],
+                                  },
+                                ],
+                              ],
+                            },
+                          ],
+                        ],
+                      },
+                    ],
+                  ],
+                },
+              ],
+              storage: {
+                prim: 'Pair',
+                args: [
+                  [
+                    {
+                      prim: 'Elt',
+                      args: [
+                        {
+                          string: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                        },
+                        {
+                          prim: 'Pair',
+                          args: [
+                            {
+                              int: '2',
+                            },
+                            [],
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                  {
+                    prim: 'Pair',
+                    args: [
+                      {
+                        string: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                      },
+                      {
+                        prim: 'Pair',
+                        args: [
+                          {
+                            prim: 'False',
+                          },
+                          {
+                            int: '200',
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                  change: '-5943',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '5943',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                balance_updates: [
+                  {
+                    kind: 'contract',
+                    contract: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                    change: '-1333500',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'burned',
+                    category: 'storage fees',
+                    change: '1333500',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'contract',
+                    contract: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                    change: '-64250',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'burned',
+                    category: 'storage fees',
+                    change: '64250',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'contract',
+                    contract: 'tz29SSCBkTYXK4stSPosByHC4h26WDB3N11o',
+                    change: '-1000000',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'contract',
+                    contract: 'KT1VL1jr716oN2tRZo5kavH1uZvdigsBFZfE',
+                    change: '1000000',
+                    origin: 'block',
+                  },
+                ],
+                originated_contracts: ['KT1VL1jr716oN2tRZo5kavH1uZvdigsBFZfE'],
+                consumed_milligas: '3055338',
+                storage_size: '5334',
+                paid_storage_size_diff: '5334',
+                lazy_storage_diff: [
+                  {
+                    kind: 'big_map',
+                    id: '18017',
+                    diff: {
+                      action: 'alloc',
+                      updates: [
+                        {
+                          key_hash: 'expru4tqUZyJzVXwYSTrPjA7jHVktca5Mpj8YCyfCfTx2rqmqsnVjY',
+                          key: {
+                            bytes: '00010c54a9f271091316a015922761e7b6fa59f64d5c',
+                          },
+                          value: {
+                            prim: 'Pair',
+                            args: [
+                              {
+                                int: '2',
+                              },
+                              [],
+                            ],
+                          },
+                        },
+                      ],
+                      key_type: {
+                        prim: 'address',
+                      },
+                      value_type: {
+                        prim: 'pair',
+                        args: [
+                          {
+                            prim: 'nat',
+                          },
+                          {
+                            prim: 'map',
+                            args: [
+                              {
+                                prim: 'address',
+                              },
+                              {
+                                prim: 'nat',
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        signature:
+          'sigNz82U5DSZEDPyNz1kC1rJ8BjufB4ziqr8Ey4wnaHbSWqhh3gxn49cG3mwiQSWRPNGkhZ9KNS7Pk9NM1VyzoZ5TFF6yDr9',
+      },
+    ],
+  ],
+};

--- a/packages/taquito/test/wallet/operation.spec.ts
+++ b/packages/taquito/test/wallet/operation.spec.ts
@@ -2,6 +2,7 @@ import { BlockResponse } from '@taquito/rpc';
 import { rxSandbox } from 'rx-sandbox';
 import { Context } from '../../src/context';
 import { WalletOperation } from '../../src/wallet';
+import { blockResponse } from './data';
 describe('WalletOperation', () => {
   const toJSON = (x: any) => JSON.parse(JSON.stringify(x));
 
@@ -143,10 +144,40 @@ describe('WalletOperation', () => {
         totalAllocationBurn: '0',
         totalFee: '0',
         totalGas: '0',
+        totalMilliGas: '0',
         totalOriginationBurn: '0',
         totalPaidStorageDiff: '0',
         totalStorage: '0',
         totalStorageBurn: '0',
+      });
+
+      done();
+    });
+
+    it('should return a receipt from actual case values ​​after including the operation in a block', async (done) => {
+      const { cold, flush } = rxSandbox.create();
+      const blockObs = cold<BlockResponse>('--a', {
+        a: blockResponse as unknown as BlockResponse,
+      });
+
+      const op = new WalletOperation(
+        'oot9JqetdfF5KtZS7VoepGvB18aQENcQVzJ3G7WsQnCfQo3wmms',
+        new Context('url'),
+        blockObs
+      );
+
+      flush();
+      const receipt = await op.receipt();
+
+      expect(toJSON(receipt)).toEqual({
+        totalFee: '6317',
+        totalGas: '4056',
+        totalMilliGas: '4055338',
+        totalOriginationBurn: '257',
+        totalPaidStorageDiff: '5334',
+        totalStorage: '5591',
+        totalStorageBurn: '1397750',
+        totalAllocationBurn: '0',
       });
 
       done();


### PR DESCRIPTION
In kathmandu, the property consumed_gas is removed from the RPC responses in favor of
consumed_milligas. Added a totalMilliGas property to the receipt and totalGas is now the total
milliGas divided by 1000 and roundedup.

re #1769

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
