### PR TITLE
test(integration test): 1 manager operation per manager per block

### DIFF
--- a/docs/batch-api.md
+++ b/docs/batch-api.md
@@ -20,7 +20,12 @@ await op1.confirmation();
 await op2.confirmation();
 
 /*
- * Error Message returned by the node:
+ * Error Message returned by the node (since Kathmandu):
+ * Error while applying operation opHash: 
+ * Only one manager operation per manager per block allowed (found opHash2 with Xtez fee. 
+ * You may want to use --replace to provide adequate fee and replace it).
+ * 
+ * Error Message that was returned by the node (before Kathmandu):
  * "Error while applying operation opWH2nEcmmzUwK4T6agHg3bn9GDR7fW1ynqWL58AVRAb7aZFciD:
  * branch refused (Error:
  * Counter 1122148 already used for contract tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb (expected 1122149))"

--- a/integration-tests/injecting-multiple-manager-operations-in-a-block.spec.ts
+++ b/integration-tests/injecting-multiple-manager-operations-in-a-block.spec.ts
@@ -1,0 +1,25 @@
+import { CONFIGS } from "./config";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+    const Tezos = lib;
+    describe(`Test injecting more than one manager operation in a block: ${rpc}`, () => {
+
+        beforeEach(async (done) => {
+            await setup()
+            done()
+        })
+        test('Verify that doing transfers without awaiting the confirmation after each will fail', async (done) => {
+            try {
+                const op1 = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 1 });
+                const op2 = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 });
+
+                await op1.confirmation();
+                await op2.confirmation();
+
+            } catch (error) {
+                expect(error.message).toContain('Only one manager operation per manager per block allowed');
+            }
+            done();
+        })
+    });
+})


### PR DESCRIPTION
Added a test showing the expected error message if we try to inject multiple maganer operations in
the same block

re #1748

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
