### PR TITLE
style(injector): remove unwanted error message related to tezos-client

### DIFF
--- a/docs/batch-api.md
+++ b/docs/batch-api.md
@@ -22,8 +22,7 @@ await op2.confirmation();
 /*
  * Error Message returned by the node (since Kathmandu):
  * Error while applying operation opHash: 
- * Only one manager operation per manager per block allowed (found opHash2 with Xtez fee. 
- * You may want to use --replace to provide adequate fee and replace it).
+ * Only one manager operation per manager per block allowed (found opHash2 with Xtez fee).
  * 
  * Error Message that was returned by the node (before Kathmandu):
  * "Error while applying operation opWH2nEcmmzUwK4T6agHg3bn9GDR7fW1ynqWL58AVRAb7aZFciD:

--- a/integration-tests/injecting-multiple-manager-operations-in-a-block.spec.ts
+++ b/integration-tests/injecting-multiple-manager-operations-in-a-block.spec.ts
@@ -1,14 +1,17 @@
+import { Protocols } from "@taquito/taquito";
 import { CONFIGS } from "./config";
 
-CONFIGS().forEach(({ lib, rpc, setup }) => {
+CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
     const Tezos = lib;
+    const kathmandunet = (protocol === Protocols.PtKathman) ? test : test.skip;
     describe(`Test injecting more than one manager operation in a block: ${rpc}`, () => {
 
         beforeEach(async (done) => {
             await setup()
             done()
         })
-        test('Verify that doing transfers without awaiting the confirmation after each will fail', async (done) => {
+
+        kathmandunet('Verify that doing transfers without awaiting the confirmation after each will fail', async (done) => {
             try {
                 const op1 = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 1 });
                 const op2 = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 });
@@ -16,7 +19,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
                 await op1.confirmation();
                 await op2.confirmation();
 
-            } catch (error) {
+            } catch (error: any) {
                 expect(error.message).toContain('Only one manager operation per manager per block allowed');
             }
             done();

--- a/packages/taquito/src/injector/helper.ts
+++ b/packages/taquito/src/injector/helper.ts
@@ -1,0 +1,21 @@
+import { HttpResponseError } from '@taquito/http-utils';
+
+export function formatErrorMessage(error: HttpResponseError, stringToReplace: string) {
+  const body = JSON.parse(error.body);
+  if (body[0] && body[0].kind && body[0].msg) {
+    const newBody = JSON.stringify({
+      kind: body[0].kind,
+      id: body[0].id,
+      msg: body[0].msg.replace(stringToReplace, ''),
+    });
+    return new HttpResponseError(
+      `Http error response: (${error.status}) ${newBody}`,
+      error.status,
+      error.statusText,
+      newBody,
+      error.url
+    );
+  } else {
+    return error;
+  }
+}

--- a/packages/taquito/src/injector/rpc-injector.ts
+++ b/packages/taquito/src/injector/rpc-injector.ts
@@ -1,9 +1,23 @@
 import { Injector } from './interface';
 import { Context } from '../context';
+import { formatErrorMessage } from './helper';
+import { HttpResponseError } from '@taquito/http-utils';
 
 export class RpcInjector implements Injector {
   constructor(private context: Context) {}
-  inject(signedOperationBytes: string): Promise<string> {
-    return this.context.rpc.injectOperation(signedOperationBytes);
+  async inject(signedOperationBytes: string): Promise<string> {
+    let hash: string;
+    try {
+      hash = await this.context.rpc.injectOperation(signedOperationBytes);
+    } catch (error) {
+      const stringToStrip =
+        '. You may want to use --replace to provide adequate fee and replace it';
+      if (error instanceof HttpResponseError && error.message.includes(stringToStrip)) {
+        throw formatErrorMessage(error, stringToStrip);
+      } else {
+        throw error;
+      }
+    }
+    return hash;
   }
 }


### PR DESCRIPTION
Override "Error while applying operation opHash: Only one manager operation per manager per block
allowed (found opHash2 with Xtez fee. You may want to use --replace to provide adequate fee and
replace it)." for "Error while applying operation opHash: Only one manager operation per manager per
block allowed (found opHash2 with Xtez fee)."

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
