### PR TITLE
Tweak configuration for CodeQL analysis

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -3,3 +3,4 @@ paths-ignore:
   - "example"
   - "integration-tests"
   - "packages/**/test"
+  - "packages/**/data"

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,5 @@
+---
+paths-ignore:
+  - "example"
+  - "integration-tests"
+  - "packages/**/test"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,6 +19,10 @@ jobs:
   analyse:
     name: Analyse
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-  # TODO: Revert before merging
-    branches: 
-      - '*'
+    branches: [master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,10 +23,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
 
     # If this run was triggered by a pull request event, then checkout
     # the head of the pull request instead of the merge commit.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+  # TODO: Revert before merging
+    branches: 
+      - '*'
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]
@@ -34,6 +36,8 @@ jobs:
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
+      with:
+        config-file: ./.github/codeql/codeql-config.yml
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,12 +22,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/checkout@v3
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [ ] ~You have added unit tests~ N/A
- [ ] ~You have added integration tests (if relevant/appropriate)~ N/A
- [ ] ~All public methods or types have TypeDoc coverage with a complete description, and ideally an @example~ N/A
- [ ] ~You have added or updated corresponding documentation~ N/A
- [ ] ~If relevant, you have written a first draft summary describing the change for inclusion in Release Notes.~ N/A 

## Release Note Draft Snippet

Recent CodeQL GH Action runs are throwing errors caused by Github runners running out of memory. An example of the error is present in the snippet below.

https://github.com/ecadlabs/taquito/actions/runs/3003313388/jobs/4829799996

```
Error: 9-07 11:49:09] [ERROR] Spawned process exited abnormally (code 1; tried to run: [/opt/hostedtoolcache/CodeQL/0.0.0-20220825/x64/codeql/javascript/tools/autobuild.sh])
  A fatal error occurred: Exit status 1 from command: [/opt/hostedtoolcache/CodeQL/0.0.0-20220825/x64/codeql/javascript/tools/autobuild.sh]
  Error: The process '/opt/hostedtoolcache/CodeQL/0.0.0-20220825/x64/codeql/codeql' failed with exit code 2
  Error: The process '/opt/hostedtoolcache/CodeQL/0.0.0-20220825/x64/codeql/codeql' failed with exit code 2
```

@roxaneletourneau pointed out that this error is caused by large Micheline contracts' code being analyzed by the pipeline. [As this GH Issue also points out](https://github.com/github/codeql-action/issues/1082) CodeQL doesn't need to analyze unit tests and also can't parse Micheline code so making CodeQL analyze contracts' code doesn't provide any value nor insights on security vulnerabilities.

In this PR I'm tweaking CodeQL configuration file to ignore files and folders containing unit/integration tests and Micheline contracts. This fixes the out of memory issue with the runner. 

Additionally, I've upgraded the `checkout` action to `v3` and removed some deprecated steps in the GH workflow