### PR TITLE
1795 contract balance flexibility

### DIFF
--- a/integration-tests/contract-michelson-origination.spec.ts
+++ b/integration-tests/contract-michelson-origination.spec.ts
@@ -1,3 +1,4 @@
+import { IntegerError } from "@taquito/taquito";
 import { CONFIGS } from "./config";
 import { idMichelsonCode, idInitData } from "./data/id-contract"
 
@@ -18,6 +19,25 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       await op.confirmation()
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+      done();
+    });
+    it('Origination should pass with balance as number', async (done) => {
+      const op = await Tezos.contract.originate({
+        balance: 0,
+        code: idMichelsonCode,
+        init: idInitData
+      })
+      await op.confirmation()
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+      done();
+    });
+    it('Origination should thow error if given NaN for balance', async (done) => {
+      expect(() => Tezos.contract.originate({
+        balance: "asdf",
+        code: idMichelsonCode,
+        init: idInitData
+      })).rejects.toThrowError(IntegerError)
       done();
     });
   });

--- a/packages/taquito/src/contract/errors.ts
+++ b/packages/taquito/src/contract/errors.ts
@@ -142,3 +142,10 @@ export class OriginationParameterError extends Error {
     super(message);
   }
 }
+
+export class IntegerError extends Error {
+  public name = 'IntegerError';
+  constructor(public message: string) {
+    super(message);
+  }
+}

--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -24,7 +24,7 @@ import {
 } from '../operations/types';
 import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT } from '../constants';
 import { format } from '@taquito/utils';
-import { InvalidCodeParameter, InvalidInitParameter, OriginationParameterError } from './errors';
+import { InvalidCodeParameter, InvalidInitParameter, OriginationParameterError, IntegerError } from './errors';
 
 export const createOriginationOperation = async ({
   code,
@@ -67,6 +67,10 @@ export const createOriginationOperation = async ({
     code,
     storage: contractStorage,
   };
+
+  if (isNaN(Number(balance))) {
+    throw new IntegerError(`Unexpected Invalid Integer ${balance}`)
+  }
 
   const operation: RPCOriginationOperation = {
     kind: OpKind.ORIGINATION,

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -153,7 +153,7 @@ export interface FeeConsumingOperation {
 }
 
 export type OriginateParamsBase = {
-  balance?: string;
+  balance?: string | number;
   code: string | object[];
   delegate?: string;
   fee?: number;


### PR DESCRIPTION
allow balance to be entered as a number or string. add tests. and error cases

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
