### PR TITLE
docs(faucet): remove usage of JSON faucet in the documentation

### DIFF
--- a/docs/complex_parameters.md
+++ b/docs/complex_parameters.md
@@ -83,7 +83,7 @@ const validatorsMap = new MichelsonMap();
 //key is a nat, value is an address
 validatorsMap.set('1', 'tz1btkXVkVFWLgXa66sbRJa8eeUSwvQFX4kP')
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(() => {
   return Tezos.contract.originate({
     code : contractJson,
@@ -132,7 +132,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(signer => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz')
 }).then(myContract => {
@@ -150,7 +150,7 @@ importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(signer => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz')
 }).then(myContract => {
@@ -181,7 +181,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 // const Tezos = new TezosToolkit('https://jakartanet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(signer => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz')
 }).then(myContract => {

--- a/docs/inmemory_signer.md
+++ b/docs/inmemory_signer.md
@@ -177,55 +177,9 @@ InMemorySigner.fromSecretKey(
 
 ### Using a testnet faucet key
 
-To load a faucet key (available from https://faucet.tzalpha.net/) for working a public testnet use the `importKey` function.
-can do so as follows:
-
-```js
-import { TezosToolkit } from '@taquito/taquito';
-import { importKey } from '@taquito/taquito-signer';
-
-const Tezos = new TezosToolkit('https://YOUR_PREFERRED_TESTNET_RPC_URL');
-
-// A key faucet, similar to what is available from https://faucet.tzalpha.net/
-const FAUCET_KEY = {
-  mnemonic: [
-    'cart',
-    'will',
-    'page',
-    'bench',
-    'notice',
-    'leisure',
-    'penalty',
-    'medal',
-    'define',
-    'odor',
-    'ride',
-    'devote',
-    'cannon',
-    'setup',
-    'rescue',
-  ],
-  secret: '35f266fbf0fca752da1342fdfc745a9c608e7b20',
-  amount: '4219352756',
-  pkh: 'tz1YBMFg1nLAPxBE6djnCPbMRH5PLXQWt8Mg',
-  password: 'Fa26j580dQ',
-  email: 'jxmjvauo.guddusns@tezos.example.org',
-};
-
-importKey(
-  Tezos,
-  FAUCET_KEY.email,
-  FAUCET_KEY.password,
-  FAUCET_KEY.mnemonic.join(' '),
-  FAUCET_KEY.secret
-);
-// Your Tezos instance is now operably configured for signing with the faucet key.
-```
-
-If you configure Taquito this way, you will now be able to use every function that needs signing support.
-
+~~To load a faucet key (available from https://faucet.tzalpha.net/) for working a public testnet use the `importKey` function.~~
 :::note
-The operation will be signed automatically using the signer (no prompt)
+Since August 2022, the JSON faucets we used to import with the `importKey` function are no longer available. You can use the following link to fund an address on the different testnets: https://teztnets.xyz/.
 :::
 
 ### A simple factory multiple keys/wallets

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -84,49 +84,7 @@ Tezos.setProvider({
 });
 ```
 
-#### Importing a Faucet Key
-
-"Faucet Keys" allows you to get Tezos tokens on the various Tezos "testnets." You can download a faucet key for the current and upcoming protocols at https://teztnets.xyz/. The key is a JSON file, which you can use with Taquito as follows:
-
-```js
-import { TezosToolkit } from '@taquito/taquito';
-import { importKey } from '@taquito/signer';
-
-const Tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL');
-
-const FAUCET_KEY = {
-  mnemonic: [
-    'cart',
-    'will',
-    'page',
-    'bench',
-    'notice',
-    'leisure',
-    'penalty',
-    'medal',
-    'define',
-    'odor',
-    'ride',
-    'devote',
-    'cannon',
-    'setup',
-    'rescue',
-  ],
-  activation_code: '35f266fbf0fca752da1342fdfc745a9c608e7b20',
-  amount: '4219352756',
-  pkh: 'tz1YBMFg1nLAPxBE6djnCPbMRH5PLXQWt8Mg',
-  password: 'Fa26j580dQ',
-  email: 'jxmjvauo.guddusns@tezos.example.org',
-};
-
-importKey(
-  Tezos,
-  FAUCET_KEY.email,
-  FAUCET_KEY.password,
-  FAUCET_KEY.mnemonic.join(' '),
-  FAUCET_KEY.activation_code
-).catch((e) => console.error(e));
-```
+The following link can be used to fund an address on the different testnets: https://teztnets.xyz/.
 
 ### Transfer
 
@@ -179,7 +137,7 @@ Tezos.wallet
 
 ### Interact with a smart contract
 
-Calling smart contract operations requires a configured signer; in this example we will use a faucet key. The Ligo source code for the smart contract [KT1GJ5dUyHiaj7Uuc8gqfsbdv5tTbEH3fiRP][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
+Calling smart contract operations requires a configured signer. The Ligo source code for the smart contract [KT1GJ5dUyHiaj7Uuc8gqfsbdv5tTbEH3fiRP][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
 
 <Tabs
 defaultValue="contractAPI"

--- a/docs/smartcontracts.md
+++ b/docs/smartcontracts.md
@@ -283,7 +283,7 @@ The preceding example returns an array which contains the different possible sig
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
   .then((signer) => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz');
   })
@@ -337,7 +337,7 @@ The preceding example returns an object giving indication on how to structure th
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
   .then((signer) => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz');
   })

--- a/integration-tests/contract-register-delegate.spec.ts
+++ b/integration-tests/contract-register-delegate.spec.ts
@@ -23,7 +23,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
         if (protocol === Protocols.PsFLorena) {
           expect(ex.message).toMatch('delegate.unchanged')
         } else {
-          // When running tests more than one time with the same faucet key, the account is already delegated to the given delegate
+          // When running tests more than one time with the same key, the account is already delegated to the given delegate
           expect(ex.message).toMatch('delegate.already_active')
         }
       }

--- a/integration-tests/contract-set-delegate-auto-estimate.spec.ts
+++ b/integration-tests/contract-set-delegate-auto-estimate.spec.ts
@@ -27,7 +27,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
           // Forbidden delegate deletion
           expect(ex.message).toMatch('delegate.no_deletion')
         } else {
-          // When running tests more than one time with the same faucet key, the account is already delegated to the given delegate
+          // When running tests more than one time with the same key, the account is already delegated to the given delegate
           expect(ex.message).toMatch('delegate.unchanged')
         }
       }

--- a/integration-tests/contract-simple-delegation.spec.ts
+++ b/integration-tests/contract-simple-delegation.spec.ts
@@ -38,7 +38,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
           // Forbidden delegate deletion
           expect(ex.message).toMatch('delegate.no_deletion')
         } else {
-          // When running tests more than one time with the same faucet key, the account is already delegated to the given delegate
+          // When running tests more than one time with the same key, the account is already delegated to the given delegate
           expect(ex.message).toMatch('delegate.unchanged')
         }
       }

--- a/integration-tests/wallet-register-delegate.spec.ts
+++ b/integration-tests/wallet-register-delegate.spec.ts
@@ -31,7 +31,7 @@ CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
                 if (protocol === Protocols.PsFLorena) {
                     expect(ex.message).toMatch('delegate.unchanged')
                 } else {
-                    // When running tests more than one time with the same faucet key, the account is already delegated to the given delegate
+                    // When running tests more than one time with the same key, the account is already delegated to the given delegate
                     expect(ex.message).toMatch('delegate.already_active')
                 }
             }

--- a/integration-tests/wallet-set-delegate-auto-estimate.spec.ts
+++ b/integration-tests/wallet-set-delegate-auto-estimate.spec.ts
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
           // Forbidden delegate deletion
           expect(ex.message).toMatch('delegate.no_deletion')
         } else {
-          // When running tests more than one time with the same faucet key, the account is already delegated to the given delegate
+          // When running tests more than one time with the same key, the account is already delegated to the given delegate
           expect(ex.message).toMatch('delegate.unchanged')
         }
       }

--- a/packages/taquito-signer/README.md
+++ b/packages/taquito-signer/README.md
@@ -45,51 +45,7 @@ Tezos.setProvider({
 });
 ```
 
-### Using a testnet faucet key
-
-To load a faucet key (available from https://teztnets.xyz/) for working with a public testnet, use the `importKey` function.
-
-```js
-import { TezosToolkit } from '@taquito/taquito';
-import { importKey } from '@taquito/signer';
-
-const Tezos = new TezosToolkit('https://YOUR_PREFERRED_TESTNET_RPC_URL');
-
-// A key faucet, similar to what is available from https://teztnets.xyz/
-const FAUCET_KEY = {
-  mnemonic: [
-    'cart',
-    'will',
-    'page',
-    'bench',
-    'notice',
-    'leisure',
-    'penalty',
-    'medal',
-    'define',
-    'odor',
-    'ride',
-    'devote',
-    'cannon',
-    'setup',
-    'rescue',
-  ],
-  secret: '35f266fbf0fca752da1342fdfc745a9c608e7b20',
-  amount: '4219352756',
-  pkh: 'tz1YBMFg1nLAPxBE6djnCPbMRH5PLXQWt8Mg',
-  password: 'Fa26j580dQ',
-  email: 'jxmjvauo.guddusns@tezos.example.org',
-};
-
-importKey(
-  Tezos,
-  FAUCET_KEY.email,
-  FAUCET_KEY.password,
-  FAUCET_KEY.mnemonic.join(' '),
-  FAUCET_KEY.secret
-);
-// Your Tezos instance is now operably configured for signing with the faucet key.
-```
+The following link can be used to fund an address on the different testnets: https://teztnets.xyz/.
 
 ## Additional info
 

--- a/packages/taquito-signer/src/import-key.ts
+++ b/packages/taquito-signer/src/import-key.ts
@@ -5,6 +5,7 @@ import { TezosToolkit } from '@taquito/taquito';
  *
  * @description Import a key to sign operation with the side-effect of setting the Tezos instance to use the InMemorySigner provider
  *
+ * @warn The JSON faucets are no longer available on https://teztnets.xyz/
  * @param toolkit The toolkit instance to attach a signer
  * @param privateKeyOrEmail Key to load in memory
  * @param passphrase If the key is encrypted passphrase to decrypt it

--- a/website/src/theme/Playground/index.js
+++ b/website/src/theme/Playground/index.js
@@ -115,10 +115,7 @@ const contractMapBigMap =
 [ { "prim": "parameter", "args": [ { "prim": "unit" } ] },{ "prim": "storage","args":[ { "prim": "pair","args":[ { "prim": "big_map","args":[ { "prim": "pair","args": [ { "prim": "nat" }, { "prim": "address" } ] },{ "prim": "int" } ], "annots": [ "%thebigmap" ] },{ "prim": "map","args":[ { "prim": "pair","args": [ { "prim": "nat" }, { "prim": "address" } ] },{ "prim": "int" } ], "annots": [ "%themap" ] } ] } ] },{ "prim": "code","args":[ [ { "prim": "DUP" }, { "prim": "CDR" },{ "prim": "NIL", "args": [ { "prim": "operation" } ] },{ "prim": "PAIR" },{ "prim": "DIP", "args": [ [ { "prim": "DROP" } ] ] } ] ] } ]
 
 //signer required for examples in complex_parameter.md
-const emailExample = "zsjpcmui.oysiavbv@tezos.example.org"
-const passwordExample = "4rW0D22yXt"
-const mnemonicExample = "arrange ceiling whisper churn congress double step carpet empty rice prevent swallow silk casual champion"
-const secretExample = "af552679c4943509bd77643b8ef3f8dcf42e61b3"
+const secretKey = "edskS56s5PHASc9Cxpjt5wXhEZPpgmmommNLVgc22pzmSeNmfNQXR89mPtmeHZzHVjsBVCThmSXR4JtZ9PfiLDcPdf7rjhmFib"
 
 // This is the code of the contract use in complex_parameter.md
 const contractJson = [{"prim":"parameter","args":[{"prim":"or","args":[{"prim":"or","args":[{"prim":"lambda","args":[{"prim":"pair","args":[{"prim":"pair","args":[{"prim":"address","annots":["%owner"]},{"prim":"big_map","args":[{"prim":"bytes"},{"prim":"pair","args":[{"prim":"pair","args":[{"prim":"pair","args":[{"prim":"option","args":[{"prim":"address"}],"annots":["%address"]},{"prim":"map","args":[{"prim":"string"},{"prim":"or","args":[{"prim":"or","args":[{"prim":"or","args":[{"prim":"or","args":[{"prim":"address","annots":["%address"]},{"prim":"bool","annots":["%bool"]}]},

--- a/website/versioned_docs/version-14.0.0/complex_parameters.md
+++ b/website/versioned_docs/version-14.0.0/complex_parameters.md
@@ -83,7 +83,7 @@ const validatorsMap = new MichelsonMap();
 //key is a nat, value is an address
 validatorsMap.set('1', 'tz1btkXVkVFWLgXa66sbRJa8eeUSwvQFX4kP')
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(() => {
   return Tezos.contract.originate({
     code : contractJson,
@@ -132,7 +132,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(signer => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz')
 }).then(myContract => {
@@ -150,7 +150,7 @@ importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(signer => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz')
 }).then(myContract => {
@@ -181,7 +181,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 // const Tezos = new TezosToolkit('https://jakartanet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
 .then(signer => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz')
 }).then(myContract => {

--- a/website/versioned_docs/version-14.0.0/inmemory_signer.md
+++ b/website/versioned_docs/version-14.0.0/inmemory_signer.md
@@ -177,55 +177,9 @@ InMemorySigner.fromSecretKey(
 
 ### Using a testnet faucet key
 
-To load a faucet key (available from https://faucet.tzalpha.net/) for working a public testnet use the `importKey` function.
-can do so as follows:
-
-```js
-import { TezosToolkit } from '@taquito/taquito';
-import { importKey } from '@taquito/taquito-signer';
-
-const Tezos = new TezosToolkit('https://YOUR_PREFERRED_TESTNET_RPC_URL');
-
-// A key faucet, similar to what is available from https://faucet.tzalpha.net/
-const FAUCET_KEY = {
-  mnemonic: [
-    'cart',
-    'will',
-    'page',
-    'bench',
-    'notice',
-    'leisure',
-    'penalty',
-    'medal',
-    'define',
-    'odor',
-    'ride',
-    'devote',
-    'cannon',
-    'setup',
-    'rescue',
-  ],
-  secret: '35f266fbf0fca752da1342fdfc745a9c608e7b20',
-  amount: '4219352756',
-  pkh: 'tz1YBMFg1nLAPxBE6djnCPbMRH5PLXQWt8Mg',
-  password: 'Fa26j580dQ',
-  email: 'jxmjvauo.guddusns@tezos.example.org',
-};
-
-importKey(
-  Tezos,
-  FAUCET_KEY.email,
-  FAUCET_KEY.password,
-  FAUCET_KEY.mnemonic.join(' '),
-  FAUCET_KEY.secret
-);
-// Your Tezos instance is now operably configured for signing with the faucet key.
-```
-
-If you configure Taquito this way, you will now be able to use every function that needs signing support.
-
+~~To load a faucet key (available from https://faucet.tzalpha.net/) for working a public testnet use the `importKey` function.~~
 :::note
-The operation will be signed automatically using the signer (no prompt)
+Since August 2022, the JSON faucets we used to import with the `importKey` function are no longer available. You can use the following link to fund an address on the different testnets: https://teztnets.xyz/.
 :::
 
 ### A simple factory multiple keys/wallets

--- a/website/versioned_docs/version-14.0.0/quick_start.md
+++ b/website/versioned_docs/version-14.0.0/quick_start.md
@@ -84,49 +84,7 @@ Tezos.setProvider({
 });
 ```
 
-#### Importing a Faucet Key
-
-"Faucet Keys" allows you to get Tezos tokens on the various Tezos "testnets." You can download a faucet key for the current and upcoming protocols at https://teztnets.xyz/. The key is a JSON file, which you can use with Taquito as follows:
-
-```js
-import { TezosToolkit } from '@taquito/taquito';
-import { importKey } from '@taquito/signer';
-
-const Tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL');
-
-const FAUCET_KEY = {
-  mnemonic: [
-    'cart',
-    'will',
-    'page',
-    'bench',
-    'notice',
-    'leisure',
-    'penalty',
-    'medal',
-    'define',
-    'odor',
-    'ride',
-    'devote',
-    'cannon',
-    'setup',
-    'rescue',
-  ],
-  activation_code: '35f266fbf0fca752da1342fdfc745a9c608e7b20',
-  amount: '4219352756',
-  pkh: 'tz1YBMFg1nLAPxBE6djnCPbMRH5PLXQWt8Mg',
-  password: 'Fa26j580dQ',
-  email: 'jxmjvauo.guddusns@tezos.example.org',
-};
-
-importKey(
-  Tezos,
-  FAUCET_KEY.email,
-  FAUCET_KEY.password,
-  FAUCET_KEY.mnemonic.join(' '),
-  FAUCET_KEY.activation_code
-).catch((e) => console.error(e));
-```
+The following link can be used to fund an address on the different testnets: https://teztnets.xyz/.
 
 ### Transfer
 
@@ -179,7 +137,7 @@ Tezos.wallet
 
 ### Interact with a smart contract
 
-Calling smart contract operations requires a configured signer; in this example we will use a faucet key. The Ligo source code for the smart contract [KT1GJ5dUyHiaj7Uuc8gqfsbdv5tTbEH3fiRP][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
+Calling smart contract operations requires a configured signer. The Ligo source code for the smart contract [KT1GJ5dUyHiaj7Uuc8gqfsbdv5tTbEH3fiRP][smart_contract_on_better_call_dev] used in this example can be found in a [Ligo Web IDE][smart_contract_source].
 
 <Tabs
 defaultValue="contractAPI"

--- a/website/versioned_docs/version-14.0.0/smartcontracts.md
+++ b/website/versioned_docs/version-14.0.0/smartcontracts.md
@@ -283,7 +283,7 @@ The preceding example returns an array which contains the different possible sig
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
   .then((signer) => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz');
   })
@@ -337,7 +337,7 @@ The preceding example returns an object giving indication on how to structure th
 // const Tezos = new TezosToolkit('https://kathmandunet.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
-importKey(Tezos, emailExample, passwordExample, mnemonicExample, secretExample)
+importKey(Tezos, secretKey)
   .then((signer) => {
     return Tezos.contract.at('KT1Resnq6SvWRUXA9FaNczhJ278QzwPjWcGz');
   })


### PR DESCRIPTION
Since August 2022, JSON faucet are no longer available

fix #1872

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
