### PR TITLE
test(config txrollup): added origination of txrollup to the script us…

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -4,9 +4,9 @@ import { HttpBackend } from '@taquito/http-utils';
 import { b58cencode, Prefix, prefix } from '@taquito/utils';
 import { importKey, InMemorySigner } from '@taquito/signer';
 import { RpcClient, RpcClientCache } from '@taquito/rpc';
-import { knownBigMapContractProtoALph, knownContractProtoALph, knownOnChainViewContractAddressProtoALph, knownSaplingContractProtoALph, knownTzip12BigMapOffChainContractProtoALph } from './known-contracts-ProtoALph';
-import { knownContractPtKathman, knownBigMapContractPtKathman, knownTzip12BigMapOffChainContractPtKathman, knownSaplingContractPtKathman, knownOnChainViewContractAddressPtKathman } from './known-contracts-PtKathman';
-import { knownContractPtJakart2, knownBigMapContractPtJakart2, knownTzip12BigMapOffChainContractPtJakart2, knownSaplingContractPtJakart2, knownOnChainViewContractAddressPtJakart2 } from './known-contracts-PtJakart2';
+import { knownBigMapContractProtoALph, knownContractProtoALph, knownOnChainViewContractAddressProtoALph, knownSaplingContractProtoALph, knownTzip12BigMapOffChainContractProtoALph, txRollupAddressProtoALph } from './known-contracts-ProtoALph';
+import { knownContractPtKathman, knownBigMapContractPtKathman, knownTzip12BigMapOffChainContractPtKathman, knownSaplingContractPtKathman, knownOnChainViewContractAddressPtKathman, txRollupAddressPtKathman } from './known-contracts-PtKathman';
+import { knownContractPtJakart2, knownBigMapContractPtJakart2, knownTzip12BigMapOffChainContractPtJakart2, knownSaplingContractPtJakart2, knownOnChainViewContractAddressPtJakart2, txRollupAddressPtJakart2 } from './known-contracts-PtJakart2';
 
 const nodeCrypto = require('crypto');
 
@@ -85,7 +85,7 @@ const kathmandunetEphemeral = {
   txRollupWithdrawContract: process.env['TEZOS_KATHMANDUET_TX_ROLLUP_WITHDRAW_CONTRACT'] || '',
   txRollupDepositContract: process.env['TEZOS_KATHMANDUET_TX_ROLLUP_DEPOSIT_CONTRACT'] || '',
   knownViewContract: process.env['TEZOS_KATHMANDUET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtKathman,
-  txRollupAddress: process.env['TEZOS_KATHMANDUET_TXROLLUP_ADDRESS'] || 'txr1ebHhewaVykePYWRH5g8vZchXdX9ebwYZQ',
+  txRollupAddress: process.env['TEZOS_KATHMANDUET_TXROLLUP_ADDRESS'] || txRollupAddressPtKathman,
   protocol: Protocols.PtKathman,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
@@ -106,7 +106,7 @@ const jakartanetEphemeral = {
   txRollupWithdrawContract: process.env['TEZOS_JAKARTANET_TX_ROLLUP_WITHDRAW_CONTRACT'] || '',
   txRollupDepositContract: process.env['TEZOS_JAKARTANET_TX_ROLLUP_DEPOSIT_CONTRACT'] || '',
   knownViewContract: process.env['TEZOS_JAKARTANET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtJakart2,
-  txRollupAddress: process.env['TEZOS_JAKARTANET_TXROLLUP_ADDRESS'] || 'txr1YTdi9BktRmybwhgkhRK7WPrutEWVGJT7w',
+  txRollupAddress: process.env['TEZOS_JAKARTANET_TXROLLUP_ADDRESS'] || txRollupAddressPtJakart2,
   protocol: Protocols.PtJakart2,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
@@ -127,7 +127,7 @@ const mondaynetEphemeral = {
   txRollupWithdrawContract: process.env['TX_ROLLUP_WITHDRAW_CONTRACT'] || '',
   txRollupDepositContract: process.env['TX_ROLLUP_DEPOSIT_CONTRACT'] || '',
   knownViewContract: process.env['TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressProtoALph,
-  txRollupAddress: process.env['TEZOS_MONDAYNET_TXROLLUP_ADDRESS'] || '',
+  txRollupAddress: process.env['TEZOS_MONDAYNET_TXROLLUP_ADDRESS'] || txRollupAddressProtoALph,
   protocol: Protocols.ProtoALpha,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
@@ -148,7 +148,7 @@ const kathmandunetSecretKey = {
   txRollupWithdrawContract: process.env['TEZOS_KATHMANDUET_TX_ROLLUP_WITHDRAW_CONTRACT'] || '',
   txRollupDepositContract: process.env['TEZOS_KATHMANDUET_TX_ROLLUP_DEPOSIT_CONTRACT'] || '',
   knownViewContract: process.env['TEZOS_KATHMANDUET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtKathman,
-  txRollupAddress: process.env['TEZOS_KATHMANDUET_TXROLLUP_ADDRESS'] || 'txr1ebHhewaVykePYWRH5g8vZchXdX9ebwYZQ',
+  txRollupAddress: process.env['TEZOS_KATHMANDUET_TXROLLUP_ADDRESS'] || txRollupAddressPtKathman,
   protocol: Protocols.PtKathman,
   signerConfig: defaultSecretKey,
 };
@@ -165,7 +165,7 @@ const jakartanetSecretKey = {
   txRollupWithdrawContract: process.env['TEZOS_JAKARTANET_TX_ROLLUP_WITHDRAW_CONTRACT'] || '',
   txRollupDepositContract: process.env['TEZOS_JAKARTANET_TX_ROLLUP_DEPOSIT_CONTRACT'] || '',
   knownViewContract: process.env['TEZOS_JAKARTANET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtJakart2,
-  txRollupAddress: process.env['TEZOS_JAKARTANET_TXROLLUP_ADDRESS'] || 'txr1YTdi9BktRmybwhgkhRK7WPrutEWVGJT7w',
+  txRollupAddress: process.env['TEZOS_JAKARTANET_TXROLLUP_ADDRESS'] || txRollupAddressPtJakart2,
   protocol: Protocols.PtJakart2,
   signerConfig: defaultSecretKey
 };
@@ -182,7 +182,7 @@ const mondaynetSecretKey = {
   txRollupWithdrawContract: process.env['TX_ROLLUP_WITHDRAW_CONTRACT'] || '',
   txRollupDepositContract: process.env['TX_ROLLUP_DEPOSIT_CONTRACT'] || '',
   knownViewContract: process.env['TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressProtoALph,
-  txRollupAddress: process.env['TEZOS_MONDAYNET_TXROLLUP_ADDRESS'] || '',
+  txRollupAddress: process.env['TEZOS_MONDAYNET_TXROLLUP_ADDRESS'] || txRollupAddressProtoALph,
   protocol: Protocols.ProtoALpha,
   signerConfig: defaultSecretKey
 };

--- a/integration-tests/known-contracts-ProtoALph.ts
+++ b/integration-tests/known-contracts-ProtoALph.ts
@@ -3,3 +3,4 @@ export const knownBigMapContractProtoALph = "KT1MsswzJwY3AAnWXMDc5f5ZmLG89bf8kwe
 export const knownTzip12BigMapOffChainContractProtoALph = "KT1V1yUaK8svcHwGbwL6EwTiQBW2Wjsb3tu9";
 export const knownSaplingContractProtoALph = "KT1NLd6Q9ZdDbjiKp53rhUUTsD4RrGMJv21v";
 export const knownOnChainViewContractAddressProtoALph = "KT1G4Lkj2rvPHc6EAoZXPcSTqPebdN4TTb58";
+export const txRollupAddressProtoALph = "txr1ZhMZY2XK5Ef2ekWyojeUoapM7AUpFZEhh";

--- a/integration-tests/known-contracts-PtJakart2.ts
+++ b/integration-tests/known-contracts-PtJakart2.ts
@@ -3,3 +3,4 @@ export const knownBigMapContractPtJakart2 = "KT1AbzoXYgGXjCD3Msi3spuqa5r5MP3rkvM
 export const knownTzip12BigMapOffChainContractPtJakart2 = "KT1GmRf51jFNMQBFDo2mYKnC8Pjm1d7yDwVj";
 export const knownSaplingContractPtJakart2 = "KT1G2kvdfPoavgR6Fjdd68M2vaPk14qJ8bhC";
 export const knownOnChainViewContractAddressPtJakart2 = "KT1N6MT9xd3SpbwEG16FrwSfMDUkFNFK1eze";
+export const txRollupAddressPtJakart2 = "txr1YTdi9BktRmybwhgkhRK7WPrutEWVGJT7w";

--- a/integration-tests/known-contracts-PtKathman.ts
+++ b/integration-tests/known-contracts-PtKathman.ts
@@ -3,3 +3,4 @@ export const knownBigMapContractPtKathman = "KT1K65F9P54MiQ7it2k5wmTCKGNXyDH2wen
 export const knownTzip12BigMapOffChainContractPtKathman = "KT1H4xzuERAWgJzomFxLvn2tmKttCU43Rp44";
 export const knownSaplingContractPtKathman = "KT1V9vrxyBv3cAWZwucoJYFFTRUt3eYp5EoA";
 export const knownOnChainViewContractAddressPtKathman = "KT1ArzUybP2LMxNVdottnFoy5Z8vPbJ7BDjB";
+export const txRollupAddressPtKathman = "txr1ebHhewaVykePYWRH5g8vZchXdX9ebwYZQ";

--- a/integration-tests/originate-known-contracts.ts
+++ b/integration-tests/originate-known-contracts.ts
@@ -133,6 +133,20 @@ CONFIGS().forEach(({ lib, setup, protocol }) => {
       storage: 2
     });
 
+    // originate tx rollup
+    try {
+    const op = await tezos.contract.txRollupOriginate({});
+    await op.confirmation();
+    console.log(`txRollupAddress:  ${op.originatedRollup}`);
+      fs.appendFile(`known-contracts-${protocol.substring(0,9)}.ts`, `export const txRollupAddress${protocol.substring(0,9)} = "${op.originatedRollup}";\n`, (err: any) => {
+        if (err) {
+          console.error(err);
+        }
+      });
+    } catch (e: any) {
+      console.error(`Failed to originate tx rollup | Error: ${e.stack}`);
+    }
+
     console.log(`
 ################################################################################
 Public Key Hash : ${keyPkh}


### PR DESCRIPTION
…ed to deploy known contracts

This change is needed to run the integrations against alpha using a sandbox. The script originate-know-contracts.ts deploy the contracts(or txRollup) that are required in different tests.

Closes #1971