### PR TITLE
fix(wallet and contract APIs): fetch missed blocks during operation confirmation

### DIFF
--- a/integration-tests/contract-handling-missed-blocks.spec.ts
+++ b/integration-tests/contract-handling-missed-blocks.spec.ts
@@ -1,0 +1,25 @@
+import { PollingSubscribeProvider } from "@taquito/taquito";
+import { CONFIGS } from "./config";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+   describe(`Test handling of missed blocks through contract api using: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup()
+      done()
+    })
+    it('Verify the operation is found even if the poller skipped blocks', async (done) => {
+      // To simulate the behavior where blocks are skipped, we use a polling interval higher than the time between blocks
+      // Before fixing issue #1783, if the block containing the operation was skipped, the operation was never found, and the test ended with a timeout
+      // After fixing issue #1783, if blocks are skipped, they will be retrieved and inspected by the Operation class
+      Tezos.setStreamProvider(Tezos.getFactory(PollingSubscribeProvider)({ pollingIntervalMilliseconds: 60000 }));
+      const op = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 });
+      await op.confirmation();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+      expect(op.status).toBe('applied');
+
+      done();
+    })
+  });
+})

--- a/integration-tests/wallet-handling-missed-blocks.spec.ts
+++ b/integration-tests/wallet-handling-missed-blocks.spec.ts
@@ -1,0 +1,25 @@
+import { PollingSubscribeProvider } from "@taquito/taquito";
+import { CONFIGS } from "./config";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+   describe(`Test handling of missed blocks through wallet api using: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup()
+      done()
+    })
+    test('Verify operation is found even if the poller skipped blocks', async (done) => {
+      // To simulate the behavior where blocks are skipped, we use a polling interval higher than the time between blocks
+      // Before fixing issue #1783, if a block was skipped, the `WalletOperation` class was throwing an error `MissedBlockDuringConfirmationError`
+      // After fixing issue #1783, if blocks are skipped, they will be retrieved and inspected by the WalletOperation class
+      Tezos.setStreamProvider(Tezos.getFactory(PollingSubscribeProvider)({ pollingIntervalMilliseconds: 60000 }));
+      const op = await Tezos.wallet.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 }).send();
+      await op.confirmation();
+      expect(op.opHash).toBeDefined();
+      expect(await op.status()).toBe('applied');
+
+      done();
+    })
+  });
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,36 +49,38 @@
       }
     },
     "node_modules/@airgap/beacon-core": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.1.4.tgz",
-      "integrity": "sha512-GpSFjQL+larOigCRKtdEE4Dhl3cWOl0GP3tjVI6WSCExEAVKGE8EW37NDIgRDJwANFPAHt427wVcrk6slXqmbQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.2.0.tgz",
+      "integrity": "sha512-gdyEPzjegPPgAQHXrYtpnqV075p+3YBVNijtUNxrSEsLSPHO6EahIlr067bKzHUkz7S325838nPH7WKWP5BxuQ==",
       "dependencies": {
-        "@airgap/beacon-types": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4",
-        "@types/libsodium-wrappers": "0.7.9",
-        "bs58check": "2.1.2",
-        "libsodium-wrappers": "0.7.9"
+        "@airgap/beacon-types": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0",
+        "@stablelib/ed25519": "^1.0.3",
+        "@stablelib/nacl": "^1.0.4",
+        "@stablelib/utf8": "^1.0.1",
+        "@stablelib/x25519-session": "^1.0.4",
+        "bs58check": "2.1.2"
       }
     },
     "node_modules/@airgap/beacon-dapp": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.1.4.tgz",
-      "integrity": "sha512-/7OXrejWlI92pvZXOPqs6eLtC9XBXga0CIz60Uieif43kjRpwhiwm7qVOyjmDi9rRx19ZMP92YWJQX+nuovzbg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.2.0.tgz",
+      "integrity": "sha512-AqxjalyBdBteHFMmIo+wfweZKbGq10zl/700GtMLthcIRBMJlNQtvLyVxus8e2d8vGSuMHFzUxRbaROD3xv8eA==",
       "dependencies": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-transport-matrix": "^3.1.4",
-        "@airgap/beacon-transport-postmessage": "^3.1.4",
-        "@airgap/beacon-ui": "^3.1.4",
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-transport-matrix": "^3.2.0",
+        "@airgap/beacon-transport-postmessage": "^3.2.0",
+        "@airgap/beacon-ui": "^3.2.0",
         "qrcode-generator": "1.4.4"
       }
     },
     "node_modules/@airgap/beacon-transport-matrix": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.1.4.tgz",
-      "integrity": "sha512-IvZnylEqjXyB9JWvpgnSRMom9C5thK5JB88joL2/q24JI73MXTzBh50/GVNfwAat6Ct+ftbn36j17Kh5O/y4wg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.2.0.tgz",
+      "integrity": "sha512-YROvZKlLDcUtuyozi8wNadVtrqHTXNy0wsQofgDDILYTAotT60AsdhwjS0nGkhe8K3KEtJEnFeJ4pOlL6iyFSg==",
       "dependencies": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4",
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0",
         "axios": "0.24.0"
       }
     },
@@ -91,21 +93,19 @@
       }
     },
     "node_modules/@airgap/beacon-transport-postmessage": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.1.4.tgz",
-      "integrity": "sha512-uEPtTZ7n5C03rNzpjgx1T1bS74DfVs39WEBHACKPhbX0RM5DGDveU/+T/iCJLpF3HTp3v65oomLIRXcL24JY/g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.2.0.tgz",
+      "integrity": "sha512-X6c+g+I6HXFtwyWslQVSareBwzmKYxUH39xyncEKhOXqKY0b0W2byW4iKJBZitxarPEfBQn6bEXcEsD/MOXGYA==",
       "dependencies": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-types": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4",
-        "@types/libsodium-wrappers": "0.7.9",
-        "libsodium-wrappers": "0.7.9"
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-types": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0"
       }
     },
     "node_modules/@airgap/beacon-types": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.1.4.tgz",
-      "integrity": "sha512-x3HM0YKe4gA31lqopAOpP2YF5hfAiu2TQ0Pv/8pPLM/VHLJoJd19XF3WZyIL958tkLOmvNb3IUan1XPT1ENsqA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.2.0.tgz",
+      "integrity": "sha512-qM+FmtIOrwZ5Fj5eIkE7Y8o7Va5fsBeYPzeTfzPF4ulJZQ5wTiNEK2HVUAzui+bMej9tPtcF9I6kF6wrOtK27A==",
       "dependencies": {
         "@types/chrome": "0.0.163"
       }
@@ -120,24 +120,25 @@
       }
     },
     "node_modules/@airgap/beacon-ui": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.1.4.tgz",
-      "integrity": "sha512-g/iiF53wfNAQ62htF2fbING6bwHiE1s/q0LJlxfUQx/OINmp9Gt1HrIdp92Af0QBi9db0hda6PlN4T4j4OKjaQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.2.0.tgz",
+      "integrity": "sha512-UFi4bxXwGVSt/uUvod+dAAgnX1IuUUtqjI+1BFDuAJ1H8dkkcWYstiDqssPsVkMTeGBbE5ExyCV0QaKFKjnKEg==",
       "dependencies": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-transport-postmessage": "^3.1.4",
-        "@airgap/beacon-types": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4"
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-transport-postmessage": "^3.2.0",
+        "@airgap/beacon-types": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0"
       }
     },
     "node_modules/@airgap/beacon-utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.1.4.tgz",
-      "integrity": "sha512-hDDRgG7pU4h8hOLlgScBetjFTPHH3gTWEeKiFkVq/3LzqIe1c84JBaCDqMNpnxd9jenFo+/Q0jRj1zhvW6Bg6w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.2.0.tgz",
+      "integrity": "sha512-0oqAjyJ78up/Tz6JxKHleqjScG7FjLOxGEKz46CE8h05vsdSw1fRtzyzhoVzTNaxFtHbTX6kgGBbowhW49uemw==",
       "dependencies": {
-        "@types/libsodium-wrappers": "0.7.9",
-        "bs58check": "2.1.2",
-        "libsodium-wrappers": "0.7.9"
+        "@stablelib/nacl": "^1.0.3",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/utf8": "^1.0.1",
+        "bs58check": "2.1.2"
       }
     },
     "node_modules/@airgap/sapling-wasm": {
@@ -4165,6 +4166,11 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "node_modules/@stablelib/utf8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz",
+      "integrity": "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
+    },
     "node_modules/@stablelib/wipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
@@ -4178,6 +4184,18 @@
         "@stablelib/keyagreement": "^1.0.1",
         "@stablelib/random": "^1.0.2",
         "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/x25519-session": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz",
+      "integrity": "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w==",
+      "dependencies": {
+        "@stablelib/blake2b": "^1.0.1",
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/wipe": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3"
       }
     },
     "node_modules/@stablelib/xsalsa20": {
@@ -4482,7 +4500,8 @@
     "node_modules/@types/libsodium-wrappers": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
-      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw==",
+      "dev": true
     },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
@@ -20580,7 +20599,7 @@
       "version": "14.0.0",
       "license": "MIT",
       "dependencies": {
-        "@airgap/beacon-dapp": "^3.1.4",
+        "@airgap/beacon-dapp": "^3.2.0",
         "@taquito/taquito": "^14.0.0",
         "libsodium-wrappers": "0.7.9"
       },
@@ -21292,70 +21311,6 @@
         "node": ">=6.0.0"
       }
     },
-    "packages/taquito-michelson-encoder/node_modules/@taquito/http-utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz",
-      "integrity": "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^0.26.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "packages/taquito-michelson-encoder/node_modules/@taquito/rpc": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz",
-      "integrity": "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA==",
-      "dev": true,
-      "dependencies": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "packages/taquito-michelson-encoder/node_modules/@taquito/utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz",
-      "integrity": "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA==",
-      "dependencies": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@types/bs58check": "^2.1.0",
-        "bignumber.js": "^9.0.2",
-        "blakejs": "^1.2.1",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "elliptic": "^6.5.4",
-        "typedarray-to-buffer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "packages/taquito-michelson-encoder/node_modules/typedarray-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "packages/taquito-remote-signer": {
       "name": "@taquito/remote-signer",
       "version": "14.0.0",
@@ -22003,36 +21958,38 @@
   },
   "dependencies": {
     "@airgap/beacon-core": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.1.4.tgz",
-      "integrity": "sha512-GpSFjQL+larOigCRKtdEE4Dhl3cWOl0GP3tjVI6WSCExEAVKGE8EW37NDIgRDJwANFPAHt427wVcrk6slXqmbQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.2.0.tgz",
+      "integrity": "sha512-gdyEPzjegPPgAQHXrYtpnqV075p+3YBVNijtUNxrSEsLSPHO6EahIlr067bKzHUkz7S325838nPH7WKWP5BxuQ==",
       "requires": {
-        "@airgap/beacon-types": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4",
-        "@types/libsodium-wrappers": "0.7.9",
-        "bs58check": "2.1.2",
-        "libsodium-wrappers": "0.7.9"
+        "@airgap/beacon-types": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0",
+        "@stablelib/ed25519": "^1.0.3",
+        "@stablelib/nacl": "^1.0.4",
+        "@stablelib/utf8": "^1.0.1",
+        "@stablelib/x25519-session": "^1.0.4",
+        "bs58check": "2.1.2"
       }
     },
     "@airgap/beacon-dapp": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.1.4.tgz",
-      "integrity": "sha512-/7OXrejWlI92pvZXOPqs6eLtC9XBXga0CIz60Uieif43kjRpwhiwm7qVOyjmDi9rRx19ZMP92YWJQX+nuovzbg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.2.0.tgz",
+      "integrity": "sha512-AqxjalyBdBteHFMmIo+wfweZKbGq10zl/700GtMLthcIRBMJlNQtvLyVxus8e2d8vGSuMHFzUxRbaROD3xv8eA==",
       "requires": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-transport-matrix": "^3.1.4",
-        "@airgap/beacon-transport-postmessage": "^3.1.4",
-        "@airgap/beacon-ui": "^3.1.4",
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-transport-matrix": "^3.2.0",
+        "@airgap/beacon-transport-postmessage": "^3.2.0",
+        "@airgap/beacon-ui": "^3.2.0",
         "qrcode-generator": "1.4.4"
       }
     },
     "@airgap/beacon-transport-matrix": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.1.4.tgz",
-      "integrity": "sha512-IvZnylEqjXyB9JWvpgnSRMom9C5thK5JB88joL2/q24JI73MXTzBh50/GVNfwAat6Ct+ftbn36j17Kh5O/y4wg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.2.0.tgz",
+      "integrity": "sha512-YROvZKlLDcUtuyozi8wNadVtrqHTXNy0wsQofgDDILYTAotT60AsdhwjS0nGkhe8K3KEtJEnFeJ4pOlL6iyFSg==",
       "requires": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4",
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0",
         "axios": "0.24.0"
       },
       "dependencies": {
@@ -22047,21 +22004,19 @@
       }
     },
     "@airgap/beacon-transport-postmessage": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.1.4.tgz",
-      "integrity": "sha512-uEPtTZ7n5C03rNzpjgx1T1bS74DfVs39WEBHACKPhbX0RM5DGDveU/+T/iCJLpF3HTp3v65oomLIRXcL24JY/g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.2.0.tgz",
+      "integrity": "sha512-X6c+g+I6HXFtwyWslQVSareBwzmKYxUH39xyncEKhOXqKY0b0W2byW4iKJBZitxarPEfBQn6bEXcEsD/MOXGYA==",
       "requires": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-types": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4",
-        "@types/libsodium-wrappers": "0.7.9",
-        "libsodium-wrappers": "0.7.9"
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-types": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0"
       }
     },
     "@airgap/beacon-types": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.1.4.tgz",
-      "integrity": "sha512-x3HM0YKe4gA31lqopAOpP2YF5hfAiu2TQ0Pv/8pPLM/VHLJoJd19XF3WZyIL958tkLOmvNb3IUan1XPT1ENsqA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.2.0.tgz",
+      "integrity": "sha512-qM+FmtIOrwZ5Fj5eIkE7Y8o7Va5fsBeYPzeTfzPF4ulJZQ5wTiNEK2HVUAzui+bMej9tPtcF9I6kF6wrOtK27A==",
       "requires": {
         "@types/chrome": "0.0.163"
       },
@@ -22078,24 +22033,25 @@
       }
     },
     "@airgap/beacon-ui": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.1.4.tgz",
-      "integrity": "sha512-g/iiF53wfNAQ62htF2fbING6bwHiE1s/q0LJlxfUQx/OINmp9Gt1HrIdp92Af0QBi9db0hda6PlN4T4j4OKjaQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.2.0.tgz",
+      "integrity": "sha512-UFi4bxXwGVSt/uUvod+dAAgnX1IuUUtqjI+1BFDuAJ1H8dkkcWYstiDqssPsVkMTeGBbE5ExyCV0QaKFKjnKEg==",
       "requires": {
-        "@airgap/beacon-core": "^3.1.4",
-        "@airgap/beacon-transport-postmessage": "^3.1.4",
-        "@airgap/beacon-types": "^3.1.4",
-        "@airgap/beacon-utils": "^3.1.4"
+        "@airgap/beacon-core": "^3.2.0",
+        "@airgap/beacon-transport-postmessage": "^3.2.0",
+        "@airgap/beacon-types": "^3.2.0",
+        "@airgap/beacon-utils": "^3.2.0"
       }
     },
     "@airgap/beacon-utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.1.4.tgz",
-      "integrity": "sha512-hDDRgG7pU4h8hOLlgScBetjFTPHH3gTWEeKiFkVq/3LzqIe1c84JBaCDqMNpnxd9jenFo+/Q0jRj1zhvW6Bg6w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.2.0.tgz",
+      "integrity": "sha512-0oqAjyJ78up/Tz6JxKHleqjScG7FjLOxGEKz46CE8h05vsdSw1fRtzyzhoVzTNaxFtHbTX6kgGBbowhW49uemw==",
       "requires": {
-        "@types/libsodium-wrappers": "0.7.9",
-        "bs58check": "2.1.2",
-        "libsodium-wrappers": "0.7.9"
+        "@stablelib/nacl": "^1.0.3",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/utf8": "^1.0.1",
+        "bs58check": "2.1.2"
       }
     },
     "@airgap/sapling-wasm": {
@@ -25314,6 +25270,11 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "@stablelib/utf8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz",
+      "integrity": "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
+    },
     "@stablelib/wipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
@@ -25329,6 +25290,18 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
+    "@stablelib/x25519-session": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz",
+      "integrity": "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w==",
+      "requires": {
+        "@stablelib/blake2b": "^1.0.1",
+        "@stablelib/keyagreement": "^1.0.1",
+        "@stablelib/random": "^1.0.2",
+        "@stablelib/wipe": "^1.0.1",
+        "@stablelib/x25519": "^1.0.3"
+      }
+    },
     "@stablelib/xsalsa20": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
@@ -25342,7 +25315,7 @@
     "@taquito/beacon-wallet": {
       "version": "file:packages/taquito-beacon-wallet",
       "requires": {
-        "@airgap/beacon-dapp": "^3.1.4",
+        "@airgap/beacon-dapp": "^3.2.0",
         "@taquito/taquito": "^14.0.0",
         "@types/bluebird": "^3.5.36",
         "@types/chrome": "0.0.171",
@@ -25897,49 +25870,6 @@
         "ts-node": "^10.4.0",
         "ts-toolbelt": "^9.6.0",
         "typescript": "~4.1.5"
-      },
-      "dependencies": {
-        "@taquito/http-utils": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz",
-          "integrity": "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A==",
-          "dev": true,
-          "requires": {
-            "axios": "^0.26.0"
-          }
-        },
-        "@taquito/rpc": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz",
-          "integrity": "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA==",
-          "dev": true,
-          "requires": {
-            "@taquito/http-utils": "^14.0.0",
-            "@taquito/utils": "^14.0.0",
-            "bignumber.js": "^9.0.2"
-          }
-        },
-        "@taquito/utils": {
-          "version": "14.0.0",
-          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz",
-          "integrity": "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA==",
-          "requires": {
-            "@stablelib/blake2b": "^1.0.1",
-            "@stablelib/ed25519": "^1.0.2",
-            "@types/bs58check": "^2.1.0",
-            "bignumber.js": "^9.0.2",
-            "blakejs": "^1.2.1",
-            "bs58check": "^2.1.2",
-            "buffer": "^6.0.3",
-            "elliptic": "^6.5.4",
-            "typedarray-to-buffer": "^4.0.0"
-          }
-        },
-        "typedarray-to-buffer": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-          "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ=="
-        }
       }
     },
     "@taquito/remote-signer": {
@@ -26697,7 +26627,8 @@
     "@types/libsodium-wrappers": {
       "version": "0.7.9",
       "resolved": "https://registry.npmjs.org/@types/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
-      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw=="
+      "integrity": "sha512-LisgKLlYQk19baQwjkBZZXdJL0KbeTpdEnrAfz5hQACbklCY0gVFnsKUyjfNWF1UQsCSjw93Sj5jSbiO8RPfdw==",
+      "dev": true
     },
     "@types/minimatch": {
       "version": "3.0.5",

--- a/packages/taquito-beacon-wallet/package-lock.json
+++ b/packages/taquito-beacon-wallet/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "@airgap/beacon-dapp": "^3.2.0",
-        "@taquito/taquito": "^14.0.0",
         "libsodium-wrappers": "0.7.9"
       },
       "devDependencies": {
@@ -1353,140 +1352,6 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "node_modules/@taquito/http-utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz",
-      "integrity": "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A==",
-      "dependencies": {
-        "axios": "^0.26.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/http-utils/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
-    },
-    "node_modules/@taquito/local-forging": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-14.0.0.tgz",
-      "integrity": "sha512-Nm0xGmS1Jzd+tU0a/8Y8XuTghbiPBgHDLo+e4141TK3OAwTzOw0an+w3xK9QVfzvxfIcZBSMjeMZzOwDdiqkJQ==",
-      "dependencies": {
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/michel-codec": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-14.0.0.tgz",
-      "integrity": "sha512-ftnBvUVddlHBqvQbGPHEb26KrS4lIcaZ1eIpYJWiz+akb4Pcfyq7j/OEsDZbB7Pl2FP9hqu7ZygOF34zY6Lrtw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/michelson-encoder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-14.0.0.tgz",
-      "integrity": "sha512-KIS+xl4rKfnd6hf9LUr6W+Pb7gv8F/Qsx0fho9CtM2PodKvdef3YlvkpScBUM9QZntAlvq2XQXUVXcZkbvxygw==",
-      "dependencies": {
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "fast-json-stable-stringify": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/rpc": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz",
-      "integrity": "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA==",
-      "dependencies": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/taquito": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-14.0.0.tgz",
-      "integrity": "sha512-JaXfvqOCF3dkwXxhe00Ravb8WLMC2VqJxerf4GrGUEpJw+NAkwbGEb8k/52+MQQdlxMPepZdPPru/HM3nFG0Tw==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/local-forging": "^14.0.0",
-        "@taquito/michel-codec": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "rxjs": "^6.6.3"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/taquito/node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-      "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
-      }
-    },
-    "node_modules/@taquito/utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz",
-      "integrity": "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA==",
-      "dependencies": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@types/bs58check": "^2.1.0",
-        "bignumber.js": "^9.0.2",
-        "blakejs": "^1.2.1",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "elliptic": "^6.5.4",
-        "typedarray-to-buffer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/utils/node_modules/typedarray-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -1566,14 +1431,6 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
       "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
       "dev": true
-    },
-    "node_modules/@types/bs58check": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bs58check/-/bs58check-2.1.0.tgz",
-      "integrity": "sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/chrome": {
       "version": "0.0.171",
@@ -1667,7 +1524,8 @@
     "node_modules/@types/node": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
-      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
+      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2388,25 +2246,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -2415,24 +2254,6 @@
       "dependencies": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "node_modules/bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2455,11 +2276,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "node_modules/browser-process-hrtime": {
       "version": "1.0.0",
@@ -2527,29 +2343,6 @@
       "dev": true,
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -3269,20 +3062,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
       "integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg==",
       "dev": true
-    },
-    "node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/emittery": {
       "version": "0.7.2",
@@ -4010,7 +3789,8 @@
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -4484,25 +4264,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -4589,25 +4350,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -6358,16 +6100,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -8673,7 +8405,8 @@
     "node_modules/tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -10275,107 +10008,6 @@
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "@taquito/http-utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz",
-      "integrity": "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A==",
-      "requires": {
-        "axios": "^0.26.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.26.1",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-          "requires": {
-            "follow-redirects": "^1.14.8"
-          }
-        }
-      }
-    },
-    "@taquito/local-forging": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-14.0.0.tgz",
-      "integrity": "sha512-Nm0xGmS1Jzd+tU0a/8Y8XuTghbiPBgHDLo+e4141TK3OAwTzOw0an+w3xK9QVfzvxfIcZBSMjeMZzOwDdiqkJQ==",
-      "requires": {
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      }
-    },
-    "@taquito/michel-codec": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-14.0.0.tgz",
-      "integrity": "sha512-ftnBvUVddlHBqvQbGPHEb26KrS4lIcaZ1eIpYJWiz+akb4Pcfyq7j/OEsDZbB7Pl2FP9hqu7ZygOF34zY6Lrtw=="
-    },
-    "@taquito/michelson-encoder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-14.0.0.tgz",
-      "integrity": "sha512-KIS+xl4rKfnd6hf9LUr6W+Pb7gv8F/Qsx0fho9CtM2PodKvdef3YlvkpScBUM9QZntAlvq2XQXUVXcZkbvxygw==",
-      "requires": {
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "fast-json-stable-stringify": "^2.1.0"
-      }
-    },
-    "@taquito/rpc": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz",
-      "integrity": "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA==",
-      "requires": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      }
-    },
-    "@taquito/taquito": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-14.0.0.tgz",
-      "integrity": "sha512-JaXfvqOCF3dkwXxhe00Ravb8WLMC2VqJxerf4GrGUEpJw+NAkwbGEb8k/52+MQQdlxMPepZdPPru/HM3nFG0Tw==",
-      "requires": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/local-forging": "^14.0.0",
-        "@taquito/michel-codec": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "rxjs": "^6.6.3"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "6.6.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
-          "requires": {
-            "tslib": "^1.9.0"
-          }
-        }
-      }
-    },
-    "@taquito/utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz",
-      "integrity": "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA==",
-      "requires": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@types/bs58check": "^2.1.0",
-        "bignumber.js": "^9.0.2",
-        "blakejs": "^1.2.1",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "elliptic": "^6.5.4",
-        "typedarray-to-buffer": "^4.0.0"
-      },
-      "dependencies": {
-        "typedarray-to-buffer": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-          "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ=="
-        }
-      }
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -10452,14 +10084,6 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
       "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
       "dev": true
-    },
-    "@types/bs58check": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@types/bs58check/-/bs58check-2.1.0.tgz",
-      "integrity": "sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==",
-      "requires": {
-        "@types/node": "*"
-      }
     },
     "@types/chrome": {
       "version": "0.0.171",
@@ -10553,7 +10177,8 @@
     "@types/node": {
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
-      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw=="
+      "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -11071,11 +10696,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -11084,21 +10704,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "bignumber.js": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
-    },
-    "blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
-    },
-    "bn.js": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -11118,11 +10723,6 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
     },
     "browser-process-hrtime": {
       "version": "1.0.0",
@@ -11177,15 +10777,6 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -11745,20 +11336,6 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
       "integrity": "sha512-ChtwF7qB03INq1SyMpue08wc6cve+ktj2UC/Y7se9vB+JryfzziJeYwsgb8jLaCA5GMkHCdn5M62PfSMWhifZg==",
       "dev": true
-    },
-    "elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "requires": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "emittery": {
       "version": "0.7.2",
@@ -12325,7 +11902,8 @@
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -12681,25 +12259,6 @@
         "safe-buffer": "^5.2.0"
       }
     },
-    "hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
-    "hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
     "hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -12767,11 +12326,6 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
     "ignore": {
       "version": "5.2.0",
@@ -14102,16 +13656,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
-    },
-    "minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
-    "minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
     },
     "minimatch": {
       "version": "3.1.2",
@@ -15878,7 +15422,8 @@
     "tslib": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "tsutils": {
       "version": "3.21.0",

--- a/packages/taquito/src/operations/operations.ts
+++ b/packages/taquito/src/operations/operations.ts
@@ -1,12 +1,19 @@
-import { OperationContentsAndResult, OperationContentsAndResultReveal } from '@taquito/rpc';
-import { defer, EMPTY, of, ReplaySubject, throwError } from 'rxjs';
+import {
+  BlockResponse,
+  OperationContentsAndResult,
+  OperationContentsAndResultReveal,
+} from '@taquito/rpc';
+import { defer, EMPTY, of, range, ReplaySubject, throwError } from 'rxjs';
 import {
   catchError,
+  concatMap,
+  endWith,
   filter,
   first,
   map,
   shareReplay,
   switchMap,
+  tap,
   timeoutWith,
 } from 'rxjs/operators';
 import { Context } from '../context';
@@ -25,12 +32,21 @@ interface PollingConfig {
  */
 export class Operation {
   private _pollingConfig$ = new ReplaySubject<PollingConfig>(1);
+  private lastHead: BlockResponse | undefined;
 
   private currentHead$ = this._pollingConfig$.pipe(
     switchMap((config) => {
       return defer(() =>
         createObservableFromSubscription(this.context.stream.subscribeBlock('head'))
       ).pipe(
+        switchMap((newHead) => {
+          const prevHead = this.lastHead?.header.level ?? newHead.header.level - 1;
+          return range(prevHead + 1, newHead.header.level - prevHead - 1).pipe(
+            concatMap((level) => this.context.readProvider.getBlock(level)),
+            endWith(newHead)
+          );
+        }),
+        tap((newHead) => (this.lastHead = newHead)),
         timeoutWith(config.timeout * 1000, throwError(new Error('Confirmation polling timed out')))
       );
     }),

--- a/packages/taquito/src/wallet/operation.ts
+++ b/packages/taquito/src/wallet/operation.ts
@@ -1,12 +1,15 @@
 import { BlockResponse, OperationContentsAndResult, OperationResultStatusEnum } from '@taquito/rpc';
-import { combineLatest, from, Observable, of, ReplaySubject } from 'rxjs';
+import { combineLatest, from, Observable, of, range, ReplaySubject } from 'rxjs';
 import {
   catchError,
+  concatMap,
   distinctUntilChanged,
+  endWith,
   filter,
   first,
   map,
   shareReplay,
+  switchMap,
   takeWhile,
   tap,
 } from 'rxjs/operators';
@@ -17,20 +20,6 @@ import { BlockIdentifier } from '../read-provider/interface';
 import { InvalidConfirmationCountError, ConfirmationUndefinedError } from '../error';
 
 export type OperationStatus = 'pending' | 'unknown' | OperationResultStatusEnum;
-
-/**
- *  @category Error
- *  @description Error that indicates a missed block when polling to retrieve new head block. This may happen when the polling interval is greater than the time between blocks.
- */
-export class MissedBlockDuringConfirmationError extends Error {
-  name = 'MissedBlockDuringConfirmationError';
-
-  constructor() {
-    super(
-      'Taquito missed a block while waiting for operation confirmation and was not able to find the operation'
-    );
-  }
-}
 
 const MAX_BRANCH_ANCESTORS = 60;
 
@@ -44,17 +33,14 @@ export class WalletOperation {
 
   private lastHead: BlockResponse | undefined;
   protected newHead$: Observable<BlockResponse> = this._newHead$.pipe(
-    tap((newHead) => {
-      if (
-        !this._included &&
-        this.lastHead &&
-        newHead.header.level - this.lastHead.header.level > 1
-      ) {
-        throw new MissedBlockDuringConfirmationError();
-      }
-
-      this.lastHead = newHead;
+    switchMap((newHead) => {
+      const prevHead = this.lastHead?.header.level ?? newHead.header.level - 1;
+      return range(prevHead + 1, newHead.header.level - prevHead - 1).pipe(
+        concatMap((level) => this.context.readProvider.getBlock(level)),
+        endWith(newHead)
+      );
     }),
+    tap((newHead) => (this.lastHead = newHead)),
     shareReplay({ bufferSize: 1, refCount: true })
   );
 

--- a/packages/taquito/test/wallet/data.ts
+++ b/packages/taquito/test/wallet/data.ts
@@ -2,7 +2,9 @@ export const blockResponse = {
   protocol: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
   chain_id: 'NetXi2ZagzEsXbZ',
   hash: 'BM6NRnbjdWqknmErSjMmkh49NjaVqq64TNmKTsdQRaWke5iqHpz',
-  header: {},
+  header: {
+    level: 111,
+  },
   metadata: {},
   operations: [
     [],

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19,19 +19,6 @@
         "@ledgerhq/hw-transport-webhid": "^6.27.3",
         "@mdx-js/react": "^1.6.21",
         "@svgr/webpack": "^6.3.1",
-        "@taquito/beacon-wallet": "^14.0.0",
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/ledger-signer": "^14.0.0",
-        "@taquito/michel-codec": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/remote-signer": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/sapling": "^14.0.0",
-        "@taquito/signer": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/tzip12": "^14.0.0",
-        "@taquito/tzip16": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
         "@temple-wallet/dapp": "^7.0.0",
         "abort-controller": "^3.0.0",
         "algoliasearch": "^4.14.2",
@@ -377,95 +364,6 @@
       "engines": {
         "node": ">=6.0.0"
       }
-    },
-    "node_modules/@airgap/beacon-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.2.0.tgz",
-      "integrity": "sha512-gdyEPzjegPPgAQHXrYtpnqV075p+3YBVNijtUNxrSEsLSPHO6EahIlr067bKzHUkz7S325838nPH7WKWP5BxuQ==",
-      "dependencies": {
-        "@airgap/beacon-types": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0",
-        "@stablelib/ed25519": "^1.0.3",
-        "@stablelib/nacl": "^1.0.4",
-        "@stablelib/utf8": "^1.0.1",
-        "@stablelib/x25519-session": "^1.0.4",
-        "bs58check": "2.1.2"
-      }
-    },
-    "node_modules/@airgap/beacon-dapp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.2.0.tgz",
-      "integrity": "sha512-AqxjalyBdBteHFMmIo+wfweZKbGq10zl/700GtMLthcIRBMJlNQtvLyVxus8e2d8vGSuMHFzUxRbaROD3xv8eA==",
-      "dependencies": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-transport-matrix": "^3.2.0",
-        "@airgap/beacon-transport-postmessage": "^3.2.0",
-        "@airgap/beacon-ui": "^3.2.0",
-        "qrcode-generator": "1.4.4"
-      }
-    },
-    "node_modules/@airgap/beacon-transport-matrix": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.2.0.tgz",
-      "integrity": "sha512-YROvZKlLDcUtuyozi8wNadVtrqHTXNy0wsQofgDDILYTAotT60AsdhwjS0nGkhe8K3KEtJEnFeJ4pOlL6iyFSg==",
-      "dependencies": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0",
-        "axios": "0.24.0"
-      }
-    },
-    "node_modules/@airgap/beacon-transport-matrix/node_modules/axios": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.4"
-      }
-    },
-    "node_modules/@airgap/beacon-transport-postmessage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.2.0.tgz",
-      "integrity": "sha512-X6c+g+I6HXFtwyWslQVSareBwzmKYxUH39xyncEKhOXqKY0b0W2byW4iKJBZitxarPEfBQn6bEXcEsD/MOXGYA==",
-      "dependencies": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-types": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0"
-      }
-    },
-    "node_modules/@airgap/beacon-types": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.2.0.tgz",
-      "integrity": "sha512-qM+FmtIOrwZ5Fj5eIkE7Y8o7Va5fsBeYPzeTfzPF4ulJZQ5wTiNEK2HVUAzui+bMej9tPtcF9I6kF6wrOtK27A==",
-      "dependencies": {
-        "@types/chrome": "0.0.163"
-      }
-    },
-    "node_modules/@airgap/beacon-ui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.2.0.tgz",
-      "integrity": "sha512-UFi4bxXwGVSt/uUvod+dAAgnX1IuUUtqjI+1BFDuAJ1H8dkkcWYstiDqssPsVkMTeGBbE5ExyCV0QaKFKjnKEg==",
-      "dependencies": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-transport-postmessage": "^3.2.0",
-        "@airgap/beacon-types": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0"
-      }
-    },
-    "node_modules/@airgap/beacon-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.2.0.tgz",
-      "integrity": "sha512-0oqAjyJ78up/Tz6JxKHleqjScG7FjLOxGEKz46CE8h05vsdSw1fRtzyzhoVzTNaxFtHbTX6kgGBbowhW49uemw==",
-      "dependencies": {
-        "@stablelib/nacl": "^1.0.3",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/utf8": "^1.0.1",
-        "bs58check": "2.1.2"
-      }
-    },
-    "node_modules/@airgap/sapling-wasm": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@airgap/sapling-wasm/-/sapling-wasm-0.0.9.tgz",
-      "integrity": "sha512-rJjV7JIDxoardnZMgk4Uor5Z6OVsAE4I5uDlkGAb0tQ5NN0gmz9Bu2LKMPSCv7UqDpZowDX4BbMDuSqdO/IsbQ=="
     },
     "node_modules/@algolia/autocomplete-core": {
       "version": "1.6.3",
@@ -6191,6 +6089,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
       "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "peer": true,
       "dependencies": {
         "@stablelib/int": "^1.0.1"
       }
@@ -6199,26 +6098,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-1.0.1.tgz",
       "integrity": "sha512-B3KyKoBAjkIFeH7romcF96i+pVFYk7K2SBQ1pZvaxV+epSBXJ+n0C66esUhyz6FF+5FbdQVm77C5fzGFcEZpKA==",
+      "peer": true,
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "node_modules/@stablelib/bytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
-      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
-    },
-    "node_modules/@stablelib/constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
-      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
-    },
     "node_modules/@stablelib/ed25519": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
       "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+      "peer": true,
       "dependencies": {
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha512": "^1.0.1",
@@ -6228,58 +6119,22 @@
     "node_modules/@stablelib/hash": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
+      "peer": true
     },
     "node_modules/@stablelib/int": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
-    },
-    "node_modules/@stablelib/keyagreement": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
-      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
-      "dependencies": {
-        "@stablelib/bytes": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/nacl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.4.tgz",
-      "integrity": "sha512-PJ2U/MrkXSKUM8C4qFs87WeCNxri7KQwR8Cdwm9q2sweGuAtTvOJGuW0F3N+zn+ySLPJA98SYWSSpogMJ1gCmw==",
-      "dependencies": {
-        "@stablelib/poly1305": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1",
-        "@stablelib/x25519": "^1.0.3",
-        "@stablelib/xsalsa20": "^1.0.2"
-      }
-    },
-    "node_modules/@stablelib/poly1305": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
-      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
-      "dependencies": {
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+      "peer": true
     },
     "node_modules/@stablelib/random": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
       "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "peer": true,
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/salsa20": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/salsa20/-/salsa20-1.0.2.tgz",
-      "integrity": "sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/constant-time": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -6287,53 +6142,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
       "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+      "peer": true,
       "dependencies": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "node_modules/@stablelib/utf8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz",
-      "integrity": "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
-    },
     "node_modules/@stablelib/wipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
-    },
-    "node_modules/@stablelib/x25519": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
-      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
-      "dependencies": {
-        "@stablelib/keyagreement": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "node_modules/@stablelib/x25519-session": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz",
-      "integrity": "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w==",
-      "dependencies": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/keyagreement": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1",
-        "@stablelib/x25519": "^1.0.3"
-      }
-    },
-    "node_modules/@stablelib/xsalsa20": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
-      "integrity": "sha512-7XdBGbcNgBShmuhDXv1G1WPVCkjZdkb1oPMzSidO7Fve0MHntH6TjFkj5bfLI+aRE+61weO076vYpP/jmaAYog==",
-      "dependencies": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/salsa20": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1"
-      }
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
+      "peer": true
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
@@ -6599,160 +6419,60 @@
         "node": ">=6"
       }
     },
-    "node_modules/@taquito/beacon-wallet": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-14.0.0.tgz",
-      "integrity": "sha512-v9Fyx5heMOHbZGCWnVPqJqyrHxXgbtH8H4RBOnNI8m7KAq9RtQLwitj6FONcXpEcNzmMzgbIDeom/oizoOfOSQ==",
-      "dependencies": {
-        "@airgap/beacon-dapp": "^3.1.4",
-        "@taquito/taquito": "^14.0.0",
-        "libsodium-wrappers": "0.7.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/http-utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz",
-      "integrity": "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A==",
-      "dependencies": {
-        "axios": "^0.26.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/ledger-signer": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/ledger-signer/-/ledger-signer-14.0.0.tgz",
-      "integrity": "sha512-/QySUxkQEhjrQaB86WPXlH4lNSZQM9tqY36ZEVg9RX8Ydb6qudZniYbzDUP7rEPsMBwG/CvapHc2RQbOsxCC3Q==",
-      "dependencies": {
-        "@ledgerhq/hw-transport": "^6.20.0",
-        "@stablelib/blake2b": "^1.0.1",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "buffer": "^6.0.3"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@taquito/local-forging": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-14.0.0.tgz",
-      "integrity": "sha512-Nm0xGmS1Jzd+tU0a/8Y8XuTghbiPBgHDLo+e4141TK3OAwTzOw0an+w3xK9QVfzvxfIcZBSMjeMZzOwDdiqkJQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-12.1.1.tgz",
+      "integrity": "sha512-SUA1YYRIpEGsTy5OfUIgIem0k/QsAzGjDCvf/wl5XV/fVBkP/+GN7uvYoqgJblCmsgtsMBhJFtXgs+D6bjGexg==",
+      "peer": true,
       "dependencies": {
-        "@taquito/utils": "^14.0.0",
+        "@taquito/utils": "^12.1.1",
         "bignumber.js": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/local-forging/node_modules/@taquito/utils": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.1.tgz",
+      "integrity": "sha512-GxNSBrA02vwhy56ayWB49VZficB+j2oyhPdlsRb2CguephmyEYnlUaNV27ILa6dPDW+zv6+QWQj6GyqLBRpIlA==",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/blake2b": "^1.0.1",
+        "@stablelib/ed25519": "^1.0.2",
+        "@types/bs58check": "^2.1.0",
+        "blakejs": "^1.1.1",
+        "bs58check": "^2.1.2",
+        "buffer": "^6.0.3",
+        "elliptic": "^6.5.4",
+        "typedarray-to-buffer": "^4.0.0"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@taquito/michel-codec": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-14.0.0.tgz",
-      "integrity": "sha512-ftnBvUVddlHBqvQbGPHEb26KrS4lIcaZ1eIpYJWiz+akb4Pcfyq7j/OEsDZbB7Pl2FP9hqu7ZygOF34zY6Lrtw==",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/michelson-encoder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-14.0.0.tgz",
-      "integrity": "sha512-KIS+xl4rKfnd6hf9LUr6W+Pb7gv8F/Qsx0fho9CtM2PodKvdef3YlvkpScBUM9QZntAlvq2XQXUVXcZkbvxygw==",
-      "dependencies": {
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "fast-json-stable-stringify": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/remote-signer": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/remote-signer/-/remote-signer-14.0.0.tgz",
-      "integrity": "sha512-YfEl8cfojrJv1MgZNjn+MtNGD9kOUuqWlx34OlpxICAFQmIblC3xxSYUeZ9ke86UnARE5ATzDPDGpSuu89Znvw==",
-      "dependencies": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "typedarray-to-buffer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/rpc": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz",
-      "integrity": "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA==",
-      "dependencies": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@taquito/sapling": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/sapling/-/sapling-14.0.0.tgz",
-      "integrity": "sha512-qbuf1cH4nW+H+r29lNA1nowC+lxDMmiaM1mg7/QmQlO3P9y2o2kDAjo5qysLAiMjGeFsFvLY3bK4UqkPmvpaHg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "@airgap/sapling-wasm": "0.0.9",
-        "@stablelib/nacl": "^1.0.3",
-        "@stablelib/random": "^1.0.1",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "bip39": "^3.0.4",
-        "blakejs": "^1.2.1",
-        "pbkdf2": "^3.1.2",
-        "typedarray-to-buffer": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@taquito/signer": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-14.0.0.tgz",
-      "integrity": "sha512-vDqp/quzAsOiVikUt5MYUKhHI3S9qlasazyXs99xK9qpGLotbx6aseKcfb/dkaTo4/eoMzP4XzTVdnk0AqcCkw==",
-      "dependencies": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@stablelib/nacl": "^1.0.3",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "elliptic": "^6.5.4",
-        "pbkdf2": "^3.1.2",
-        "typedarray-to-buffer": "^4.0.0"
-      },
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-12.1.1.tgz",
+      "integrity": "sha512-BAig8YyLyRW5kxV/r0S191W+SvYuiTRJpgSp5IsgCDLAOh+d4/xq6IgU3PuGJgokQDstZdTbjpkrgRCnufR8lw==",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@taquito/taquito": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-14.0.0.tgz",
-      "integrity": "sha512-JaXfvqOCF3dkwXxhe00Ravb8WLMC2VqJxerf4GrGUEpJw+NAkwbGEb8k/52+MQQdlxMPepZdPPru/HM3nFG0Tw==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-12.1.1.tgz",
+      "integrity": "sha512-HvbtClQ7isrDd17X/LEKkPzzeVYA8EMUem3qrkl9qvDO6FpJx/QLbUpYfT2PC0pLUkSrzdLGzmESHAOZhcksaw==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/local-forging": "^14.0.0",
-        "@taquito/michel-codec": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
+        "@taquito/http-utils": "^12.1.1",
+        "@taquito/local-forging": "^12.1.1",
+        "@taquito/michel-codec": "^12.1.1",
+        "@taquito/michelson-encoder": "^12.1.1",
+        "@taquito/rpc": "^12.1.1",
+        "@taquito/utils": "^12.1.1",
         "bignumber.js": "^9.0.2",
         "rxjs": "^6.6.3"
       },
@@ -6760,46 +6480,57 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@taquito/tzip12": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/tzip12/-/tzip12-14.0.0.tgz",
-      "integrity": "sha512-CEVaSEYwowM0MDz5tiEDeaEyTG202YSNfj18uBUnSuPS02HKC6QVqDYOhuJ2NrhqmJ+iGgD5FAiRar1ihrRD5A==",
+    "node_modules/@taquito/taquito/node_modules/@taquito/http-utils": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-12.1.1.tgz",
+      "integrity": "sha512-Zlp/eTRVjFs0XEIiAhgxkh6s9npF4dO+e/Sm2XWsDmNPoGI2jdXNH0L+NiKJIOkYcu0CXlcgriTeEaYnbeTvcA==",
+      "peer": true,
       "dependencies": {
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/tzip16": "^14.0.0"
+        "axios": "^0.26.0"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@taquito/tzip16": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/tzip16/-/tzip16-14.0.0.tgz",
-      "integrity": "sha512-NNmN+Ld14TszXwIq23N2mbtuc/hEyHeE8o61md3qV/J7TEV4d+upo085vIMZwFEMT7UlNXLNAUcZqI1N8YgnVQ==",
+    "node_modules/@taquito/taquito/node_modules/@taquito/michelson-encoder": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-12.1.1.tgz",
+      "integrity": "sha512-mWcA1DHHlFj7UswJpEmml853x9e0IYHyeiKZYAo7DtizHz0jiUWtptCuEWiPQ4fMOreFbYZ6KVYenoVfQVNrqA==",
+      "peer": true,
       "dependencies": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
+        "@taquito/rpc": "^12.1.1",
+        "@taquito/utils": "^12.1.1",
         "bignumber.js": "^9.0.2",
-        "crypto-js": "^4.1.1"
+        "fast-json-stable-stringify": "^2.1.0"
       },
       "engines": {
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@taquito/utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz",
-      "integrity": "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA==",
+    "node_modules/@taquito/taquito/node_modules/@taquito/rpc": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-12.1.1.tgz",
+      "integrity": "sha512-CgAF9kdmKLa/UbmiqApDtncCQGiG7kEOIYis8IIa0JUT9JD1H8WBbSNF/oNh4e0soWUK9BL2qU369RFnxIW+iA==",
+      "peer": true,
+      "dependencies": {
+        "@taquito/http-utils": "^12.1.1",
+        "@taquito/utils": "^12.1.1",
+        "bignumber.js": "^9.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@taquito/taquito/node_modules/@taquito/utils": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.1.tgz",
+      "integrity": "sha512-GxNSBrA02vwhy56ayWB49VZficB+j2oyhPdlsRb2CguephmyEYnlUaNV27ILa6dPDW+zv6+QWQj6GyqLBRpIlA==",
+      "peer": true,
       "dependencies": {
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.2",
         "@types/bs58check": "^2.1.0",
-        "bignumber.js": "^9.0.2",
-        "blakejs": "^1.2.1",
+        "blakejs": "^1.1.1",
         "bs58check": "^2.1.2",
         "buffer": "^6.0.3",
         "elliptic": "^6.5.4",
@@ -6868,17 +6599,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/bs58check/-/bs58check-2.1.0.tgz",
       "integrity": "sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@types/chrome": {
-      "version": "0.0.163",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.163.tgz",
-      "integrity": "sha512-g+3E2tg/ukFsEgH+tB3a/b+J1VSvq/8gh2Jwih9eq+T3Idrz7ngj97u+/ya58Bfei2TQtPlRivj1FsCaSnukDA==",
-      "dependencies": {
-        "@types/filesystem": "*",
-        "@types/har-format": "*"
       }
     },
     "node_modules/@types/connect": {
@@ -6948,24 +6671,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
-    },
-    "node_modules/@types/filesystem": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
-      "dependencies": {
-        "@types/filewriter": "*"
-      }
-    },
-    "node_modules/@types/filewriter": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
-    },
-    "node_modules/@types/har-format": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.9.tgz",
-      "integrity": "sha512-rffW6MhQ9yoa75bdNi+rjZBAvu2HhehWJXlhuWXnWdENeuKe82wUgAwxYOb7KRKKmxYN+D/iRKd2NDQMLqlUmg=="
     },
     "node_modules/@types/hast": {
       "version": "2.3.4",
@@ -8168,6 +7873,7 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
       "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -8227,6 +7933,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
       "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8299,26 +8006,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "node_modules/bip39": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
-      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
-      "dependencies": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
-      }
-    },
-    "node_modules/bip39/node_modules/@types/node": {
-      "version": "11.11.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-      "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-    },
     "node_modules/blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "peer": true
     },
     "node_modules/bluebird": {
       "version": "3.7.2",
@@ -8329,7 +8021,8 @@
     "node_modules/bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "peer": true
     },
     "node_modules/body-parser": {
       "version": "1.20.0",
@@ -8503,7 +8196,8 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "peer": true
     },
     "node_modules/browserify-aes": {
       "version": "1.2.0",
@@ -8641,6 +8335,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "peer": true,
       "dependencies": {
         "base-x": "^3.0.2"
       }
@@ -8649,6 +8344,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "peer": true,
       "dependencies": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -9170,6 +8866,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -10193,6 +9890,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "peer": true,
       "dependencies": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -10205,6 +9903,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "peer": true,
       "dependencies": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -10254,11 +9953,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -11898,6 +11592,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "peer": true,
       "dependencies": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -13763,6 +13458,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -13789,12 +13485,14 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -13920,6 +13618,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "peer": true,
       "dependencies": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -15498,19 +15197,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/libsodium": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
-      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
-    },
-    "node_modules/libsodium-wrappers": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
-      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
-      "dependencies": {
-        "libsodium": "^0.7.0"
-      }
-    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -15852,6 +15538,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "peer": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -16304,7 +15991,8 @@
     "node_modules/minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "peer": true
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -18351,6 +18039,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "peer": true,
       "dependencies": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -19364,11 +19053,6 @@
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
       }
-    },
-    "node_modules/qrcode-generator": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
-      "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
     },
     "node_modules/qs": {
       "version": "6.10.3",
@@ -21000,6 +20684,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "peer": true,
       "dependencies": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -21607,6 +21292,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -23277,7 +22963,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "4.5.2",
@@ -25562,97 +25249,6 @@
     }
   },
   "dependencies": {
-    "@airgap/beacon-core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.2.0.tgz",
-      "integrity": "sha512-gdyEPzjegPPgAQHXrYtpnqV075p+3YBVNijtUNxrSEsLSPHO6EahIlr067bKzHUkz7S325838nPH7WKWP5BxuQ==",
-      "requires": {
-        "@airgap/beacon-types": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0",
-        "@stablelib/ed25519": "^1.0.3",
-        "@stablelib/nacl": "^1.0.4",
-        "@stablelib/utf8": "^1.0.1",
-        "@stablelib/x25519-session": "^1.0.4",
-        "bs58check": "2.1.2"
-      }
-    },
-    "@airgap/beacon-dapp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.2.0.tgz",
-      "integrity": "sha512-AqxjalyBdBteHFMmIo+wfweZKbGq10zl/700GtMLthcIRBMJlNQtvLyVxus8e2d8vGSuMHFzUxRbaROD3xv8eA==",
-      "requires": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-transport-matrix": "^3.2.0",
-        "@airgap/beacon-transport-postmessage": "^3.2.0",
-        "@airgap/beacon-ui": "^3.2.0",
-        "qrcode-generator": "1.4.4"
-      }
-    },
-    "@airgap/beacon-transport-matrix": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.2.0.tgz",
-      "integrity": "sha512-YROvZKlLDcUtuyozi8wNadVtrqHTXNy0wsQofgDDILYTAotT60AsdhwjS0nGkhe8K3KEtJEnFeJ4pOlL6iyFSg==",
-      "requires": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0",
-        "axios": "0.24.0"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "0.24.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-          "requires": {
-            "follow-redirects": "^1.14.4"
-          }
-        }
-      }
-    },
-    "@airgap/beacon-transport-postmessage": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.2.0.tgz",
-      "integrity": "sha512-X6c+g+I6HXFtwyWslQVSareBwzmKYxUH39xyncEKhOXqKY0b0W2byW4iKJBZitxarPEfBQn6bEXcEsD/MOXGYA==",
-      "requires": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-types": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0"
-      }
-    },
-    "@airgap/beacon-types": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.2.0.tgz",
-      "integrity": "sha512-qM+FmtIOrwZ5Fj5eIkE7Y8o7Va5fsBeYPzeTfzPF4ulJZQ5wTiNEK2HVUAzui+bMej9tPtcF9I6kF6wrOtK27A==",
-      "requires": {
-        "@types/chrome": "0.0.163"
-      }
-    },
-    "@airgap/beacon-ui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.2.0.tgz",
-      "integrity": "sha512-UFi4bxXwGVSt/uUvod+dAAgnX1IuUUtqjI+1BFDuAJ1H8dkkcWYstiDqssPsVkMTeGBbE5ExyCV0QaKFKjnKEg==",
-      "requires": {
-        "@airgap/beacon-core": "^3.2.0",
-        "@airgap/beacon-transport-postmessage": "^3.2.0",
-        "@airgap/beacon-types": "^3.2.0",
-        "@airgap/beacon-utils": "^3.2.0"
-      }
-    },
-    "@airgap/beacon-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.2.0.tgz",
-      "integrity": "sha512-0oqAjyJ78up/Tz6JxKHleqjScG7FjLOxGEKz46CE8h05vsdSw1fRtzyzhoVzTNaxFtHbTX6kgGBbowhW49uemw==",
-      "requires": {
-        "@stablelib/nacl": "^1.0.3",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/utf8": "^1.0.1",
-        "bs58check": "2.1.2"
-      }
-    },
-    "@airgap/sapling-wasm": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@airgap/sapling-wasm/-/sapling-wasm-0.0.9.tgz",
-      "integrity": "sha512-rJjV7JIDxoardnZMgk4Uor5Z6OVsAE4I5uDlkGAb0tQ5NN0gmz9Bu2LKMPSCv7UqDpZowDX4BbMDuSqdO/IsbQ=="
-    },
     "@algolia/autocomplete-core": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.6.3.tgz",
@@ -29836,6 +29432,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
       "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "peer": true,
       "requires": {
         "@stablelib/int": "^1.0.1"
       }
@@ -29844,26 +29441,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/blake2b/-/blake2b-1.0.1.tgz",
       "integrity": "sha512-B3KyKoBAjkIFeH7romcF96i+pVFYk7K2SBQ1pZvaxV+epSBXJ+n0C66esUhyz6FF+5FbdQVm77C5fzGFcEZpKA==",
+      "peer": true,
       "requires": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "@stablelib/bytes": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/bytes/-/bytes-1.0.1.tgz",
-      "integrity": "sha512-Kre4Y4kdwuqL8BR2E9hV/R5sOrUj6NanZaZis0V6lX5yzqC3hBuVSDXUIBqQv/sCpmuWRiHLwqiT1pqqjuBXoQ=="
-    },
-    "@stablelib/constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz",
-      "integrity": "sha512-tNOs3uD0vSJcK6z1fvef4Y+buN7DXhzHDPqRLSXUel1UfqMB1PWNsnnAezrKfEwTLpN0cGH2p9NNjs6IqeD0eg=="
-    },
     "@stablelib/ed25519": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz",
       "integrity": "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==",
+      "peer": true,
       "requires": {
         "@stablelib/random": "^1.0.2",
         "@stablelib/sha512": "^1.0.1",
@@ -29873,58 +29462,22 @@
     "@stablelib/hash": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-1.0.1.tgz",
-      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg=="
+      "integrity": "sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==",
+      "peer": true
     },
     "@stablelib/int": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
-      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w=="
-    },
-    "@stablelib/keyagreement": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/keyagreement/-/keyagreement-1.0.1.tgz",
-      "integrity": "sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==",
-      "requires": {
-        "@stablelib/bytes": "^1.0.1"
-      }
-    },
-    "@stablelib/nacl": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.4.tgz",
-      "integrity": "sha512-PJ2U/MrkXSKUM8C4qFs87WeCNxri7KQwR8Cdwm9q2sweGuAtTvOJGuW0F3N+zn+ySLPJA98SYWSSpogMJ1gCmw==",
-      "requires": {
-        "@stablelib/poly1305": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1",
-        "@stablelib/x25519": "^1.0.3",
-        "@stablelib/xsalsa20": "^1.0.2"
-      }
-    },
-    "@stablelib/poly1305": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/poly1305/-/poly1305-1.0.1.tgz",
-      "integrity": "sha512-1HlG3oTSuQDOhSnLwJRKeTRSAdFNVB/1djy2ZbS35rBSJ/PFqx9cf9qatinWghC2UbfOYD8AcrtbUQl8WoxabA==",
-      "requires": {
-        "@stablelib/constant-time": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+      "peer": true
     },
     "@stablelib/random": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
       "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "peer": true,
       "requires": {
         "@stablelib/binary": "^1.0.1",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/salsa20": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/salsa20/-/salsa20-1.0.2.tgz",
-      "integrity": "sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/constant-time": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
@@ -29932,53 +29485,18 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/sha512/-/sha512-1.0.1.tgz",
       "integrity": "sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==",
+      "peer": true,
       "requires": {
         "@stablelib/binary": "^1.0.1",
         "@stablelib/hash": "^1.0.1",
         "@stablelib/wipe": "^1.0.1"
       }
     },
-    "@stablelib/utf8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz",
-      "integrity": "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
-    },
     "@stablelib/wipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
-      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
-    },
-    "@stablelib/x25519": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
-      "integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
-      "requires": {
-        "@stablelib/keyagreement": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1"
-      }
-    },
-    "@stablelib/x25519-session": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz",
-      "integrity": "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w==",
-      "requires": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/keyagreement": "^1.0.1",
-        "@stablelib/random": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1",
-        "@stablelib/x25519": "^1.0.3"
-      }
-    },
-    "@stablelib/xsalsa20": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/xsalsa20/-/xsalsa20-1.0.2.tgz",
-      "integrity": "sha512-7XdBGbcNgBShmuhDXv1G1WPVCkjZdkb1oPMzSidO7Fve0MHntH6TjFkj5bfLI+aRE+61weO076vYpP/jmaAYog==",
-      "requires": {
-        "@stablelib/binary": "^1.0.1",
-        "@stablelib/salsa20": "^1.0.2",
-        "@stablelib/wipe": "^1.0.1"
-      }
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
+      "peer": true
     },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.3.1",
@@ -30113,170 +29631,104 @@
         "defer-to-connect": "^1.0.1"
       }
     },
-    "@taquito/beacon-wallet": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/beacon-wallet/-/beacon-wallet-14.0.0.tgz",
-      "integrity": "sha512-v9Fyx5heMOHbZGCWnVPqJqyrHxXgbtH8H4RBOnNI8m7KAq9RtQLwitj6FONcXpEcNzmMzgbIDeom/oizoOfOSQ==",
-      "requires": {
-        "@airgap/beacon-dapp": "^3.1.4",
-        "@taquito/taquito": "^14.0.0",
-        "libsodium-wrappers": "0.7.9"
-      }
-    },
-    "@taquito/http-utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz",
-      "integrity": "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A==",
-      "requires": {
-        "axios": "^0.26.0"
-      }
-    },
-    "@taquito/ledger-signer": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/ledger-signer/-/ledger-signer-14.0.0.tgz",
-      "integrity": "sha512-/QySUxkQEhjrQaB86WPXlH4lNSZQM9tqY36ZEVg9RX8Ydb6qudZniYbzDUP7rEPsMBwG/CvapHc2RQbOsxCC3Q==",
-      "requires": {
-        "@ledgerhq/hw-transport": "^6.20.0",
-        "@stablelib/blake2b": "^1.0.1",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "buffer": "^6.0.3"
-      }
-    },
     "@taquito/local-forging": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-14.0.0.tgz",
-      "integrity": "sha512-Nm0xGmS1Jzd+tU0a/8Y8XuTghbiPBgHDLo+e4141TK3OAwTzOw0an+w3xK9QVfzvxfIcZBSMjeMZzOwDdiqkJQ==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-12.1.1.tgz",
+      "integrity": "sha512-SUA1YYRIpEGsTy5OfUIgIem0k/QsAzGjDCvf/wl5XV/fVBkP/+GN7uvYoqgJblCmsgtsMBhJFtXgs+D6bjGexg==",
+      "peer": true,
       "requires": {
-        "@taquito/utils": "^14.0.0",
+        "@taquito/utils": "^12.1.1",
         "bignumber.js": "^9.0.2"
+      },
+      "dependencies": {
+        "@taquito/utils": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.1.tgz",
+          "integrity": "sha512-GxNSBrA02vwhy56ayWB49VZficB+j2oyhPdlsRb2CguephmyEYnlUaNV27ILa6dPDW+zv6+QWQj6GyqLBRpIlA==",
+          "peer": true,
+          "requires": {
+            "@stablelib/blake2b": "^1.0.1",
+            "@stablelib/ed25519": "^1.0.2",
+            "@types/bs58check": "^2.1.0",
+            "blakejs": "^1.1.1",
+            "bs58check": "^2.1.2",
+            "buffer": "^6.0.3",
+            "elliptic": "^6.5.4",
+            "typedarray-to-buffer": "^4.0.0"
+          }
+        }
       }
     },
     "@taquito/michel-codec": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-14.0.0.tgz",
-      "integrity": "sha512-ftnBvUVddlHBqvQbGPHEb26KrS4lIcaZ1eIpYJWiz+akb4Pcfyq7j/OEsDZbB7Pl2FP9hqu7ZygOF34zY6Lrtw=="
-    },
-    "@taquito/michelson-encoder": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-14.0.0.tgz",
-      "integrity": "sha512-KIS+xl4rKfnd6hf9LUr6W+Pb7gv8F/Qsx0fho9CtM2PodKvdef3YlvkpScBUM9QZntAlvq2XQXUVXcZkbvxygw==",
-      "requires": {
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "fast-json-stable-stringify": "^2.1.0"
-      }
-    },
-    "@taquito/remote-signer": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/remote-signer/-/remote-signer-14.0.0.tgz",
-      "integrity": "sha512-YfEl8cfojrJv1MgZNjn+MtNGD9kOUuqWlx34OlpxICAFQmIblC3xxSYUeZ9ke86UnARE5ATzDPDGpSuu89Znvw==",
-      "requires": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "typedarray-to-buffer": "^4.0.0"
-      }
-    },
-    "@taquito/rpc": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz",
-      "integrity": "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA==",
-      "requires": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2"
-      }
-    },
-    "@taquito/sapling": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/sapling/-/sapling-14.0.0.tgz",
-      "integrity": "sha512-qbuf1cH4nW+H+r29lNA1nowC+lxDMmiaM1mg7/QmQlO3P9y2o2kDAjo5qysLAiMjGeFsFvLY3bK4UqkPmvpaHg==",
-      "requires": {
-        "@airgap/sapling-wasm": "0.0.9",
-        "@stablelib/nacl": "^1.0.3",
-        "@stablelib/random": "^1.0.1",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "bip39": "^3.0.4",
-        "blakejs": "^1.2.1",
-        "pbkdf2": "^3.1.2",
-        "typedarray-to-buffer": "^4.0.0"
-      }
-    },
-    "@taquito/signer": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/signer/-/signer-14.0.0.tgz",
-      "integrity": "sha512-vDqp/quzAsOiVikUt5MYUKhHI3S9qlasazyXs99xK9qpGLotbx6aseKcfb/dkaTo4/eoMzP4XzTVdnk0AqcCkw==",
-      "requires": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@stablelib/nacl": "^1.0.3",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "elliptic": "^6.5.4",
-        "pbkdf2": "^3.1.2",
-        "typedarray-to-buffer": "^4.0.0"
-      }
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-12.1.1.tgz",
+      "integrity": "sha512-BAig8YyLyRW5kxV/r0S191W+SvYuiTRJpgSp5IsgCDLAOh+d4/xq6IgU3PuGJgokQDstZdTbjpkrgRCnufR8lw==",
+      "peer": true
     },
     "@taquito/taquito": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-14.0.0.tgz",
-      "integrity": "sha512-JaXfvqOCF3dkwXxhe00Ravb8WLMC2VqJxerf4GrGUEpJw+NAkwbGEb8k/52+MQQdlxMPepZdPPru/HM3nFG0Tw==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@taquito/taquito/-/taquito-12.1.1.tgz",
+      "integrity": "sha512-HvbtClQ7isrDd17X/LEKkPzzeVYA8EMUem3qrkl9qvDO6FpJx/QLbUpYfT2PC0pLUkSrzdLGzmESHAOZhcksaw==",
+      "peer": true,
       "requires": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/local-forging": "^14.0.0",
-        "@taquito/michel-codec": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
+        "@taquito/http-utils": "^12.1.1",
+        "@taquito/local-forging": "^12.1.1",
+        "@taquito/michel-codec": "^12.1.1",
+        "@taquito/michelson-encoder": "^12.1.1",
+        "@taquito/rpc": "^12.1.1",
+        "@taquito/utils": "^12.1.1",
         "bignumber.js": "^9.0.2",
         "rxjs": "^6.6.3"
-      }
-    },
-    "@taquito/tzip12": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/tzip12/-/tzip12-14.0.0.tgz",
-      "integrity": "sha512-CEVaSEYwowM0MDz5tiEDeaEyTG202YSNfj18uBUnSuPS02HKC6QVqDYOhuJ2NrhqmJ+iGgD5FAiRar1ihrRD5A==",
-      "requires": {
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/tzip16": "^14.0.0"
-      }
-    },
-    "@taquito/tzip16": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/tzip16/-/tzip16-14.0.0.tgz",
-      "integrity": "sha512-NNmN+Ld14TszXwIq23N2mbtuc/hEyHeE8o61md3qV/J7TEV4d+upo085vIMZwFEMT7UlNXLNAUcZqI1N8YgnVQ==",
-      "requires": {
-        "@taquito/http-utils": "^14.0.0",
-        "@taquito/michelson-encoder": "^14.0.0",
-        "@taquito/rpc": "^14.0.0",
-        "@taquito/taquito": "^14.0.0",
-        "@taquito/utils": "^14.0.0",
-        "bignumber.js": "^9.0.2",
-        "crypto-js": "^4.1.1"
-      }
-    },
-    "@taquito/utils": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz",
-      "integrity": "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA==",
-      "requires": {
-        "@stablelib/blake2b": "^1.0.1",
-        "@stablelib/ed25519": "^1.0.2",
-        "@types/bs58check": "^2.1.0",
-        "bignumber.js": "^9.0.2",
-        "blakejs": "^1.2.1",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "elliptic": "^6.5.4",
-        "typedarray-to-buffer": "^4.0.0"
+      },
+      "dependencies": {
+        "@taquito/http-utils": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-12.1.1.tgz",
+          "integrity": "sha512-Zlp/eTRVjFs0XEIiAhgxkh6s9npF4dO+e/Sm2XWsDmNPoGI2jdXNH0L+NiKJIOkYcu0CXlcgriTeEaYnbeTvcA==",
+          "peer": true,
+          "requires": {
+            "axios": "^0.26.0"
+          }
+        },
+        "@taquito/michelson-encoder": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-12.1.1.tgz",
+          "integrity": "sha512-mWcA1DHHlFj7UswJpEmml853x9e0IYHyeiKZYAo7DtizHz0jiUWtptCuEWiPQ4fMOreFbYZ6KVYenoVfQVNrqA==",
+          "peer": true,
+          "requires": {
+            "@taquito/rpc": "^12.1.1",
+            "@taquito/utils": "^12.1.1",
+            "bignumber.js": "^9.0.2",
+            "fast-json-stable-stringify": "^2.1.0"
+          }
+        },
+        "@taquito/rpc": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@taquito/rpc/-/rpc-12.1.1.tgz",
+          "integrity": "sha512-CgAF9kdmKLa/UbmiqApDtncCQGiG7kEOIYis8IIa0JUT9JD1H8WBbSNF/oNh4e0soWUK9BL2qU369RFnxIW+iA==",
+          "peer": true,
+          "requires": {
+            "@taquito/http-utils": "^12.1.1",
+            "@taquito/utils": "^12.1.1",
+            "bignumber.js": "^9.0.2"
+          }
+        },
+        "@taquito/utils": {
+          "version": "12.1.1",
+          "resolved": "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.1.tgz",
+          "integrity": "sha512-GxNSBrA02vwhy56ayWB49VZficB+j2oyhPdlsRb2CguephmyEYnlUaNV27ILa6dPDW+zv6+QWQj6GyqLBRpIlA==",
+          "peer": true,
+          "requires": {
+            "@stablelib/blake2b": "^1.0.1",
+            "@stablelib/ed25519": "^1.0.2",
+            "@types/bs58check": "^2.1.0",
+            "blakejs": "^1.1.1",
+            "bs58check": "^2.1.2",
+            "buffer": "^6.0.3",
+            "elliptic": "^6.5.4",
+            "typedarray-to-buffer": "^4.0.0"
+          }
+        }
       }
     },
     "@temple-wallet/dapp": {
@@ -30324,17 +29776,9 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/bs58check/-/bs58check-2.1.0.tgz",
       "integrity": "sha512-OxsysnJQh82vy9DRbOcw9m2j/WiyqZLn0YBhKxdQ+aCwoHj+tWzyCgpwAkr79IfDXZKxc6h7k89T9pwS78CqTQ==",
+      "peer": true,
       "requires": {
         "@types/node": "*"
-      }
-    },
-    "@types/chrome": {
-      "version": "0.0.163",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.163.tgz",
-      "integrity": "sha512-g+3E2tg/ukFsEgH+tB3a/b+J1VSvq/8gh2Jwih9eq+T3Idrz7ngj97u+/ya58Bfei2TQtPlRivj1FsCaSnukDA==",
-      "requires": {
-        "@types/filesystem": "*",
-        "@types/har-format": "*"
       }
     },
     "@types/connect": {
@@ -30397,24 +29841,6 @@
         "@types/qs": "*",
         "@types/range-parser": "*"
       }
-    },
-    "@types/filesystem": {
-      "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/filesystem/-/filesystem-0.0.32.tgz",
-      "integrity": "sha512-Yuf4jR5YYMR2DVgwuCiP11s0xuVRyPKmz8vo6HBY3CGdeMj8af93CFZX+T82+VD1+UqHOxTq31lO7MI7lepBtQ==",
-      "requires": {
-        "@types/filewriter": "*"
-      }
-    },
-    "@types/filewriter": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/filewriter/-/filewriter-0.0.29.tgz",
-      "integrity": "sha512-BsPXH/irW0ht0Ji6iw/jJaK8Lj3FJemon2gvEqHKpCdDCeemHa+rI3WBGq5z7cDMZgoLjY40oninGxqk+8NzNQ=="
-    },
-    "@types/har-format": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.9.tgz",
-      "integrity": "sha512-rffW6MhQ9yoa75bdNi+rjZBAvu2HhehWJXlhuWXnWdENeuKe82wUgAwxYOb7KRKKmxYN+D/iRKd2NDQMLqlUmg=="
     },
     "@types/hast": {
       "version": "2.3.4",
@@ -31369,6 +30795,7 @@
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
       "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "peer": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -31393,7 +30820,8 @@
     "bignumber.js": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
-      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
+      "peer": true
     },
     "bin-links": {
       "version": "3.0.1",
@@ -31445,28 +30873,11 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bip39": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.0.4.tgz",
-      "integrity": "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw==",
-      "requires": {
-        "@types/node": "11.11.6",
-        "create-hash": "^1.1.0",
-        "pbkdf2": "^3.0.9",
-        "randombytes": "^2.0.1"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "11.11.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.6.tgz",
-          "integrity": "sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ=="
-        }
-      }
-    },
     "blakejs": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "peer": true
     },
     "bluebird": {
       "version": "3.7.2",
@@ -31477,7 +30888,8 @@
     "bn.js": {
       "version": "4.12.0",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+      "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+      "peer": true
     },
     "body-parser": {
       "version": "1.20.0",
@@ -31599,7 +31011,8 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
+      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "peer": true
     },
     "browserify-aes": {
       "version": "1.2.0",
@@ -31711,6 +31124,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "peer": true,
       "requires": {
         "base-x": "^3.0.2"
       }
@@ -31719,6 +31133,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
+      "peer": true,
       "requires": {
         "bs58": "^4.0.0",
         "create-hash": "^1.1.0",
@@ -32058,6 +31473,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -32781,6 +32197,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "peer": true,
       "requires": {
         "cipher-base": "^1.0.1",
         "inherits": "^2.0.1",
@@ -32793,6 +32210,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "peer": true,
       "requires": {
         "cipher-base": "^1.0.3",
         "create-hash": "^1.1.0",
@@ -32834,11 +32252,6 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
-    },
-    "crypto-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
-      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "crypto-random-string": {
       "version": "2.0.0"
@@ -34037,6 +33450,7 @@
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
       "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+      "peer": true,
       "requires": {
         "bn.js": "^4.11.9",
         "brorand": "^1.1.0",
@@ -35350,6 +34764,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.4",
         "readable-stream": "^3.6.0",
@@ -35359,7 +34774,8 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "peer": true
         }
       }
     },
@@ -35367,6 +34783,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.3",
         "minimalistic-assert": "^1.0.1"
@@ -35458,6 +34875,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
+      "peer": true,
       "requires": {
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
@@ -36508,19 +35926,6 @@
         }
       }
     },
-    "libsodium": {
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/libsodium/-/libsodium-0.7.10.tgz",
-      "integrity": "sha512-eY+z7hDrDKxkAK+QKZVNv92A5KYkxfvIshtBJkmg5TSiCnYqZP3i9OO9whE79Pwgm4jGaoHgkM4ao/b9Cyu4zQ=="
-    },
-    "libsodium-wrappers": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/libsodium-wrappers/-/libsodium-wrappers-0.7.9.tgz",
-      "integrity": "sha512-9HaAeBGk1nKTRFRHkt7nzxqCvnkWTjn1pdjKgcUnZxj0FyOP4CnhgFhMdrFfgNsukijBGyBLpP2m2uKT1vuWhQ==",
-      "requires": {
-        "libsodium": "^0.7.0"
-      }
-    },
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -36778,6 +36183,7 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "peer": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
@@ -37092,7 +36498,8 @@
     "minimalistic-crypto-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg=="
+      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
+      "peer": true
     },
     "minimatch": {
       "version": "3.1.2",
@@ -38612,6 +38019,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
       "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+      "peer": true,
       "requires": {
         "create-hash": "^1.1.2",
         "create-hmac": "^1.1.4",
@@ -39239,11 +38647,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
-    },
-    "qrcode-generator": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/qrcode-generator/-/qrcode-generator-1.4.4.tgz",
-      "integrity": "sha512-HM7yY8O2ilqhmULxGMpcHSF1EhJJ9yBj8gvDEuZ6M+KGJ0YY2hKpnXvRD+hZPLrDVck3ExIGhmPtSdcjC+guuw=="
     },
     "qs": {
       "version": "6.10.3",
@@ -40377,6 +39780,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+      "peer": true,
       "requires": {
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
@@ -40811,6 +40215,7 @@
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+      "peer": true,
       "requires": {
         "inherits": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -42003,7 +41408,8 @@
     "typedarray-to-buffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ=="
+      "integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
+      "peer": true
     },
     "typescript": {
       "version": "4.5.2"

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3241,11 +3241,11 @@
     "@stablelib/wipe" "^1.0.1"
 
 "@stablelib/ed25519@^1.0.2":
-  "integrity" "sha512-FtnvUwvKbp6l1dNcg4CswMAVFVu/nzLK3oC7/PRtjYyHbWsIkD8j+5cjXHmwcCpdCpRCaTGACkEhhMQ1RcdSOQ=="
-  "resolved" "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.2.tgz"
-  "version" "1.0.2"
+  "integrity" "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg=="
+  "resolved" "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz"
+  "version" "1.0.3"
   dependencies:
-    "@stablelib/random" "^1.0.1"
+    "@stablelib/random" "^1.0.2"
     "@stablelib/sha512" "^1.0.1"
     "@stablelib/wipe" "^1.0.1"
 
@@ -3259,7 +3259,7 @@
   "resolved" "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz"
   "version" "1.0.1"
 
-"@stablelib/random@^1.0.1":
+"@stablelib/random@^1.0.2":
   "integrity" "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w=="
   "resolved" "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz"
   "version" "1.0.2"
@@ -3392,69 +3392,68 @@
   dependencies:
     "defer-to-connect" "^1.0.1"
 
-"@taquito/http-utils@^14.0.0":
-  "integrity" "sha512-ZWZzod/+/OEE26b9CnDRjHGfUKBJft3aXv/e/A9bTHAtvRNJqGIhofHcDg/jTaolBMarCF2b3XBYw35aOOSk4A=="
-  "resolved" "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-14.0.0.tgz"
-  "version" "14.0.0"
+"@taquito/http-utils@^12.1.1":
+  "integrity" "sha512-Zlp/eTRVjFs0XEIiAhgxkh6s9npF4dO+e/Sm2XWsDmNPoGI2jdXNH0L+NiKJIOkYcu0CXlcgriTeEaYnbeTvcA=="
+  "resolved" "https://registry.npmjs.org/@taquito/http-utils/-/http-utils-12.1.1.tgz"
+  "version" "12.1.1"
   dependencies:
     "axios" "^0.26.0"
 
-"@taquito/local-forging@^14.0.0":
-  "integrity" "sha512-Nm0xGmS1Jzd+tU0a/8Y8XuTghbiPBgHDLo+e4141TK3OAwTzOw0an+w3xK9QVfzvxfIcZBSMjeMZzOwDdiqkJQ=="
-  "resolved" "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-14.0.0.tgz"
-  "version" "14.0.0"
+"@taquito/local-forging@^12.1.1":
+  "integrity" "sha512-SUA1YYRIpEGsTy5OfUIgIem0k/QsAzGjDCvf/wl5XV/fVBkP/+GN7uvYoqgJblCmsgtsMBhJFtXgs+D6bjGexg=="
+  "resolved" "https://registry.npmjs.org/@taquito/local-forging/-/local-forging-12.1.1.tgz"
+  "version" "12.1.1"
   dependencies:
-    "@taquito/utils" "^14.0.0"
+    "@taquito/utils" "^12.1.1"
     "bignumber.js" "^9.0.2"
 
-"@taquito/michel-codec@^14.0.0":
-  "integrity" "sha512-ftnBvUVddlHBqvQbGPHEb26KrS4lIcaZ1eIpYJWiz+akb4Pcfyq7j/OEsDZbB7Pl2FP9hqu7ZygOF34zY6Lrtw=="
-  "resolved" "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-14.0.0.tgz"
-  "version" "14.0.0"
+"@taquito/michel-codec@^12.1.1":
+  "integrity" "sha512-BAig8YyLyRW5kxV/r0S191W+SvYuiTRJpgSp5IsgCDLAOh+d4/xq6IgU3PuGJgokQDstZdTbjpkrgRCnufR8lw=="
+  "resolved" "https://registry.npmjs.org/@taquito/michel-codec/-/michel-codec-12.1.1.tgz"
+  "version" "12.1.1"
 
-"@taquito/michelson-encoder@^14.0.0":
-  "integrity" "sha512-KIS+xl4rKfnd6hf9LUr6W+Pb7gv8F/Qsx0fho9CtM2PodKvdef3YlvkpScBUM9QZntAlvq2XQXUVXcZkbvxygw=="
-  "resolved" "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-14.0.0.tgz"
-  "version" "14.0.0"
+"@taquito/michelson-encoder@^12.1.1":
+  "integrity" "sha512-mWcA1DHHlFj7UswJpEmml853x9e0IYHyeiKZYAo7DtizHz0jiUWtptCuEWiPQ4fMOreFbYZ6KVYenoVfQVNrqA=="
+  "resolved" "https://registry.npmjs.org/@taquito/michelson-encoder/-/michelson-encoder-12.1.1.tgz"
+  "version" "12.1.1"
   dependencies:
-    "@taquito/rpc" "^14.0.0"
-    "@taquito/utils" "^14.0.0"
+    "@taquito/rpc" "^12.1.1"
+    "@taquito/utils" "^12.1.1"
     "bignumber.js" "^9.0.2"
     "fast-json-stable-stringify" "^2.1.0"
 
-"@taquito/rpc@^14.0.0":
-  "integrity" "sha512-FMfb80sA+VJwNx8OTNN07boDAt2roISqLLCUgmOIwy/cFDqhII7gdS4aYWJWqlKbdPKCPqh3a3ZQD1X/jyQHOA=="
-  "resolved" "https://registry.npmjs.org/@taquito/rpc/-/rpc-14.0.0.tgz"
-  "version" "14.0.0"
+"@taquito/rpc@^12.1.1":
+  "integrity" "sha512-CgAF9kdmKLa/UbmiqApDtncCQGiG7kEOIYis8IIa0JUT9JD1H8WBbSNF/oNh4e0soWUK9BL2qU369RFnxIW+iA=="
+  "resolved" "https://registry.npmjs.org/@taquito/rpc/-/rpc-12.1.1.tgz"
+  "version" "12.1.1"
   dependencies:
-    "@taquito/http-utils" "^14.0.0"
-    "@taquito/utils" "^14.0.0"
+    "@taquito/http-utils" "^12.1.1"
+    "@taquito/utils" "^12.1.1"
     "bignumber.js" "^9.0.2"
 
 "@taquito/taquito@^12.0.0":
-  "integrity" "sha512-JaXfvqOCF3dkwXxhe00Ravb8WLMC2VqJxerf4GrGUEpJw+NAkwbGEb8k/52+MQQdlxMPepZdPPru/HM3nFG0Tw=="
-  "resolved" "https://registry.npmjs.org/@taquito/taquito/-/taquito-14.0.0.tgz"
-  "version" "14.0.0"
+  "integrity" "sha512-HvbtClQ7isrDd17X/LEKkPzzeVYA8EMUem3qrkl9qvDO6FpJx/QLbUpYfT2PC0pLUkSrzdLGzmESHAOZhcksaw=="
+  "resolved" "https://registry.npmjs.org/@taquito/taquito/-/taquito-12.1.1.tgz"
+  "version" "12.1.1"
   dependencies:
-    "@taquito/http-utils" "^14.0.0"
-    "@taquito/local-forging" "^14.0.0"
-    "@taquito/michel-codec" "^14.0.0"
-    "@taquito/michelson-encoder" "^14.0.0"
-    "@taquito/rpc" "^14.0.0"
-    "@taquito/utils" "^14.0.0"
+    "@taquito/http-utils" "^12.1.1"
+    "@taquito/local-forging" "^12.1.1"
+    "@taquito/michel-codec" "^12.1.1"
+    "@taquito/michelson-encoder" "^12.1.1"
+    "@taquito/rpc" "^12.1.1"
+    "@taquito/utils" "^12.1.1"
     "bignumber.js" "^9.0.2"
     "rxjs" "^6.6.3"
 
-"@taquito/utils@^14.0.0":
-  "integrity" "sha512-0RSHn/CzbcbMdldJJIlXyxOvAajwmL6iPKJ6NaRyYJqqLM2CxYjG72KpXVv716pCMV1MbIWsOAr9FKbxW73PsA=="
-  "resolved" "https://registry.npmjs.org/@taquito/utils/-/utils-14.0.0.tgz"
-  "version" "14.0.0"
+"@taquito/utils@^12.1.1":
+  "integrity" "sha512-GxNSBrA02vwhy56ayWB49VZficB+j2oyhPdlsRb2CguephmyEYnlUaNV27ILa6dPDW+zv6+QWQj6GyqLBRpIlA=="
+  "resolved" "https://registry.npmjs.org/@taquito/utils/-/utils-12.1.1.tgz"
+  "version" "12.1.1"
   dependencies:
     "@stablelib/blake2b" "^1.0.1"
     "@stablelib/ed25519" "^1.0.2"
     "@types/bs58check" "^2.1.0"
-    "bignumber.js" "^9.0.2"
-    "blakejs" "^1.2.1"
+    "blakejs" "^1.1.1"
     "bs58check" "^2.1.2"
     "buffer" "^6.0.3"
     "elliptic" "^6.5.4"
@@ -4546,7 +4545,7 @@
 "binary-extensions@^2.0.0":
   "version" "2.2.0"
 
-"blakejs@^1.2.1":
+"blakejs@^1.1.1":
   "integrity" "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
   "resolved" "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz"
   "version" "1.2.1"
@@ -5102,8 +5101,10 @@
     "isobject" "^3.0.0"
     "static-extend" "^0.1.1"
 
-"classnames@^2.2.5", "classnames@^2.3.1":
-  "version" "2.3.1"
+"classnames@^2.2.5", "classnames@^2.3.2":
+  "integrity" "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
+  "resolved" "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz"
+  "version" "2.3.2"
 
 "clean-css@^5.2.2", "clean-css@^5.3.0":
   "version" "5.3.0"
@@ -6445,11 +6446,6 @@
     "loader-utils" "^2.0.0"
     "schema-utils" "^3.0.0"
 
-"file-uri-to-path@1.0.0":
-  "integrity" "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-  "resolved" "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
-  "version" "1.0.0"
-
 "filesize@^8.0.6":
   "version" "8.0.7"
 
@@ -6668,17 +6664,6 @@
 
 "fs.realpath@^1.0.0":
   "version" "1.0.0"
-
-"fsevents@^1.2.7":
-  "integrity" "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
-  "version" "1.2.13"
-  dependencies:
-    "bindings" "^1.5.0"
-    "nan" "^2.12.1"
-
-"fsevents@~2.3.2":
-  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "version" "1.1.1"
@@ -8840,11 +8825,6 @@
   "integrity" "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
   "resolved" "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   "version" "0.0.8"
-
-"nan@^2.12.1":
-  "integrity" "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
-  "resolved" "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
-  "version" "2.16.0"
 
 "nanoid@^3.1.30", "nanoid@^3.3.4":
   "integrity" "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw=="
@@ -11216,10 +11196,10 @@
     "klona" "^2.0.4"
     "neo-async" "^2.6.2"
 
-"sass@^1.3.0", "sass@^1.30.0", "sass@^1.54.8":
-  "integrity" "sha512-ib4JhLRRgbg6QVy6bsv5uJxnJMTS2soVcCp9Y88Extyy13A8vV0G1fAwujOzmNkFQbR3LvedudAMbtuNRPbQww=="
-  "resolved" "https://registry.npmjs.org/sass/-/sass-1.54.8.tgz"
-  "version" "1.54.8"
+"sass@^1.3.0", "sass@^1.30.0", "sass@^1.54.9":
+  "integrity" "sha512-xb1hjASzEH+0L0WI9oFjqhRi51t/gagWnxLiwUNMltA0Ab6jIDkAacgKiGYKM9Jhy109osM7woEEai6SXeJo5Q=="
+  "resolved" "https://registry.npmjs.org/sass/-/sass-1.54.9.tgz"
+  "version" "1.54.9"
   dependencies:
     "chokidar" ">=3.0.0 <4.0.0"
     "immutable" "^4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,73 +2,74 @@
 # yarn lockfile v1
 
 
-"@airgap/beacon-core@^3.1.4":
-  "integrity" "sha512-GpSFjQL+larOigCRKtdEE4Dhl3cWOl0GP3tjVI6WSCExEAVKGE8EW37NDIgRDJwANFPAHt427wVcrk6slXqmbQ=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-core@^3.2.0":
+  "integrity" "sha512-gdyEPzjegPPgAQHXrYtpnqV075p+3YBVNijtUNxrSEsLSPHO6EahIlr067bKzHUkz7S325838nPH7WKWP5BxuQ=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-core/-/beacon-core-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
-    "@airgap/beacon-types" "^3.1.4"
-    "@airgap/beacon-utils" "^3.1.4"
-    "@types/libsodium-wrappers" "0.7.9"
+    "@airgap/beacon-types" "^3.2.0"
+    "@airgap/beacon-utils" "^3.2.0"
+    "@stablelib/ed25519" "^1.0.3"
+    "@stablelib/nacl" "^1.0.4"
+    "@stablelib/utf8" "^1.0.1"
+    "@stablelib/x25519-session" "^1.0.4"
     "bs58check" "2.1.2"
-    "libsodium-wrappers" "0.7.9"
 
-"@airgap/beacon-dapp@^3.1.4":
-  "integrity" "sha512-/7OXrejWlI92pvZXOPqs6eLtC9XBXga0CIz60Uieif43kjRpwhiwm7qVOyjmDi9rRx19ZMP92YWJQX+nuovzbg=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-dapp@^3.2.0":
+  "integrity" "sha512-AqxjalyBdBteHFMmIo+wfweZKbGq10zl/700GtMLthcIRBMJlNQtvLyVxus8e2d8vGSuMHFzUxRbaROD3xv8eA=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-dapp/-/beacon-dapp-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
-    "@airgap/beacon-core" "^3.1.4"
-    "@airgap/beacon-transport-matrix" "^3.1.4"
-    "@airgap/beacon-transport-postmessage" "^3.1.4"
-    "@airgap/beacon-ui" "^3.1.4"
+    "@airgap/beacon-core" "^3.2.0"
+    "@airgap/beacon-transport-matrix" "^3.2.0"
+    "@airgap/beacon-transport-postmessage" "^3.2.0"
+    "@airgap/beacon-ui" "^3.2.0"
     "qrcode-generator" "1.4.4"
 
-"@airgap/beacon-transport-matrix@^3.1.4":
-  "integrity" "sha512-IvZnylEqjXyB9JWvpgnSRMom9C5thK5JB88joL2/q24JI73MXTzBh50/GVNfwAat6Ct+ftbn36j17Kh5O/y4wg=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-transport-matrix@^3.2.0":
+  "integrity" "sha512-YROvZKlLDcUtuyozi8wNadVtrqHTXNy0wsQofgDDILYTAotT60AsdhwjS0nGkhe8K3KEtJEnFeJ4pOlL6iyFSg=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-transport-matrix/-/beacon-transport-matrix-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
-    "@airgap/beacon-core" "^3.1.4"
-    "@airgap/beacon-utils" "^3.1.4"
+    "@airgap/beacon-core" "^3.2.0"
+    "@airgap/beacon-utils" "^3.2.0"
     "axios" "0.24.0"
 
-"@airgap/beacon-transport-postmessage@^3.1.4":
-  "integrity" "sha512-uEPtTZ7n5C03rNzpjgx1T1bS74DfVs39WEBHACKPhbX0RM5DGDveU/+T/iCJLpF3HTp3v65oomLIRXcL24JY/g=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-transport-postmessage@^3.2.0":
+  "integrity" "sha512-X6c+g+I6HXFtwyWslQVSareBwzmKYxUH39xyncEKhOXqKY0b0W2byW4iKJBZitxarPEfBQn6bEXcEsD/MOXGYA=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-transport-postmessage/-/beacon-transport-postmessage-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
-    "@airgap/beacon-core" "^3.1.4"
-    "@airgap/beacon-types" "^3.1.4"
-    "@airgap/beacon-utils" "^3.1.4"
-    "@types/libsodium-wrappers" "0.7.9"
-    "libsodium-wrappers" "0.7.9"
+    "@airgap/beacon-core" "^3.2.0"
+    "@airgap/beacon-types" "^3.2.0"
+    "@airgap/beacon-utils" "^3.2.0"
 
-"@airgap/beacon-types@^3.1.4":
-  "integrity" "sha512-x3HM0YKe4gA31lqopAOpP2YF5hfAiu2TQ0Pv/8pPLM/VHLJoJd19XF3WZyIL958tkLOmvNb3IUan1XPT1ENsqA=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-types@^3.2.0":
+  "integrity" "sha512-qM+FmtIOrwZ5Fj5eIkE7Y8o7Va5fsBeYPzeTfzPF4ulJZQ5wTiNEK2HVUAzui+bMej9tPtcF9I6kF6wrOtK27A=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-types/-/beacon-types-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
     "@types/chrome" "0.0.163"
 
-"@airgap/beacon-ui@^3.1.4":
-  "integrity" "sha512-g/iiF53wfNAQ62htF2fbING6bwHiE1s/q0LJlxfUQx/OINmp9Gt1HrIdp92Af0QBi9db0hda6PlN4T4j4OKjaQ=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-ui@^3.2.0":
+  "integrity" "sha512-UFi4bxXwGVSt/uUvod+dAAgnX1IuUUtqjI+1BFDuAJ1H8dkkcWYstiDqssPsVkMTeGBbE5ExyCV0QaKFKjnKEg=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-ui/-/beacon-ui-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
-    "@airgap/beacon-core" "^3.1.4"
-    "@airgap/beacon-transport-postmessage" "^3.1.4"
-    "@airgap/beacon-types" "^3.1.4"
-    "@airgap/beacon-utils" "^3.1.4"
+    "@airgap/beacon-core" "^3.2.0"
+    "@airgap/beacon-transport-postmessage" "^3.2.0"
+    "@airgap/beacon-types" "^3.2.0"
+    "@airgap/beacon-utils" "^3.2.0"
 
-"@airgap/beacon-utils@^3.1.4":
-  "integrity" "sha512-hDDRgG7pU4h8hOLlgScBetjFTPHH3gTWEeKiFkVq/3LzqIe1c84JBaCDqMNpnxd9jenFo+/Q0jRj1zhvW6Bg6w=="
-  "resolved" "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.1.4.tgz"
-  "version" "3.1.4"
+"@airgap/beacon-utils@^3.2.0":
+  "integrity" "sha512-0oqAjyJ78up/Tz6JxKHleqjScG7FjLOxGEKz46CE8h05vsdSw1fRtzyzhoVzTNaxFtHbTX6kgGBbowhW49uemw=="
+  "resolved" "https://registry.npmjs.org/@airgap/beacon-utils/-/beacon-utils-3.2.0.tgz"
+  "version" "3.2.0"
   dependencies:
-    "@types/libsodium-wrappers" "0.7.9"
+    "@stablelib/nacl" "^1.0.3"
+    "@stablelib/random" "^1.0.2"
+    "@stablelib/utf8" "^1.0.1"
     "bs58check" "2.1.2"
-    "libsodium-wrappers" "0.7.9"
 
 "@airgap/sapling-wasm@0.0.9":
   "integrity" "sha512-rJjV7JIDxoardnZMgk4Uor5Z6OVsAE4I5uDlkGAb0tQ5NN0gmz9Bu2LKMPSCv7UqDpZowDX4BbMDuSqdO/IsbQ=="
@@ -828,28 +829,28 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@ledgerhq/devices@^7.0.0":
-  "integrity" "sha512-vq4B33WdU0dRAJIRFWZMj6w1W1yw1i4mekCmhk7N9wPaFrtGWZ2iI9WDihsNOBooCWKQe8Jsb9eD8RVThbSlFQ=="
-  "resolved" "https://registry.npmjs.org/@ledgerhq/devices/-/devices-7.0.0.tgz"
-  "version" "7.0.0"
+"@ledgerhq/devices@^7.0.1":
+  "integrity" "sha512-LlAyDU5+GH0w+J1wscLU+Ga4z5a5ACKmMGQKILj5XscCtp63NjbtVdVt4oc/xrmoUdRqVehIw2Ui+e9nIF52yA=="
+  "resolved" "https://registry.npmjs.org/@ledgerhq/devices/-/devices-7.0.1.tgz"
+  "version" "7.0.1"
   dependencies:
-    "@ledgerhq/errors" "^6.10.1"
+    "@ledgerhq/errors" "^6.10.2"
     "@ledgerhq/logs" "^6.10.0"
     "rxjs" "6"
     "semver" "^7.3.5"
 
-"@ledgerhq/errors@^6.10.1":
-  "integrity" "sha512-92d1zRQleR1AQ4CAXgWgDtKUms+8EwShLVUcajI+BLWvgJ1Vclmq6PsBIDEQbsm+riVu/Ji3LcHdmgFgmi0VGw=="
-  "resolved" "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.1.tgz"
-  "version" "6.10.1"
+"@ledgerhq/errors@^6.10.2":
+  "integrity" "sha512-iMfEJPWaan8QaZw87WMUnFFRJqveE3FpU2ObTE0ydTJLPJNOUJjjurGBklqdWM/j5BIQvpi3byGKFChfNg8CaQ=="
+  "resolved" "https://registry.npmjs.org/@ledgerhq/errors/-/errors-6.10.2.tgz"
+  "version" "6.10.2"
 
-"@ledgerhq/hw-transport@^6.20.0":
-  "integrity" "sha512-GF4pmK78rEKhZfbmunwQ131c+0MGa6L5IoYlwgFcg6CaFpUjjPiTCKUFsm4flsE0Z0Ltn9QuKoe+xEHULo7rGA=="
-  "resolved" "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.27.2.tgz"
-  "version" "6.27.2"
+"@ledgerhq/hw-transport@^6.27.3":
+  "integrity" "sha512-i3RYKfSIZ7PHM2sFljAU443qOYMTlghx8l5AZqsNKsXbawHkuOr7EtISW3zqbC0Wh3uws7u63qQ/50TLmylr7g=="
+  "resolved" "https://registry.npmjs.org/@ledgerhq/hw-transport/-/hw-transport-6.27.4.tgz"
+  "version" "6.27.4"
   dependencies:
-    "@ledgerhq/devices" "^7.0.0"
-    "@ledgerhq/errors" "^6.10.1"
+    "@ledgerhq/devices" "^7.0.1"
+    "@ledgerhq/errors" "^6.10.2"
     "events" "^3.3.0"
 
 "@ledgerhq/logs@^6.10.0":
@@ -1903,7 +1904,7 @@
   "resolved" "https://registry.npmjs.org/@stablelib/constant-time/-/constant-time-1.0.1.tgz"
   "version" "1.0.1"
 
-"@stablelib/ed25519@^1.0.2":
+"@stablelib/ed25519@^1.0.3":
   "integrity" "sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg=="
   "resolved" "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-1.0.3.tgz"
   "version" "1.0.3"
@@ -1929,7 +1930,7 @@
   dependencies:
     "@stablelib/bytes" "^1.0.1"
 
-"@stablelib/nacl@^1.0.3":
+"@stablelib/nacl@^1.0.3", "@stablelib/nacl@^1.0.4":
   "integrity" "sha512-PJ2U/MrkXSKUM8C4qFs87WeCNxri7KQwR8Cdwm9q2sweGuAtTvOJGuW0F3N+zn+ySLPJA98SYWSSpogMJ1gCmw=="
   "resolved" "https://registry.npmjs.org/@stablelib/nacl/-/nacl-1.0.4.tgz"
   "version" "1.0.4"
@@ -1974,10 +1975,26 @@
     "@stablelib/hash" "^1.0.1"
     "@stablelib/wipe" "^1.0.1"
 
+"@stablelib/utf8@^1.0.1":
+  "integrity" "sha512-FrYD1xadah/TtAP6VJ04lDD5h9rdDj/d8wH/jMYTtHqZBv9z2btdvEU8vTxdjdkFmo1b/BH+t3R1wi/mYhCCNg=="
+  "resolved" "https://registry.npmjs.org/@stablelib/utf8/-/utf8-1.0.1.tgz"
+  "version" "1.0.1"
+
 "@stablelib/wipe@^1.0.1":
   "integrity" "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
   "resolved" "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz"
   "version" "1.0.1"
+
+"@stablelib/x25519-session@^1.0.4":
+  "integrity" "sha512-UZw67EJWSNTaou7Qp086fzGek7crrCQl2K7MoqEzslXxrm6vybySfcdsqaZ0ZpKq19IHWK8G0wAlFBy70srm3w=="
+  "resolved" "https://registry.npmjs.org/@stablelib/x25519-session/-/x25519-session-1.0.4.tgz"
+  "version" "1.0.4"
+  dependencies:
+    "@stablelib/blake2b" "^1.0.1"
+    "@stablelib/keyagreement" "^1.0.1"
+    "@stablelib/random" "^1.0.2"
+    "@stablelib/wipe" "^1.0.1"
+    "@stablelib/x25519" "^1.0.3"
 
 "@stablelib/x25519@^1.0.3":
   "integrity" "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw=="
@@ -1997,161 +2014,143 @@
     "@stablelib/salsa20" "^1.0.2"
     "@stablelib/wipe" "^1.0.1"
 
-"@taquito/beacon-wallet@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-beacon-wallet":
+"@taquito/beacon-wallet@file:/home/mike/taquito/packages/taquito-beacon-wallet":
   "resolved" "file:packages/taquito-beacon-wallet"
   "version" "14.0.0"
   dependencies:
-    "@airgap/beacon-dapp" "^3.1.4"
+    "@airgap/beacon-dapp" "^3.2.0"
     "@taquito/taquito" "^14.0.0"
     "libsodium-wrappers" "0.7.9"
 
-"@taquito/contracts-library@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-contracts-library":
+"@taquito/contracts-library@file:/home/mike/taquito/packages/taquito-contracts-library":
   "resolved" "file:packages/taquito-contracts-library"
   "version" "14.0.0"
   dependencies:
     "@taquito/rpc" "^14.0.0"
     "@taquito/taquito" "^14.0.0"
     "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
 
-"@taquito/http-utils@^14.0.0", "@taquito/http-utils@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-http-utils":
+"@taquito/http-utils@^14.0.0", "@taquito/http-utils@file:/home/mike/taquito/packages/taquito-http-utils":
   "resolved" "file:packages/taquito-http-utils"
   "version" "14.0.0"
   dependencies:
     "axios" "^0.26.0"
 
-"@taquito/ledger-signer@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-ledger-signer":
+"@taquito/ledger-signer@file:/home/mike/taquito/packages/taquito-ledger-signer":
   "resolved" "file:packages/taquito-ledger-signer"
   "version" "14.0.0"
   dependencies:
-    "@ledgerhq/hw-transport" "^6.20.0"
+    "@ledgerhq/hw-transport" "^6.27.3"
     "@stablelib/blake2b" "^1.0.1"
     "@taquito/taquito" "^14.0.0"
     "@taquito/utils" "^14.0.0"
     "buffer" "^6.0.3"
 
-"@taquito/local-forging@^14.0.0", "@taquito/local-forging@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-local-forging":
+"@taquito/local-forging@^14.0.0", "@taquito/local-forging@file:/home/mike/taquito/packages/taquito-local-forging":
   "resolved" "file:packages/taquito-local-forging"
   "version" "14.0.0"
   dependencies:
     "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
 
-"@taquito/michel-codec@^14.0.0", "@taquito/michel-codec@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-michel-codec":
+"@taquito/michel-codec@^14.0.0", "@taquito/michel-codec@file:/home/mike/taquito/packages/taquito-michel-codec":
   "resolved" "file:packages/taquito-michel-codec"
   "version" "14.0.0"
 
-"@taquito/michelson-encoder@^14.0.0", "@taquito/michelson-encoder@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-michelson-encoder":
+"@taquito/michelson-encoder@^14.0.0", "@taquito/michelson-encoder@file:/home/mike/taquito/packages/taquito-michelson-encoder":
   "resolved" "file:packages/taquito-michelson-encoder"
   "version" "14.0.0"
   dependencies:
     "@taquito/rpc" "^14.0.0"
     "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
     "fast-json-stable-stringify" "^2.1.0"
 
-"@taquito/remote-signer@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-remote-signer":
+"@taquito/remote-signer@file:/home/mike/taquito/packages/taquito-remote-signer":
   "resolved" "file:packages/taquito-remote-signer"
   "version" "14.0.0"
   dependencies:
     "@stablelib/blake2b" "^1.0.1"
-    "@stablelib/ed25519" "^1.0.2"
+    "@stablelib/ed25519" "^1.0.3"
     "@taquito/http-utils" "^14.0.0"
     "@taquito/taquito" "^14.0.0"
     "@taquito/utils" "^14.0.0"
     "typedarray-to-buffer" "^4.0.0"
 
-"@taquito/rpc@^14.0.0", "@taquito/rpc@^14.0.0-beta-RC.0", "@taquito/rpc@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-rpc":
+"@taquito/rpc@^14.0.0", "@taquito/rpc@^14.0.0-beta-RC.0", "@taquito/rpc@file:/home/mike/taquito/packages/taquito-rpc":
   "resolved" "file:packages/taquito-rpc"
   "version" "14.0.0"
   dependencies:
     "@taquito/http-utils" "^14.0.0"
     "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
 
-"@taquito/sapling@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-sapling":
+"@taquito/sapling@file:/home/mike/taquito/packages/taquito-sapling":
   "resolved" "file:packages/taquito-sapling"
   "version" "14.0.0"
   dependencies:
     "@airgap/sapling-wasm" "0.0.9"
     "@stablelib/nacl" "^1.0.3"
     "@stablelib/random" "^1.0.1"
-    "@taquito/rpc" "^14.0.0"
-    "@taquito/taquito" "^14.0.0"
-    "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
     "bip39" "^3.0.4"
     "blakejs" "^1.2.1"
     "pbkdf2" "^3.1.2"
     "typedarray-to-buffer" "^4.0.0"
 
-"@taquito/signer@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-signer":
+"@taquito/signer@file:/home/mike/taquito/packages/taquito-signer":
   "resolved" "file:packages/taquito-signer"
   "version" "14.0.0"
   dependencies:
     "@stablelib/blake2b" "^1.0.1"
-    "@stablelib/ed25519" "^1.0.2"
-    "@stablelib/nacl" "^1.0.3"
+    "@stablelib/ed25519" "^1.0.3"
+    "@stablelib/nacl" "^1.0.4"
     "@taquito/taquito" "^14.0.0"
     "@taquito/utils" "^14.0.0"
     "elliptic" "^6.5.4"
     "pbkdf2" "^3.1.2"
     "typedarray-to-buffer" "^4.0.0"
 
-"@taquito/taquito@^14.0.0", "@taquito/taquito@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito":
+"@taquito/taquito@^14.0.0", "@taquito/taquito@file:/home/mike/taquito/packages/taquito":
   "resolved" "file:packages/taquito"
   "version" "14.0.0"
   dependencies:
-    "@taquito/http-utils" "^14.0.0"
-    "@taquito/local-forging" "^14.0.0"
-    "@taquito/michel-codec" "^14.0.0"
-    "@taquito/michelson-encoder" "^14.0.0"
-    "@taquito/rpc" "^14.0.0"
-    "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
     "rxjs" "^6.6.3"
 
-"@taquito/tezbridge-signer@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-tezbridge-signer":
+"@taquito/tezbridge-signer@file:/home/mike/taquito/packages/taquito-tezbridge-signer":
   "resolved" "file:packages/taquito-tezbridge-signer"
   "version" "14.0.0"
   dependencies:
     "@taquito/utils" "^14.0.0"
     "typedarray-to-buffer" "^4.0.0"
 
-"@taquito/tezbridge-wallet@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-tezbridge-wallet":
+"@taquito/tezbridge-wallet@file:/home/mike/taquito/packages/taquito-tezbridge-wallet":
   "resolved" "file:packages/taquito-tezbridge-wallet"
   "version" "14.0.0"
   dependencies:
     "@taquito/taquito" "^14.0.0"
 
-"@taquito/tzip12@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-tzip12":
+"@taquito/tzip12@file:/home/mike/taquito/packages/taquito-tzip12":
   "resolved" "file:packages/taquito-tzip12"
   "version" "14.0.0"
-  dependencies:
-    "@taquito/michelson-encoder" "^14.0.0"
-    "@taquito/taquito" "^14.0.0"
-    "@taquito/tzip16" "^14.0.0"
 
-"@taquito/tzip16@^14.0.0", "@taquito/tzip16@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-tzip16":
+"@taquito/tzip16@^14.0.0", "@taquito/tzip16@file:/home/mike/taquito/packages/taquito-tzip16":
   "resolved" "file:packages/taquito-tzip16"
   "version" "14.0.0"
   dependencies:
-    "@taquito/http-utils" "^14.0.0"
-    "@taquito/michelson-encoder" "^14.0.0"
-    "@taquito/rpc" "^14.0.0"
-    "@taquito/taquito" "^14.0.0"
-    "@taquito/utils" "^14.0.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
     "crypto-js" "^4.1.1"
 
-"@taquito/utils@^14.0.0", "@taquito/utils@file:/Users/dsawali/Desktop/ecadlabs/taquito/packages/taquito-utils":
+"@taquito/utils@^14.0.0", "@taquito/utils@file:/home/mike/taquito/packages/taquito-utils":
   "resolved" "file:packages/taquito-utils"
   "version" "14.0.0"
   dependencies:
     "@stablelib/blake2b" "^1.0.1"
-    "@stablelib/ed25519" "^1.0.2"
+    "@stablelib/ed25519" "^1.0.3"
     "@types/bs58check" "^2.1.0"
-    "bignumber.js" "^9.0.2"
+    "bignumber.js" "^9.1.0"
     "blakejs" "^1.2.1"
     "bs58check" "^2.1.2"
     "buffer" "^6.0.3"
@@ -2861,12 +2860,17 @@
   "resolved" "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   "version" "5.3.2"
 
-"acorn-walk@^7.1.1", "acorn-walk@^8.1.1":
+"acorn-walk@^7.1.1":
   "integrity" "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA=="
   "resolved" "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz"
   "version" "7.2.0"
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", "acorn@^8", "acorn@^8.2.4", "acorn@^8.5.0", "acorn@^8.7.1", "acorn@^8.8.0":
+"acorn-walk@^8.1.1":
+  "integrity" "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+  "resolved" "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
+  "version" "8.2.0"
+
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", "acorn@^8", "acorn@^8.2.4", "acorn@^8.4.1", "acorn@^8.5.0", "acorn@^8.7.1", "acorn@^8.8.0":
   "integrity" "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
   "resolved" "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz"
   "version" "8.8.0"
@@ -2880,11 +2884,6 @@
   "integrity" "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
   "resolved" "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz"
   "version" "7.4.1"
-
-"acorn@^8.4.1":
-  "integrity" "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-  "resolved" "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz"
-  "version" "6.4.2"
 
 "add-stream@^1.0.0":
   "integrity" "sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ=="
@@ -3333,7 +3332,7 @@
   "resolved" "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
   "version" "5.2.2"
 
-"bignumber.js@^9.0.2":
+"bignumber.js@^9.1.0":
   "integrity" "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
   "resolved" "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz"
   "version" "9.1.0"
@@ -3359,13 +3358,6 @@
   "integrity" "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
   "resolved" "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz"
   "version" "2.2.0"
-
-"bindings@^1.5.0":
-  "integrity" "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="
-  "resolved" "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz"
-  "version" "1.5.0"
-  dependencies:
-    "file-uri-to-path" "1.0.0"
 
 "bip39@^3.0.4":
   "integrity" "sha512-YZKQlb752TrUWqHWj7XAwCSjYEgGAk+/Aas3V7NyjQeZYsztO8JnQUaCWhcnL4T+jL8nvB8typ2jRPzTlgugNw=="
@@ -4614,7 +4606,12 @@
   "resolved" "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz"
   "version" "1.0.0"
 
-"detect-indent@^5.0.0", "detect-indent@^6.0.0", "detect-indent@6.0.0":
+"detect-indent@^5.0.0":
+  "integrity" "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g=="
+  "resolved" "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz"
+  "version" "5.0.0"
+
+"detect-indent@^6.0.0", "detect-indent@6.0.0":
   "integrity" "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA=="
   "resolved" "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz"
   "version" "6.0.0"
@@ -5299,11 +5296,6 @@
   dependencies:
     "flat-cache" "^3.0.4"
 
-"file-uri-to-path@1.0.0":
-  "integrity" "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-  "resolved" "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz"
-  "version" "1.0.0"
-
 "filename-reserved-regex@^2.0.0":
   "integrity" "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ=="
   "resolved" "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz"
@@ -5570,19 +5562,6 @@
   "integrity" "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
-
-"fsevents@^1.2.7":
-  "integrity" "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz"
-  "version" "1.2.13"
-  dependencies:
-    "bindings" "^1.5.0"
-    "nan" "^2.12.1"
-
-"fsevents@^2.1.2", "fsevents@~2.3.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
@@ -6456,7 +6435,7 @@
   "resolved" "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz"
   "version" "2.0.0"
 
-"is-plain-obj@^1.1.0":
+"is-plain-obj@^1.0.0", "is-plain-obj@^1.1.0":
   "integrity" "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
   "resolved" "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
   "version" "1.1.0"
@@ -7570,7 +7549,15 @@
     "pify" "^4.0.1"
     "semver" "^5.6.0"
 
-"make-dir@^2.1.0", "make-dir@^3.0.0", "make-dir@^3.0.2":
+"make-dir@^2.1.0":
+  "integrity" "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA=="
+  "resolved" "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz"
+  "version" "2.1.0"
+  dependencies:
+    "pify" "^4.0.1"
+    "semver" "^5.6.0"
+
+"make-dir@^3.0.0", "make-dir@^3.0.2":
   "integrity" "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="
   "resolved" "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz"
   "version" "3.1.0"
@@ -7973,11 +7960,6 @@
   "integrity" "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
   "resolved" "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz"
   "version" "0.0.8"
-
-"nan@^2.12.1":
-  "integrity" "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
-  "resolved" "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz"
-  "version" "2.16.0"
 
 "nanomatch@^1.2.9":
   "integrity" "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA=="
@@ -8837,7 +8819,12 @@
   "resolved" "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
   "version" "3.0.0"
 
-"pify@^4.0.1", "pify@^5.0.0":
+"pify@^4.0.1":
+  "integrity" "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+  "resolved" "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz"
+  "version" "4.0.1"
+
+"pify@^5.0.0":
   "integrity" "sha512-eW/gHNMlxdSP6dmG6uJip6FXN0EQBwm2clYYd8Wul42Cwu/DK8HEftzsapcNdYe2MfLiIwZqsDk2RDEsTE79hA=="
   "resolved" "https://registry.npmjs.org/pify/-/pify-5.0.0.tgz"
   "version" "5.0.0"
@@ -9900,7 +9887,14 @@
     "ip" "^2.0.0"
     "smart-buffer" "^4.2.0"
 
-"sort-keys@^2.0.0", "sort-keys@^4.0.0":
+"sort-keys@^2.0.0":
+  "integrity" "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg=="
+  "resolved" "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz"
+  "version" "2.0.0"
+  dependencies:
+    "is-plain-obj" "^1.0.0"
+
+"sort-keys@^4.0.0":
   "integrity" "sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg=="
   "resolved" "https://registry.npmjs.org/sort-keys/-/sort-keys-4.2.0.tgz"
   "version" "4.2.0"
@@ -10761,9 +10755,9 @@
   "version" "4.1.6"
 
 "typescript@^4.6.4", "typescript@>=3":
-  "integrity" "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ=="
-  "resolved" "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz"
-  "version" "4.7.4"
+  "integrity" "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw=="
+  "resolved" "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz"
+  "version" "4.8.2"
 
 "uglify-js@^3.1.4":
   "integrity" "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw=="
@@ -11282,7 +11276,16 @@
   "resolved" "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   "version" "1.0.2"
 
-"write-file-atomic@^2.4.2", "write-file-atomic@^3.0.0":
+"write-file-atomic@^2.4.2":
+  "integrity" "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ=="
+  "resolved" "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz"
+  "version" "2.4.3"
+  dependencies:
+    "graceful-fs" "^4.1.11"
+    "imurmurhash" "^0.1.4"
+    "signal-exit" "^3.0.2"
+
+"write-file-atomic@^3.0.0":
   "integrity" "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="
   "resolved" "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz"
   "version" "3.0.3"
@@ -11399,10 +11402,15 @@
     "camelcase" "^5.0.0"
     "decamelize" "^1.2.0"
 
-"yargs-parser@^20.2.2", "yargs-parser@^20.2.3", "yargs-parser@^21.0.0", "yargs-parser@20.2.4", "yargs-parser@20.x":
+"yargs-parser@^20.2.2", "yargs-parser@^20.2.3", "yargs-parser@20.2.4", "yargs-parser@20.x":
   "integrity" "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
   "resolved" "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz"
   "version" "20.2.4"
+
+"yargs-parser@^21.0.0":
+  "integrity" "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+  "resolved" "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz"
+  "version" "21.1.1"
 
 "yargs-parser@21.0.1":
   "integrity" "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="


### PR DESCRIPTION
During the confirmation of an operation (step where we poll on the head block until the injected operation is found), Taquito was throwing an error `MissedBlockDuringConfirmationError` when blocks were skipped. 

Made a change to fetch the skipped blocks and verify if the operation is inside those instead of throwing an error. The polling resumes normally after fetching those blocks if the operation is not found. 

re #1783

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
