### PR TITLE
fix(confirmationPollingTimeoutSecond): fix for contract/wallet API

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -10,6 +10,8 @@ import { knownContractPtJakart2, knownBigMapContractPtJakart2, knownTzip12BigMap
 
 const nodeCrypto = require('crypto');
 
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 if (typeof jest !== 'undefined') {
   jest.setTimeout(60000 * 10);
 }

--- a/integration-tests/contract-confirmation-timeout.spec.ts
+++ b/integration-tests/contract-confirmation-timeout.spec.ts
@@ -1,7 +1,5 @@
 import BigNumber from "bignumber.js";
-import { CONFIGS } from "./config";
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { CONFIGS, sleep } from "./config";
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;

--- a/integration-tests/contract-confirmation-timeout.spec.ts
+++ b/integration-tests/contract-confirmation-timeout.spec.ts
@@ -1,0 +1,40 @@
+import BigNumber from "bignumber.js";
+import { CONFIGS } from "./config";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+  let timeBetweenBlocks: BigNumber;
+  describe(`Test confirmationPollingTimeoutSecond with contract API using: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup();
+      timeBetweenBlocks = (await Tezos.rpc.getConstants()).delay_increment_per_round ?? new BigNumber(15);
+      done()
+    })
+
+    it('Verify a timeout error is thrown when an operation is never confirmed', async (done) => {
+      const timeout = Number(timeBetweenBlocks.multipliedBy(2));
+      Tezos.setProvider({ config: { confirmationPollingTimeoutSecond: timeout } })
+      expect(async () => {
+        const op = await Tezos.contract.originate({
+          code: `parameter string;
+          storage string;
+          code {CAR;
+                PUSH string "Hello ";
+                CONCAT;
+                NIL operation; PAIR};
+          `,
+          init: `"test"`,
+          gasLimit: 600000 // gas limit too high, the operation won't be included in a block
+        })
+        await op.confirmation()
+      }).rejects.toThrow('Confirmation polling timed out');
+
+      await sleep(timeout * 2000);
+
+      done();
+    })
+  });
+})

--- a/integration-tests/contract-handling-missed-blocks.spec.ts
+++ b/integration-tests/contract-handling-missed-blocks.spec.ts
@@ -1,19 +1,23 @@
 import { PollingSubscribeProvider } from "@taquito/taquito";
+import BigNumber from "bignumber.js";
 import { CONFIGS } from "./config";
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
-   describe(`Test handling of missed blocks through contract api using: ${rpc}`, () => {
+  let timeBetweenBlocks: BigNumber;
+  describe(`Test handling of missed blocks through contract api using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
-      await setup()
+      await setup();
+      timeBetweenBlocks = (await Tezos.rpc.getConstants()).delay_increment_per_round ?? new BigNumber(15);
       done()
     })
+
     it('Verify the operation is found even if the poller skipped blocks', async (done) => {
       // To simulate the behavior where blocks are skipped, we use a polling interval higher than the time between blocks
       // Before fixing issue #1783, if the block containing the operation was skipped, the operation was never found, and the test ended with a timeout
       // After fixing issue #1783, if blocks are skipped, they will be retrieved and inspected by the Operation class
-      Tezos.setStreamProvider(Tezos.getFactory(PollingSubscribeProvider)({ pollingIntervalMilliseconds: 60000 }));
+      Tezos.setStreamProvider(Tezos.getFactory(PollingSubscribeProvider)({ pollingIntervalMilliseconds: Number(timeBetweenBlocks.multipliedBy(4000)) }));
       const op = await Tezos.contract.transfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 2 });
       await op.confirmation();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);

--- a/integration-tests/polling-subscribe-provider.spec.ts
+++ b/integration-tests/polling-subscribe-provider.spec.ts
@@ -1,7 +1,5 @@
-import { CONFIGS } from "./config";
+import { CONFIGS, sleep } from "./config";
 import { Protocols, PollingSubscribeProvider } from "@taquito/taquito";
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;

--- a/integration-tests/wallet-confirmation-timeout.spec.ts
+++ b/integration-tests/wallet-confirmation-timeout.spec.ts
@@ -1,7 +1,5 @@
 import BigNumber from "bignumber.js";
-import { CONFIGS } from "./config";
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+import { CONFIGS, sleep } from "./config";
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;

--- a/integration-tests/wallet-confirmation-timeout.spec.ts
+++ b/integration-tests/wallet-confirmation-timeout.spec.ts
@@ -1,0 +1,42 @@
+import BigNumber from "bignumber.js";
+import { CONFIGS } from "./config";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+  let timeBetweenBlocks: BigNumber;
+  describe(`Test confirmationPollingTimeoutSecond with wallet API using: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup();
+      timeBetweenBlocks = (await Tezos.rpc.getConstants()).delay_increment_per_round ?? new BigNumber(15);
+      done()
+    })
+
+    it('Verify a timeout error is thrown when an operation is never confirmed', async (done) => {
+      const timeout = Number(timeBetweenBlocks.multipliedBy(2));
+      Tezos.setProvider({ config: { confirmationPollingTimeoutSecond: timeout } })
+      expect(async () => {
+
+          const op = await Tezos.wallet.originate({
+          code: `parameter string;
+          storage string;
+          code {CAR;
+                PUSH string "Hello ";
+                CONCAT;
+                NIL operation; PAIR};
+          `,
+          init: `"test"`,
+          gasLimit: 600000 // gas limit too high, the operation won't be included in a block
+        }).send()
+        await op.confirmation()
+
+      }).rejects.toThrow('Confirmation polling timed out');
+
+      await sleep(timeout * 2000);
+
+      done();
+    })
+  });
+})

--- a/packages/taquito/src/wallet/operation.ts
+++ b/packages/taquito/src/wallet/operation.ts
@@ -8,7 +8,8 @@ import {
   filter,
   first,
   map,
-  shareReplay,
+  publishReplay,
+  refCount,
   switchMap,
   takeWhile,
   tap,
@@ -41,7 +42,8 @@ export class WalletOperation {
       );
     }),
     tap((newHead) => (this.lastHead = newHead)),
-    shareReplay({ bufferSize: 1, refCount: true })
+    publishReplay(1),
+    refCount()
   );
 
   // Observable that emit once operation is seen in a block
@@ -64,7 +66,8 @@ export class WalletOperation {
       return typeof x !== 'undefined';
     }),
     first(),
-    shareReplay({ bufferSize: 1, refCount: true })
+    publishReplay(1),
+    refCount()
   );
 
   async operationResults() {


### PR DESCRIPTION
The timeout was not taken into consideration on both the contract and wallet API when confirming the operations. In cases where an operation was not found, our integration tests would never end instead of throwing a timeout error.

fix #2006

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
