### PR TITLE
contract-security-non-existent-KT-address: use rpc (#2091)

### DIFF
--- a/integration-tests/contract-security-non-existent-KT-address.spec.ts
+++ b/integration-tests/contract-security-non-existent-KT-address.spec.ts
@@ -6,11 +6,11 @@ import { Protocols, TezosToolkit } from '@taquito/taquito';
 
 // KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn is the tzBTC contract on mainnet
 
-const Tezos = new TezosToolkit(new RpcClient('http://mondaynet.ecadinfra.com:8732'));
 const testContractAddress = 'KT1PWx2mnDueood7fEmfbBDKx1D9BAnnXitn';
 
 CONFIGS().forEach(({ rpc, setup, protocol }) => {
-  const mondaynet = protocol === Protocols.ProtoALpha ? test: test.skip;
+  const mondaynet = protocol === Protocols.ProtoALpha ? test : test.skip;
+  const Tezos = new TezosToolkit(new RpcClient(rpc));
 
   describe(`Test contracts using: ${rpc}`, () => {
     beforeEach(async (done) => {


### PR DESCRIPTION
To test:

1. Start local, sandboxed Octez node with RPC endpoint `http://127.0.0.1:18731`.
2. Run `TEZOS_RPC_MONDAYNET=http://127.0.0.1:18731 npm run "test:mondaynet-secret-key" "contract-security-non-existent-KT-address.spec.ts"`
3. The test should work with this fix, and will fail without it as described in #2091 