### PR TITLE
fix(local-forging): fix encoding for deposit entrypoint

### DIFF
--- a/integration-tests/contract-call-with-xtz-amount.spec.ts
+++ b/integration-tests/contract-call-with-xtz-amount.spec.ts
@@ -10,7 +10,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
   describe(`Test contract call with amount using: ${rpc}`, () => {
     beforeEach(async (done) => {
-      await setup();
+      await setup(true);
       done();
     });
 

--- a/integration-tests/contract-unit-as-param.spec.ts
+++ b/integration-tests/contract-unit-as-param.spec.ts
@@ -7,7 +7,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
   describe(`Test contract origination with unit as params through contract api using: ${rpc}`, () => {
 
     beforeEach(async (done) => {
-      await setup()
+      await setup(true)
       done()
     })
     test('Verify contract.originate for a contract and call deposit method with unit param', async (done) => {

--- a/integration-tests/wallet-unit-as-param.spec.ts
+++ b/integration-tests/wallet-unit-as-param.spec.ts
@@ -6,7 +6,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
   describe(`Test smart contract entrypoint call with unit as param through wallet API using:: ${rpc}`, () => {
 
     beforeEach(async (done) => {
-      await setup()
+      await setup(true)
       done()
     })
     test('Verify wallet.originate for a contract and call deposit method with unit param', async (done) => {

--- a/packages/taquito-local-forging/src/constants.ts
+++ b/packages/taquito-local-forging/src/constants.ts
@@ -256,6 +256,7 @@ export const entrypointMapping: { [key: string]: string } = {
   '02': 'do',
   '03': 'set_delegate',
   '04': 'remove_delegate',
+  '05': 'deposit',
 };
 
 export const entrypointMappingReverse = (() => {

--- a/packages/taquito-local-forging/src/proto14-kathmandu/constants-proto14.ts
+++ b/packages/taquito-local-forging/src/proto14-kathmandu/constants-proto14.ts
@@ -166,3 +166,19 @@ export const opMappingReverseProto14 = (() => {
   });
   return result;
 })();
+
+export const entrypointMappingProto14: { [key: string]: string } = {
+  '00': 'default',
+  '01': 'root',
+  '02': 'do',
+  '03': 'set_delegate',
+  '04': 'remove_delegate',
+};
+
+export const entrypointMappingReverseProto14 = (() => {
+  const result: { [key: string]: string } = {};
+  Object.keys(entrypointMappingProto14).forEach((key: string) => {
+    result[entrypointMappingProto14[key]] = key;
+  });
+  return result;
+})();

--- a/packages/taquito-local-forging/test/codec.spec.ts
+++ b/packages/taquito-local-forging/test/codec.spec.ts
@@ -210,7 +210,7 @@ describe('Tests for Entrypoint functions and for encode and decoder error messag
     expect(() =>
       entrypointDecoder(
         Uint8ArrayConsumer.fromHexString(
-          '055c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae95c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae9'
+          '085c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae95c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae9'
         )
       )
     ).toThrow(OversizedEntryPointError);
@@ -218,7 +218,7 @@ describe('Tests for Entrypoint functions and for encode and decoder error messag
     expect(() =>
       entrypointDecoder(
         Uint8ArrayConsumer.fromHexString(
-          '055c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae95c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae9'
+          '085c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae95c8244b8de7d57795962c1bfc855d0813f8c61eddf3795f804ccdea3e4c82ae9'
         )
       )
     ).toThrow(


### PR DESCRIPTION
In lima protocol, the %deposit entrypoint is now represented by 0x05

fix #2158

https://gitlab.com/tezos/tezos/-/blob/master/src/proto_015_PtLimaPt/lib_protocol/entrypoint_repr.ml#L214

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
