### PR TITLE
integration tests: don't hardcode testnet constant values

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -4,9 +4,9 @@ import { HttpBackend } from '@taquito/http-utils';
 import { b58cencode, Prefix, prefix } from '@taquito/utils';
 import { importKey, InMemorySigner } from '@taquito/signer';
 import { RpcClient, RpcClientCache } from '@taquito/rpc';
-import { knownBigMapContractProtoALph, knownContractProtoALph, knownOnChainViewContractAddressProtoALph, knownSaplingContractProtoALph, knownTzip12BigMapOffChainContractProtoALph } from './known-contracts-ProtoALph';
-import { knownContractPtGhostnet, knownBigMapContractPtGhostnet, knownTzip12BigMapOffChainContractPtGhostnet, knownSaplingContractPtGhostnet, knownOnChainViewContractAddressPtGhostnet } from './known-contracts-PtGhostnet';
-import { knownContractPtNairobi, knownBigMapContractPtNairobi, knownTzip12BigMapOffChainContractPtNairobi, knownSaplingContractPtNairobi, knownOnChainViewContractAddressPtNairobi } from './known-contracts-PtNairobi';
+import { knownContractsProtoALph } from './known-contracts-ProtoALph';
+import { knownContractsPtGhostnet } from './known-contracts-PtGhostnet';
+import { knownContractsPtNairobi } from './known-contracts-PtNairobi';
 
 const nodeCrypto = require('crypto');
 
@@ -81,11 +81,11 @@ const nairobinetEphemeral = {
   pollingIntervalMilliseconds: process.env['POLLING_INTERVAL_MILLISECONDS'] || undefined,
   rpcCacheMilliseconds: process.env['RPC_CACHE_MILLISECONDS'] || '1000',
   knownBaker: process.env['TEZOS_BAKER'] || 'tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD',
-  knownContract: process.env['TEZOS_NAIROBINET_CONTRACT_ADDRESS'] || knownContractPtNairobi,
-  knownBigMapContract: process.env['TEZOS_NAIROBINET_BIGMAPCONTRACT_ADDRESS'] || knownBigMapContractPtNairobi,
-  knownTzip1216Contract: process.env['TEZOS_NAIROBINET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractPtNairobi,
-  knownSaplingContract: process.env['TEZOS_NAIROBINET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractPtNairobi,
-  knownViewContract: process.env['TEZOS_NAIROBINET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtNairobi,
+  knownContract: process.env['TEZOS_NAIROBINET_CONTRACT_ADDRESS'] || knownContractsPtNairobi.contract,
+  knownBigMapContract: process.env['TEZOS_NAIROBINET_BIGMAPCONTRACT_ADDRESS'] || knownContractsPtNairobi.bigMapContract,
+  knownTzip1216Contract: process.env['TEZOS_NAIROBINET_TZIP1216CONTRACT_ADDRESS'] || knownContractsPtNairobi.tzip12BigMapOffChainContract,
+  knownSaplingContract: process.env['TEZOS_NAIROBINET_SAPLINGCONTRACT_ADDRESS'] || knownContractsPtNairobi.saplingContract,
+  knownViewContract: process.env['TEZOS_NAIROBINET_ON_CHAIN_VIEW_CONTRACT'] || knownContractsPtNairobi.onChainViewContractAddress,
   protocol: Protocols.PtNairobi,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
@@ -99,11 +99,11 @@ const ghostnetEphemeral = {
   pollingIntervalMilliseconds: process.env['POLLING_INTERVAL_MILLISECONDS'] || undefined,
   rpcCacheMilliseconds: process.env['RPC_CACHE_MILLISECONDS'] || '1000',
   knownBaker: process.env['TEZOS_BAKER'] || 'tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD',
-  knownContract: process.env['TEZOS_GHOSTNET_CONTRACT_ADDRESS'] || knownContractPtGhostnet,
-  knownBigMapContract: process.env['TEZOS_GHOSTNET_BIGMAPCONTRACT_ADDRESS'] || knownBigMapContractPtGhostnet,
-  knownTzip1216Contract: process.env['TEZOS_GHOSTNET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractPtGhostnet,
-  knownSaplingContract: process.env['TEZOS_GHOSTNET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractPtGhostnet,
-  knownViewContract: process.env['TEZOS_GHOSTNET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtGhostnet,
+  knownContract: process.env['TEZOS_GHOSTNET_CONTRACT_ADDRESS'] || knownContractsPtGhostnet.contract,
+  knownBigMapContract: process.env['TEZOS_GHOSTNET_BIGMAPCONTRACT_ADDRESS'] || knownContractsPtGhostnet.bigMapContract,
+  knownTzip1216Contract: process.env['TEZOS_GHOSTNET_TZIP1216CONTRACT_ADDRESS'] || knownContractsPtGhostnet.tzip12BigMapOffChainContract,
+  knownSaplingContract: process.env['TEZOS_GHOSTNET_SAPLINGCONTRACT_ADDRESS'] || knownContractsPtGhostnet.saplingContract,
+  knownViewContract: process.env['TEZOS_GHOSTNET_ON_CHAIN_VIEW_CONTRACT'] || knownContractsPtGhostnet.onChainViewContractAddress,
   protocol: Protocols.PtMumbai2,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
@@ -117,11 +117,11 @@ const mondaynetEphemeral = {
   pollingIntervalMilliseconds: process.env['POLLING_INTERVAL_MILLISECONDS'] || undefined,
   rpcCacheMilliseconds: process.env['RPC_CACHE_MILLISECONDS'] || '1000',
   knownBaker: 'tz1ck3EJwzFpbLVmXVuEn5Ptwzc6Aj14mHSH',
-  knownContract: process.env['TEZOS_MONDAYNET_CONTRACT_ADDRESS'] || knownContractProtoALph,
-  knownBigMapContract: process.env['TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS'] || knownBigMapContractProtoALph,
-  knownTzip1216Contract: process.env['TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractProtoALph,
-  knownSaplingContract: process.env['TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractProtoALph,
-  knownViewContract: process.env['TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressProtoALph,
+  knownContract: process.env['TEZOS_MONDAYNET_CONTRACT_ADDRESS'] || knownContractsProtoALph.contract,
+  knownBigMapContract: process.env['TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS'] || knownContractsProtoALph.bigMapContract,
+  knownTzip1216Contract: process.env['TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS'] || knownContractsProtoALph.tzip12BigMapOffChainContract,
+  knownSaplingContract: process.env['TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS'] || knownContractsProtoALph.saplingContract,
+  knownViewContract: process.env['TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT'] || knownContractsProtoALph.onChainViewContractAddress,
   protocol: Protocols.ProtoALpha,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
@@ -136,11 +136,11 @@ const nairobinetSecretKey = {
   pollingIntervalMilliseconds: process.env['POLLING_INTERVAL_MILLISECONDS'] || undefined,
   rpcCacheMilliseconds: process.env['RPC_CACHE_MILLISECONDS'] || '1000',
   knownBaker: process.env['TEZOS_BAKER'] || 'tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD',
-  knownContract: process.env['TEZOS_NAIROBINET_CONTRACT_ADDRESS'] || knownContractPtNairobi,
-  knownBigMapContract: process.env['TEZOS_NAIROBINET_BIGMAPCONTRACT_ADDRESS'] || knownBigMapContractPtNairobi,
-  knownTzip1216Contract: process.env['TEZOS_NAIROBINET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractPtNairobi,
-  knownSaplingContract: process.env['TEZOS_NAIROBINET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractPtNairobi,
-  knownViewContract: process.env['TEZOS_NAIROBINET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtNairobi,
+  knownContract: process.env['TEZOS_NAIROBINET_CONTRACT_ADDRESS'] || knownContractsPtNairobi.contract,
+  knownBigMapContract: process.env['TEZOS_NAIROBINET_BIGMAPCONTRACT_ADDRESS'] || knownContractsPtNairobi.bigMapContract,
+  knownTzip1216Contract: process.env['TEZOS_NAIROBINET_TZIP1216CONTRACT_ADDRESS'] || knownContractsPtNairobi.tzip12BigMapOffChainContract,
+  knownSaplingContract: process.env['TEZOS_NAIROBINET_SAPLINGCONTRACT_ADDRESS'] || knownContractsPtNairobi.saplingContract,
+  knownViewContract: process.env['TEZOS_NAIROBINET_ON_CHAIN_VIEW_CONTRACT'] || knownContractsPtNairobi.onChainViewContractAddress,
   protocol: Protocols.PtNairobi,
   signerConfig: defaultSecretKey
 };
@@ -150,11 +150,11 @@ const ghostnetSecretKey = {
   pollingIntervalMilliseconds: process.env['POLLING_INTERVAL_MILLISECONDS'] || undefined,
   rpcCacheMilliseconds: process.env['RPC_CACHE_MILLISECONDS'] || '1000',
   knownBaker: process.env['TEZOS_BAKER'] || 'tz1cjyja1TU6fiyiFav3mFAdnDsCReJ12hPD',
-  knownContract: process.env['TEZOS_GHOSTNET_CONTRACT_ADDRESS'] || knownContractPtGhostnet,
-  knownBigMapContract: process.env['TEZOS_GHOSTNET_BIGMAPCONTRACT_ADDRESS'] || knownBigMapContractPtGhostnet,
-  knownTzip1216Contract: process.env['TEZOS_GHOSTNET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractPtGhostnet,
-  knownSaplingContract: process.env['TEZOS_GHOSTNET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractPtGhostnet,
-  knownViewContract: process.env['TEZOS_GHOSTNET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtGhostnet,
+  knownContract: process.env['TEZOS_GHOSTNET_CONTRACT_ADDRESS'] || knownContractsPtGhostnet.contract,
+  knownBigMapContract: process.env['TEZOS_GHOSTNET_BIGMAPCONTRACT_ADDRESS'] || knownContractsPtGhostnet.bigMapContract,
+  knownTzip1216Contract: process.env['TEZOS_GHOSTNET_TZIP1216CONTRACT_ADDRESS'] || knownContractsPtGhostnet.tzip12BigMapOffChainContract,
+  knownSaplingContract: process.env['TEZOS_GHOSTNET_SAPLINGCONTRACT_ADDRESS'] || knownContractsPtGhostnet.saplingContract,
+  knownViewContract: process.env['TEZOS_GHOSTNET_ON_CHAIN_VIEW_CONTRACT'] || knownContractsPtGhostnet.onChainViewContractAddress,
   protocol: Protocols.PtMumbai2,
   signerConfig: defaultSecretKey
 };
@@ -164,11 +164,11 @@ const mondaynetSecretKey = {
   pollingIntervalMilliseconds: process.env['POLLING_INTERVAL_MILLISECONDS'] || undefined,
   rpcCacheMilliseconds: process.env['RPC_CACHE_MILLISECONDS'] || '1000',
   knownBaker: process.env['TEZOS_MONDAYNET_BAKER'] || 'tz1ck3EJwzFpbLVmXVuEn5Ptwzc6Aj14mHSH',
-  knownContract: process.env['TEZOS_MONDAYNET_CONTRACT_ADDRESS'] || knownContractProtoALph,
-  knownBigMapContract: process.env['TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS'] || knownBigMapContractProtoALph,
-  knownTzip1216Contract: process.env['TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractProtoALph,
-  knownSaplingContract: process.env['TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractProtoALph,
-  knownViewContract: process.env['TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressProtoALph,
+  knownContract: process.env['TEZOS_MONDAYNET_CONTRACT_ADDRESS'] || knownContractsProtoALph.contract,
+  knownBigMapContract: process.env['TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS'] || knownContractsProtoALph.bigMapContract,
+  knownTzip1216Contract: process.env['TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS'] || knownContractsProtoALph.tzip12BigMapOffChainContract,
+  knownSaplingContract: process.env['TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS'] || knownContractsProtoALph.saplingContract,
+  knownViewContract: process.env['TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT'] || knownContractsProtoALph.onChainViewContractAddress,
   protocol: Protocols.ProtoALpha,
   signerConfig: defaultSecretKey
 };

--- a/integration-tests/known-contracts-ProtoALph.ts
+++ b/integration-tests/known-contracts-ProtoALph.ts
@@ -1,5 +1,8 @@
-export const knownContractProtoALph = "KT1EqE9uiQoodrX3hymdTsMzv4Ugh9Ba7WQh";
-export const knownBigMapContractProtoALph = "KT1AhkcgTg5Yve1akqhp3L2VYe9wuJyr9Cf2";
-export const knownTzip12BigMapOffChainContractProtoALph = "KT1L13TdpnvSnH9oax8BVsjsGwYUEAymvsUY";
-export const knownSaplingContractProtoALph = "KT1REUu1WbovnUHgxP5ywV6Nc8WSTSquoRmw";
-export const knownOnChainViewContractAddressProtoALph = "KT1NewFz74bCpfQw1qVkxGbN6MncRaVgaymH";
+import { KnownContracts } from './known-contracts';
+export const knownContractsProtoALph: KnownContracts = {
+  contract: "KT1EqE9uiQoodrX3hymdTsMzv4Ugh9Ba7WQh",
+  bigMapContract: "KT1AhkcgTg5Yve1akqhp3L2VYe9wuJyr9Cf2",
+  tzip12BigMapOffChainContract: "KT1L13TdpnvSnH9oax8BVsjsGwYUEAymvsUY",
+  saplingContract: "KT1REUu1WbovnUHgxP5ywV6Nc8WSTSquoRmw",
+  onChainViewContractAddress: "KT1NewFz74bCpfQw1qVkxGbN6MncRaVgaymH"
+};

--- a/integration-tests/known-contracts-PtGhostnet.ts
+++ b/integration-tests/known-contracts-PtGhostnet.ts
@@ -1,5 +1,8 @@
-export const knownContractPtGhostnet = "KT1HwcBvLjyQZi6CapBfCt5xiXSW5KcaJ4A5";
-export const knownBigMapContractPtGhostnet = "KT1Dig4sQxbZaZjo9X18etvpEWN1eGKxTVk2";
-export const knownTzip12BigMapOffChainContractPtGhostnet = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-export const knownSaplingContractPtGhostnet = "KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf";
-export const knownOnChainViewContractAddressPtGhostnet = "KT1R5spjSabhD9q8cwZfCvssuvUoHmEd6KNv";
+import { KnownContracts } from './known-contracts';
+export const knownContractsPtGhostnet: KnownContracts = {
+  contract: "KT1HwcBvLjyQZi6CapBfCt5xiXSW5KcaJ4A5",
+  bigMapContract: "KT1Dig4sQxbZaZjo9X18etvpEWN1eGKxTVk2",
+  tzip12BigMapOffChainContract: "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr",
+  saplingContract: "KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf",
+  onChainViewContractAddress: "KT1R5spjSabhD9q8cwZfCvssuvUoHmEd6KNv",
+}

--- a/integration-tests/known-contracts-PtMumbai2.ts
+++ b/integration-tests/known-contracts-PtMumbai2.ts
@@ -1,5 +1,8 @@
-export const knownContractPtMumbai2 = "KT1XFiUYC36XSeLTanGJwZxqLzsxz9zquLFB";
-export const knownBigMapContractPtMumbai2 = "KT1KbbvszHoWVSS8Nzh9yLgvRBDkzVjKmCtj";
-export const knownTzip12BigMapOffChainContractPtMumbai2 = "KT1KKU19PxFbQUT9sBJS8KwYCVaXAzYsTkUK";
-export const knownSaplingContractPtMumbai2 = "KT1UHkJDY1CWAgYZJR1NkxXv27gsuu7hC77R";
-export const knownOnChainViewContractAddressPtMumbai2 = "KT1JxWH1vtMiTcvg4AdhTaGmyHt2oBb71tzW";
+import { KnownContracts } from './known-contracts';
+export const knownContractsPtMumbai2: KnownContracts = {
+  contract: "KT1XFiUYC36XSeLTanGJwZxqLzsxz9zquLFB",
+  bigMapContract: "KT1KbbvszHoWVSS8Nzh9yLgvRBDkzVjKmCtj",
+  tzip12BigMapOffChainContract: "KT1KKU19PxFbQUT9sBJS8KwYCVaXAzYsTkUK",
+  saplingContract: "KT1UHkJDY1CWAgYZJR1NkxXv27gsuu7hC77R",
+  onChainViewContractAddress: "KT1JxWH1vtMiTcvg4AdhTaGmyHt2oBb71tzW"
+};

--- a/integration-tests/known-contracts-PtNairobi.ts
+++ b/integration-tests/known-contracts-PtNairobi.ts
@@ -1,5 +1,8 @@
-export const knownContractPtNairobi = "KT1GrzF7DSNc7LrLmS7RNaLrBQqyYHyoMzwR";
-export const knownBigMapContractPtNairobi = "KT1Twd6GBBqHEFhzvBDEn4JiUopttq2WjdnF";
-export const knownTzip12BigMapOffChainContractPtNairobi = "KT1WZUqEKZ4TMW75FKpqod4HwB4ts7wbnsFh";
-export const knownSaplingContractPtNairobi = "KT1VNnD8NWx9ep2gxsHbzrmahrWsKpZb3xGY";
-export const knownOnChainViewContractAddressPtNairobi = "KT19eNryXTuVgH6s6cUc1a5LyjSamdBw4JXo";
+import { KnownContracts } from './known-contracts';
+export const knownContractsPtNairobi: KnownContracts = {
+  contract: "KT1GrzF7DSNc7LrLmS7RNaLrBQqyYHyoMzwR",
+  bigMapContract: "KT1Twd6GBBqHEFhzvBDEn4JiUopttq2WjdnF",
+  tzip12BigMapOffChainContract: "KT1WZUqEKZ4TMW75FKpqod4HwB4ts7wbnsFh",
+  saplingContract: "KT1VNnD8NWx9ep2gxsHbzrmahrWsKpZb3xGY",
+  onChainViewContractAddress: "KT19eNryXTuVgH6s6cUc1a5LyjSamdBw4JXo"
+};

--- a/integration-tests/known-contracts.ts
+++ b/integration-tests/known-contracts.ts
@@ -1,0 +1,7 @@
+export type KnownContracts = {
+  bigMapContract: string;
+  contract: string;
+  onChainViewContractAddress: string;
+  saplingContract: string;
+  tzip12BigMapOffChainContract: string;
+}

--- a/integration-tests/rpc-get-protocol-constants.spec.ts
+++ b/integration-tests/rpc-get-protocol-constants.spec.ts
@@ -1,5 +1,5 @@
-import { Protocols } from '@taquito/taquito';
-import { CONFIGS } from './config';
+import { Protocols } from "@taquito/taquito";
+import { CONFIGS, NetworkType } from "./config";
 import BigNumber from 'bignumber.js';
 import {
   ConstantsResponseProto009,
@@ -12,9 +12,9 @@ import {
   ConstantsResponseProto017,
 } from '@taquito/rpc';
 
-CONFIGS().forEach(({ lib, protocol, rpc }) => {
+CONFIGS().forEach(({ lib, protocol, rpc, networkType }) => {
   const Tezos = lib;
-  const alpha = (protocol === Protocols.ProtoALpha) ? test : test.skip;
+  const alpha = (networkType == NetworkType.TESTNET && protocol === Protocols.ProtoALpha) ? test : test.skip;
 
   describe('Test fetching constants for all protocols on Mainnet', () => {
 


### PR DESCRIPTION
Fixes #2163 

This is quite a hacky solution, where the values are only checked if they match an actual RPC endpoint. This means that RPC endpoints have to be updated in two places when they change.

Another possible solution: include a key in the test configurations `configuration.ts::Config` like `testnet: boolean` or `network_type: Testnet | Sandbox`. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
