### PR TITLE
docs: add missing step to test dapp docs

### DIFF
--- a/apps/taquito-test-dapp/README.md
+++ b/apps/taquito-test-dapp/README.md
@@ -10,7 +10,7 @@ A minimal end-to-end testing setup for developing Tezos DApps with Taquito and B
 1. Install dependencies: `npm i`
 1. Build Taquito: `npm run build`
 1. Change your current working directory to `apps/taquito-test-dapp`.
-1. Start development or production server as is shown below.
+1. Start development or production server as shown below.
 
 #### Start development server:
 1. `npm run dev`

--- a/apps/taquito-test-dapp/README.md
+++ b/apps/taquito-test-dapp/README.md
@@ -6,16 +6,16 @@ A minimal end-to-end testing setup for developing Tezos DApps with Taquito and B
 ## Getting Started
 #### Initial setup:
 1. Clone the Taquito repository: `git clone git@github.com:ecadlabs/taquito.git`
-1. Change your current working directory to the newly cloned repository.
-1. Install dependencies: `npm i`
+1. Change your current working directory to the newly cloned one: `cd taquito`
+1. Install dependencies: `npm clean-install`
 1. Build Taquito: `npm run build`
-1. Change your current working directory to `apps/taquito-test-dapp`.
-1. Start development or production server as shown below.
+1. Change your current working directory to the test dapp: `cd apps/taquito-test-dapp`
+1. Start the development or production server as shown below.
 
 #### Start development server:
 1. `npm run dev`
-1. Open http://localhost:3030 in your browser to see a sample application.
+1. Open `http://localhost:3030` in your browser to preview application.
 
 #### Start production server:
 1. `npm run build && npm run preview`
-1. Open http://localhost:4173 in your browser to see a preview application.
+1. Open `http://localhost:4173` in your browser to preview application.

--- a/apps/taquito-test-dapp/README.md
+++ b/apps/taquito-test-dapp/README.md
@@ -4,18 +4,18 @@
 
 A minimal end-to-end testing setup for developing Tezos DApps with Taquito and Beacon to manage signing and wallet operations.
 ## Getting Started
-#### Initial setup:
+#### Initial setup
 1. Clone the Taquito repository: `git clone git@github.com:ecadlabs/taquito.git`
 1. Change your current working directory to the newly cloned one: `cd taquito`
 1. Install dependencies: `npm clean-install`
 1. Build Taquito: `npm run build`
 1. Change your current working directory to the test dapp: `cd apps/taquito-test-dapp`
-1. Start the development or production server as shown below.
+1. Start the development or production server as shown below
 
-#### Start development server:
+#### Start development server
 1. `npm run dev`
 1. Open `http://localhost:3030` in your browser to preview application.
 
-#### Start production server:
+#### Start production server
 1. `npm run build && npm run preview`
 1. Open `http://localhost:4173` in your browser to preview application.

--- a/apps/taquito-test-dapp/README.md
+++ b/apps/taquito-test-dapp/README.md
@@ -4,13 +4,18 @@
 
 A minimal end-to-end testing setup for developing Tezos DApps with Taquito and Beacon to manage signing and wallet operations.
 ## Getting Started
+#### Initial setup:
 1. Clone the Taquito repository: `git clone git@github.com:ecadlabs/taquito.git`
-2. Change your current working directory to the newly cloned repository directory, then change to `apps/taquito-test-dapp`.
-3. Install all dependencies:
-    `npm clean-install`
-4. Start development server:
-    `npm run dev`
-5. Open http://localhost:3030 in your browser to see a sample application.
-6. Start production server:
-    `npm run build && npm run preview`
-7. Open http://localhost:4173 in your browser to see a preview application.
+1. Change your current working directory to the newly cloned repository.
+1. Install dependencies with `npm i`
+1. Build Taquito. `npm run build`
+1. Change your current working directory to `apps/taquito-test-dapp`.
+1. Start development or production server as is shown below.
+
+#### Start development server:
+1. `npm run dev`
+1. Open http://localhost:3030 in your browser to see a sample application.
+
+#### Start production server:
+1. `npm run build && npm run preview`
+1. Open http://localhost:4173 in your browser to see a preview application.

--- a/apps/taquito-test-dapp/README.md
+++ b/apps/taquito-test-dapp/README.md
@@ -7,8 +7,8 @@ A minimal end-to-end testing setup for developing Tezos DApps with Taquito and B
 #### Initial setup:
 1. Clone the Taquito repository: `git clone git@github.com:ecadlabs/taquito.git`
 1. Change your current working directory to the newly cloned repository.
-1. Install dependencies with `npm i`
-1. Build Taquito. `npm run build`
+1. Install dependencies: `npm i`
+1. Build Taquito: `npm run build`
 1. Change your current working directory to `apps/taquito-test-dapp`.
 1. Start development or production server as is shown below.
 


### PR DESCRIPTION
## Summary
Add missing steps to test dapp docs

### Testing
The steps in these updated instructions were followed exactly. I also deviated by skipping a step or running the commands in the wrong directories to assure that all the steps are needed and in the specified order and in the proper directories.