### PR TITLE
fix: force lerna to npm clean install

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "nx run-many --target=build --exclude=@taquito/website,taquito-test-dapp-vite",
     "build-test-dapp": "lerna run build --scope=taquito-test-dapp-vite",
-    "bootstrap": "lerna bootstrap --force-local",
+    "bootstrap": "lerna bootstrap --force-local --ci",
     "rebuild": "npm run clean && npm clean-install && npm run build",
     "test": "nx run-many --target=test --exclude=integration-tests,@taquito/website,taquito-test-dapp-vite --collectCoverage",
     "postinstall": "npm run bootstrap",


### PR DESCRIPTION
## Summary
Lerna runs `npm install` by default in a non-ci environment. This is problematic for local environments as `npm install` could alter the `package-lock.json` file. This change forces lerna to run `npm clean-install` in a local environment.

refs: https://github.com/lerna/lerna/tree/main/commands/bootstrap#--no-ci

- [x] Your code builds cleanly without any errors or warnings
