### PR TITLE
add tests for parsing mode for all testnets, and fail case

### DIFF
--- a/integration-tests/rpc-taquito.spec.ts
+++ b/integration-tests/rpc-taquito.spec.ts
@@ -48,6 +48,10 @@ CONFIGS().forEach(({ rpc, knownContract }) => {
               expect(() => client.getNormalizedScript(knownContract, {unparsing_mode: 'else' as any})).rejects.toThrowError(HttpResponseError)
               done()
             })
+            it('Should fail unparsing_mode not acceptable', async (done) => {
+              expect(() => client.getNormalizedScript(knownContract, {} as any )).rejects.toThrowError(HttpResponseError)
+              done()
+            })
         })
     })
 })

--- a/integration-tests/rpc-taquito.spec.ts
+++ b/integration-tests/rpc-taquito.spec.ts
@@ -1,8 +1,9 @@
 import { CONFIGS } from "./config";
 import { RpcClient } from '@taquito/rpc';
+import { HttpResponseError } from "@taquito/http-utils";
 
 
-CONFIGS().forEach(({ rpc }) => {
+CONFIGS().forEach(({ rpc, knownContract }) => {
     const client = new RpcClient(rpc);
 
     describe(`Test Taquito RPC: ${rpc}`, () => {
@@ -27,6 +28,25 @@ CONFIGS().forEach(({ rpc }) => {
 
                 expect(predecessorBlock.hash).toEqual(block.header.predecessor);
                 done();
+            })
+            it('Verify that unparse_mode has no error: Readable', async (done) => {
+              const response = await client.getNormalizedScript(knownContract, {unparsing_mode: 'Readable'})
+              expect(response.code).toBeDefined();
+              done()
+            })
+            it('Verify that unparse_mode has no error: Optimized', async (done) => {
+              const response = await client.getNormalizedScript(knownContract, {unparsing_mode: 'Optimized'})
+              expect(response.code).toBeDefined();
+              done()
+            })
+            it('Verify that unparse_mode has no error: Optimized_legacy', async (done) => {
+              const response = await client.getNormalizedScript(knownContract, {unparsing_mode: 'Optimized_legacy'})
+              expect(response.code).toBeDefined();
+              done()
+            })
+            it('Should fail unparsing_mode not acceptable', async (done) => {
+              expect(() => client.getNormalizedScript(knownContract, {unparsing_mode: 'else' as any})).rejects.toThrowError(HttpResponseError)
+              done()
             })
         })
     })

--- a/integration-tests/rpc-taquito.spec.ts
+++ b/integration-tests/rpc-taquito.spec.ts
@@ -4,54 +4,54 @@ import { HttpResponseError } from "@taquito/http-utils";
 
 
 CONFIGS().forEach(({ rpc, knownContract }) => {
-    const client = new RpcClient(rpc);
+  const client = new RpcClient(rpc);
 
-    describe(`Test Taquito RPC: ${rpc}`, () => {
-        describe('Test getBlock', () => {
-            it('Verify that client.getBlock returns a block using default syntax', async (done) => {
-                // defaults to /chains/main/blocks/head/
-                const block = await client.getBlock();
+  describe(`Test Taquito RPC: ${rpc}`, () => {
+    describe('Test getBlock', () => {
+      it('Verify that client.getBlock returns a block using default syntax', async (done) => {
+        // defaults to /chains/main/blocks/head/
+        const block = await client.getBlock();
 
-                expect(block.protocol).toBeTruthy();
-                done();
-            })
-            it('Verify that client.getBlock({ block: \'head~2\' }) returns a block using head and tilde syntax', async (done) => {
-                const block = await client.getBlock({ block: 'head~2' });
-                const blockHeader = await client.getBlockHeader({ block: block.hash })
+        expect(block.protocol).toBeTruthy();
+        done();
+      });
+      it('Verify that client.getBlock({ block: \'head~2\' }) returns a block using head and tilde syntax', async (done) => {
+        const block = await client.getBlock({ block: 'head~2' });
+        const blockHeader = await client.getBlockHeader({ block: block.hash });
 
-                expect(block.header.predecessor).toEqual(blockHeader.predecessor);
-                done();
-            })
-            it('Verify that client.getBlock({ block: `${block.hash}~1` }) returns a block using hash and tilde syntax', async (done) => {
-                const block = await client.getBlock();
-                const predecessorBlock = await client.getBlock({ block: `${block.hash}~1` })
+        expect(block.header.predecessor).toEqual(blockHeader.predecessor);
+        done();
+      });
+      it('Verify that client.getBlock({ block: `${block.hash}~1` }) returns a block using hash and tilde syntax', async (done) => {
+        const block = await client.getBlock();
+        const predecessorBlock = await client.getBlock({ block: `${block.hash}~1` });
 
-                expect(predecessorBlock.hash).toEqual(block.header.predecessor);
-                done();
-            })
-            it('Verify that unparse_mode has no error: Readable', async (done) => {
-              const response = await client.getNormalizedScript(knownContract, {unparsing_mode: 'Readable'})
-              expect(response.code).toBeDefined();
-              done()
-            })
-            it('Verify that unparse_mode has no error: Optimized', async (done) => {
-              const response = await client.getNormalizedScript(knownContract, {unparsing_mode: 'Optimized'})
-              expect(response.code).toBeDefined();
-              done()
-            })
-            it('Verify that unparse_mode has no error: Optimized_legacy', async (done) => {
-              const response = await client.getNormalizedScript(knownContract, {unparsing_mode: 'Optimized_legacy'})
-              expect(response.code).toBeDefined();
-              done()
-            })
-            it('Should fail unparsing_mode not acceptable', async (done) => {
-              expect(() => client.getNormalizedScript(knownContract, {unparsing_mode: 'else' as any})).rejects.toThrowError(HttpResponseError)
-              done()
-            })
-            it('Should fail unparsing_mode not acceptable', async (done) => {
-              expect(() => client.getNormalizedScript(knownContract, {} as any )).rejects.toThrowError(HttpResponseError)
-              done()
-            })
-        })
-    })
-})
+        expect(predecessorBlock.hash).toEqual(block.header.predecessor);
+        done();
+      });
+      it('Verify that unparse_mode has no error: Readable', async (done) => {
+        const response = await client.getNormalizedScript(knownContract, { unparsing_mode: 'Readable' });
+        expect(response.code).toBeDefined();
+        done();
+      });
+      it('Verify that unparse_mode has no error: Optimized', async (done) => {
+        const response = await client.getNormalizedScript(knownContract, { unparsing_mode: 'Optimized' });
+        expect(response.code).toBeDefined();
+        done();
+      });
+      it('Verify that unparse_mode has no error: Optimized_legacy', async (done) => {
+        const response = await client.getNormalizedScript(knownContract, { unparsing_mode: 'Optimized_legacy' });
+        expect(response.code).toBeDefined();
+        done();
+      });
+      it('Should fail unparsing_mode not acceptable', async (done) => {
+        expect(() => client.getNormalizedScript(knownContract, { unparsing_mode: 'else' as any })).rejects.toThrowError(HttpResponseError);
+        done();
+      });
+      it('Should fail unparsing_mode not acceptable', async (done) => {
+        expect(() => client.getNormalizedScript(knownContract, {} as any)).rejects.toThrowError(HttpResponseError);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
tried removing the unparsing mode and put it as something different but it fails.

the response of each is slightly different

and it fails when being sent with improper params at the http response level 

