### PR TITLE
Add Flextesa Lima box and refactor the Github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
           --set-history-mode N000:archive \
           --number-of-b 1 \
           --balance-of-bootstrap-accounts tez:100_000_000 \
-          --time-b 1 \
+          --time-b 2 \
           --add-bootstrap-account="${alice}@2_000_000_000_000" \
           --add-bootstrap-account="${bob}@2_000_000_000_000" \
           --add-bootstrap-account="${charlie}@2_000_000_000_000" \
@@ -116,7 +116,7 @@ jobs:
     - run: npm -w integration-tests run test:originate-known-contracts && npm -w integration-tests run test:${{ matrix.testnet }}-secret-key -- --testPathIgnorePatterns ledger-signer-failing-tests.spec.ts ledger-signer.spec.ts contract-estimation-tests.spec.ts rpc-get-protocol-constants.spec.ts
       env:
         RUN_${{ matrix.testnet_uppercase }}_WITH_SECRET_KEY: true
-        SECRET_KEY: edsk3RFgDiCt7tWB2oe96w1eRw72iYiiqZPLu9nnEY23MYRp2d8Kkx
+        SECRET_KEY: edsk3S8mG2sSBmSRbikAcZVLCz4SrCq4DjmsQRic6MGktqNFijfrS2
         TEZOS_RPC_${{ matrix.testnet_uppercase }}: http://localhost:20000
         POLLING_INTERVAL_MILLISECONDS: 100
         RPC_CACHE_MILLISECONDS: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,20 +62,62 @@ jobs:
   integration-tests-flextesa:
     runs-on: ubuntu-latest
     continue-on-error: true
+    strategy:
+      matrix:
+        include:
+          - protocol: Kathmandu
+            testnet: kathmandunet
+            testnet_uppercase: KATHMANDUNET
+          - protocol: Lima
+            testnet: limanet
+            testnet_uppercase: LIMANET
+    env:
+      flextesa_docker_image: oxheadalpha/flextesa:latest
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
         node-version: 16
-    - run: docker run --rm --name my-sandbox --detach -p 20000:20000 -e block_time=1 oxheadalpha/flextesa:latest kathmandubox start
+
+    ## The 4 Bootstrap Accounts (alias, pk, pkh, sk)
+    # alice,edpkvGfYw3LyB1UcCahKQk4rF2tvbMUk8GFiTuMjL75uGXrpvKXhjn,tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb,unencrypted:edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq
+    # bob,edpkurPsQ8eUApnLUJ9ZPDvu98E8VNj4KtJa1aZr16Cr5ow5VHKnz4,tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6,unencrypted:edsk3RFfvaFaxbHx8BMtEW1rKQcPtDML3LXjNqMNLCzC3wLC1bWbAt
+    # charlie,edpkuvMuRuZ6ZbAquJH1XxBFfUmuBFz1zp9ENEqjCVgLp3NcY3Ww9M,tz1RDVcKmFcqzvTpJirvg4JaUVgZbjtnRT26,unencrypted:edsk3RgWvbKKA1atEUcaGwivge7QtckHkTL9nQJUXQKY5r8WKp4pF4
+    # donald,edpkvXGp1BMZxHkwg3mKnWfJYS6HTJ5JtufD8YXxLtH8UKqLZkZVun,tz1eSWp4B9s1qhtNMMNXAkaf2oqCnDHd2iAm,unencrypted:edsk3S8mG2sSBmSRbikAcZVLCz4SrCq4DjmsQRic6MGktqNFijfrS2
+    - name: Generate Flextesa bootstrap accounts
+      run: |-
+        echo "alice=$(docker run --rm ${flextesa_docker_image} flextesa key alice)" >> $GITHUB_ENV 
+        echo "bob=$(docker run --rm ${flextesa_docker_image} flextesa key bob)" >> $GITHUB_ENV
+        echo "charlie=$(docker run --rm ${flextesa_docker_image} flextesa key charlie)" >> $GITHUB_ENV
+        echo "donald=$(docker run --rm ${flextesa_docker_image} flextesa key donald)" >> $GITHUB_ENV
+    - name: Provision Flextesa ${{ matrix.protocol }} container
+      run: |-
+        docker run \
+        --rm \
+        --name my-sandbox \
+        --detach \
+        -p 20000:20000 \
+        ${flextesa_docker_image} \
+        flextesa mini-net \
+          --root /tmp/mini-box --size 1 \
+          --set-history-mode N000:archive \
+          --number-of-b 1 \
+          --balance-of-bootstrap-accounts tez:100_000_000 \
+          --time-b 1 \
+          --add-bootstrap-account="${alice}@2_000_000_000_000" \
+          --add-bootstrap-account="${bob}@2_000_000_000_000" \
+          --add-bootstrap-account="${charlie}@2_000_000_000_000" \
+          --add-bootstrap-account="${donald}@2_000_000_000_000" \
+          --no-daemons-for=donald \
+          --until-level 200_000_000 \
+          --protocol-kind ${{ matrix.protocol }}
     - run: npm ci
     - run: npm run build
-    - run: npm -w integration-tests run test:originate-known-contracts && npm -w integration-tests run test:kathmandunet-secret-key -- --testPathIgnorePatterns ledger-signer-failing-tests.spec.ts ledger-signer.spec.ts contract-estimation-tests.spec.ts rpc-get-protocol-constants.spec.ts
+    - run: npm -w integration-tests run test:originate-known-contracts && npm -w integration-tests run test:${{ matrix.testnet }}-secret-key -- --testPathIgnorePatterns ledger-signer-failing-tests.spec.ts ledger-signer.spec.ts contract-estimation-tests.spec.ts rpc-get-protocol-constants.spec.ts
       env:
-        RUN_KATHMANDUNET_WITH_SECRET_KEY: true
+        RUN_${{ matrix.testnet_uppercase }}_WITH_SECRET_KEY: true
         SECRET_KEY: edsk3RFgDiCt7tWB2oe96w1eRw72iYiiqZPLu9nnEY23MYRp2d8Kkx
-        TEZOS_RPC_KATHMANDUNET: http://0.0.0.0:20000
+        TEZOS_RPC_${{ matrix.testnet_uppercase }}: http://localhost:20000
         POLLING_INTERVAL_MILLISECONDS: 100
         RPC_CACHE_MILLISECONDS: 0
         TEZOS_BAKER: tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb
-    - run: docker kill my-sandbox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,7 +103,7 @@ jobs:
           --set-history-mode N000:archive \
           --number-of-b 1 \
           --balance-of-bootstrap-accounts tez:100_000_000 \
-          --time-b 2 \
+          --time-b 1 \
           --add-bootstrap-account="${alice}@2_000_000_000_000" \
           --add-bootstrap-account="${bob}@2_000_000_000_000" \
           --add-bootstrap-account="${charlie}@2_000_000_000_000" \


### PR DESCRIPTION
This PR adds the ability to run integration tests against a Flextesa container running Lima protocol. Flextesa accepts additional parameters for provisioning bootstrap accounts. 

Moreover I refactored the workflow to use `matrix` strategy which reduces code duplication and improves the maintainability of the code. We will only need to append protocols in the `matrix` parameter whenever we want to support new protocols.