### PR TITLE
Run integration test against testnets for external PRs

### DIFF
--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy-edge-package:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' || github.ref == 'refs/heads/master' }}
+    if: ${{ !github.event.pull_request.head.repo.fork && (github.event_name == 'pull_request' || github.ref == 'refs/heads/master') }}
     env:
       VERDACCIO_TOKEN: ${{ secrets.EDGE_VERDACCIO_TOKEN }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,7 +53,9 @@ jobs:
       with:
         node-version: 16
     # TODO: remove after debugging
-    - run: echo "${{ github.event }}"
+    - env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
     - run: npm ci
     - run: npm run build
     - if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,8 @@ jobs:
     - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=8
       env:
         # Ternary operator workaround
-        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ !github.event.pull_request.head.repo.fork && format('http://ecad-{0}-archive:8732', matrix.testnet) || format('https://{0}.ecadinfra.com', matrix.testnet) }}
+        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.event.pull_request.head.repo.fork && format('https://{0}.ecadinfra.com', matrix.testnet) || null }}
+        TEZOS_KEYGEN_URL: ${{ github.event.pull_request.head.repo.fork && format('https://api.tez.ie/keys/{0}', matrix.testnet) || null }}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
     - run: echo "${{ github.event }}"
     - run: npm ci
     - run: npm run build
-    - if: ${{ contains(secrets.DUMMY_SECRET, 'dummy') }}
+    - if: ${{ !github.event.pull_request.head.repo.fork }}
       name: Tailscale
       uses: tailscale/github-action@v1
       with:
@@ -65,7 +65,7 @@ jobs:
     - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=8
       env:
         # Ternary operator workaround
-        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ contains(secrets.DUMMY_SECRET, 'dummy') && format('http://ecad-{0}-archive:8732', matrix.testnet) || format('https://{0}.ecadinfra.com', matrix.testnet) }}
+        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ !github.event.pull_request.head.repo.fork && format('http://ecad-{0}-archive:8732', matrix.testnet) || format('https://{0}.ecadinfra.com', matrix.testnet) }}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,7 @@ jobs:
       with:
         node-version: 16
     # TODO: remove after debugging
-    - run: env
-    - run: cat $GITHUB_ENV
+    - run: echo "${{ github.event }}"
     - run: npm ci
     - run: npm run build
     - if: ${{ contains(secrets.DUMMY_SECRET, 'dummy') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     - run: cat $GITHUB_ENV
     - run: npm ci
     - run: npm run build
-    - if: ${{ github.repository_owner == 'ecadlabs' }}
+    - if: ${{ contains(secrets.DUMMY_SECRET, 'dummy') }}
       name: Tailscale
       uses: tailscale/github-action@v1
       with:
@@ -66,7 +66,7 @@ jobs:
     - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=8
       env:
         # Ternary operator workaround
-        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.repository_owner == 'ecadlabs' && format('http://ecad-{0}-archive:8732', matrix.testnet) || format('https://{0}.ecadinfra.com', matrix.testnet) }}
+        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ contains(secrets.DUMMY_SECRET, 'dummy') && format('http://ecad-{0}-archive:8732', matrix.testnet) || format('https://{0}.ecadinfra.com', matrix.testnet) }}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,11 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        protocol:
-          - kathmandunet
-          - limanet
+        include:
+          - testnet: kathmandunet
+            testnet_uppercase: KATHMANDUNET
+          - testnet: limanet
+            testnet_uppercase: LIMANET
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
@@ -52,12 +54,16 @@ jobs:
         node-version: 16
     - run: npm ci
     - run: npm run build
-    - name: Tailscale
+    - if: ${{ github.repository_owner == 'ecadlabs' }}
+      name: Tailscale
       uses: tailscale/github-action@v1
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
         version: 1.32.2
-    - run: npm -w integration-tests run test:${{ matrix.protocol }} -- --maxWorkers=8
+    - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=8
+      env:
+        # Ternary operator workaround
+        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.repository_owner == 'ecadlabs' && "http://ecad-${{ matrix.testnet }}-archive:8732" || "https://${{ matrix.testnet }}.ecadinfra.com"}}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,6 @@ jobs:
       env:
         # Ternary operator workaround
         TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.event.pull_request.head.repo.fork && format('https://{0}.ecadinfra.com', matrix.testnet) || null }}
-        TEZOS_KEYGEN_URL: ${{ github.event.pull_request.head.repo.fork && format('https://api.tez.ie/keys/{0}', matrix.testnet) || null }}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,10 +52,6 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
-    # TODO: remove after debugging
-    - env:
-        GITHUB_CONTEXT: ${{ toJson(github) }}
-      run: echo "$GITHUB_CONTEXT"
     - run: npm ci
     - run: npm run build
     - if: ${{ !github.event.pull_request.head.repo.fork }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=8
       env:
         # Ternary operator workaround
-        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.repository_owner == 'ecadlabs' && "http://ecad-${{ matrix.testnet }}-archive:8732" || "https://${{ matrix.testnet }}.ecadinfra.com"}}
+        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.repository_owner == 'ecadlabs' && format('http://ecad-{0}-archive:8732', matrix.testnet) || format('https://{0}.ecadinfra.com', matrix.testnet) }}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,6 +52,9 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: 16
+    # TODO: remove after debugging
+    - run: env
+    - run: cat $GITHUB_ENV
     - run: npm ci
     - run: npm run build
     - if: ${{ github.repository_owner == 'ecadlabs' }}

--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -91,7 +91,7 @@ const kathmandunetEphemeral = {
   protocol: Protocols.PtKathman,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
-    keyUrl: 'http://key-gen-1.i.tez.ie:3000/kathmandunet',
+    keyUrl: process.env['TEZOS_KEYGEN_URL'] || 'http://key-gen-1.i.tez.ie:3000/kathmandunet',
     requestHeaders: { Authorization: 'Bearer taquito-example' },
   }
 };
@@ -112,7 +112,7 @@ const limanetEphemeral = {
   protocol: Protocols.PtLimaPtL,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
-    keyUrl: 'http://key-gen-1.i.tez.ie:3000/limanet',
+    keyUrl: process.env['TEZOS_KEYGEN_URL'] || 'http://key-gen-1.i.tez.ie:3000/limanet',
     requestHeaders: { Authorization: 'Bearer taquito-example' },
   },
 };
@@ -134,7 +134,7 @@ const mondaynetEphemeral = {
   protocol: Protocols.ProtoALpha,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
-    keyUrl: 'http://key-gen-1.i.tez.ie:3010/mondaynet',
+    keyUrl: process.env['TEZOS_KEYGEN_URL'] || 'http://key-gen-1.i.tez.ie:3010/mondaynet',
     requestHeaders: { Authorization: 'Bearer taquito-example' },
   },
 };

--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -91,7 +91,7 @@ const kathmandunetEphemeral = {
   protocol: Protocols.PtKathman,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
-    keyUrl: process.env['TEZOS_KEYGEN_URL'] || 'http://key-gen-1.i.tez.ie:3000/kathmandunet',
+    keyUrl: 'https://api.tez.ie/keys/kathmandunet',
     requestHeaders: { Authorization: 'Bearer taquito-example' },
   }
 };
@@ -112,7 +112,7 @@ const limanetEphemeral = {
   protocol: Protocols.PtLimaPtL,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
-    keyUrl: process.env['TEZOS_KEYGEN_URL'] || 'http://key-gen-1.i.tez.ie:3000/limanet',
+    keyUrl: 'https://api.tez.ie/keys/limanet',
     requestHeaders: { Authorization: 'Bearer taquito-example' },
   },
 };
@@ -134,7 +134,7 @@ const mondaynetEphemeral = {
   protocol: Protocols.ProtoALpha,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
-    keyUrl: process.env['TEZOS_KEYGEN_URL'] || 'http://key-gen-1.i.tez.ie:3010/mondaynet',
+    keyUrl: 'http://key-gen-1.i.tez.ie:3010/mondaynet',
     requestHeaders: { Authorization: 'Bearer taquito-example' },
   },
 };

--- a/integration-tests/rpc-nodes.spec.ts
+++ b/integration-tests/rpc-nodes.spec.ts
@@ -21,6 +21,7 @@ CONFIGS().forEach(
     const Tezos = lib;
 
     const limanetAndAlpha = protocol === Protocols.PtLimaPtL || protocol === Protocols.ProtoALpha ? test : test.skip;
+    const unrestrictedRPCNode = rpc.endsWith("ecadinfra.com") ? test.skip : test
 
     beforeAll(async (done) => {
       await setup()
@@ -155,7 +156,7 @@ CONFIGS().forEach(
           done();
         });
 
-        it('Verify that rpcClient.getBakingRights retrieves the list of delegates allowed to bake a block', async (done) => {
+        unrestrictedRPCNode('Verify that rpcClient.getBakingRights retrieves the list of delegates allowed to bake a block', async (done) => {
           const bakingRights = await rpcClient.getBakingRights({
             max_round: '2'
           });
@@ -165,7 +166,7 @@ CONFIGS().forEach(
           done();
         });
 
-        it('Verify that rpcClient.getEndorsingRights retrieves the list of delegates allowed to endorse a block', async (done) => {
+        unrestrictedRPCNode('Verify that rpcClient.getEndorsingRights retrieves the list of delegates allowed to endorse a block', async (done) => {
           const endorsingRights = await rpcClient.getEndorsingRights();
           expect(endorsingRights).toBeDefined();
           expect(endorsingRights[0].delegates).toBeDefined();


### PR DESCRIPTION
External PRs from users outside our `ecadlabs` GH org don't have access to GH Secrets. This is an intended behaviour to avoid exposing sensitive keys and tokens to third parties.

We block some resource-intensive RPC endpoints from our public-facing nodes. Since some integration tests need to contact these RPC endpoints we let GH runners join our private network and contact internal RPC Tezos nodes directly.  GH Runners use GH Secrets to join our Tailscale private network.

This PR refactors the GH workflows and skips the `baking_rights` and `endorsing_rights` tests when an external user submits a PR to Taquito. Additionally, we set the keygen `keyURL` to point to the publicly accessible keygen instance so that we can request keys without having to login to our private network. 

I've also added a condition to skip the `deploy-edge-package` workflow on external PRs. Similarly to what I mentioned above, Github Secrets aren't available on external PRs and this job would always fail as it requires a secret to publish the packages on Verdaccio. Also, this is a security consideration as we don't want to allow external users to arbitrarily publish packages to an NPM registry.

## Test Plan

Opened a PR as an external contributor and confirmed that:
 - the Tailscale job is skipped
 - Integration test the public RPC endpoint

Example workflow run from an external PR https://github.com/ecadlabs/taquito/pull/2223/checks 
