### PR TITLE
updated constant value for current protocol hash

### DIFF
--- a/packages/taquito-local-forging/src/taquito-local-forging.ts
+++ b/packages/taquito-local-forging/src/taquito-local-forging.ts
@@ -23,7 +23,7 @@ export * from './interface';
 export { VERSION } from './version';
 export { ProtocolsHash } from './protocols';
 
-const PROTOCOL_CURRENT = ProtocolsHash.PtKathman;
+const PROTOCOL_CURRENT = ProtocolsHash.PtLimaPtL;
 
 export function getCodec(codec: CODEC, _proto: ProtocolsHash) {
   // use proto14 encoders & decoders if it's kathmandu or prior


### PR DESCRIPTION
closes #2242 

Hotfix for bug where Lima protocol hash values aren't updated.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have added unit tests
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
