### PR TITLE
fix bytes in signing data example

### DIFF
--- a/docs/signing.md
+++ b/docs/signing.md
@@ -55,7 +55,7 @@ import { char2Bytes } from '@taquito/utils';
 
     const bytes = char2Bytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16)
-    const addPadding = `0000${bytesLength}`
+    const addPadding = `00000000${bytesLength}`
     const paddedBytesLength = addPadding.slice(addPadding.length - 4)
     const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -56,7 +56,7 @@ import { char2Bytes } from '@taquito/utils';
     const bytes = char2Bytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16)
     const addPadding = `00000000${bytesLength}`
-    const paddedBytesLength = addPadding.slice(addPadding.length - 4)
+    const paddedBytesLength = addPadding.slice(addPadding.length - 8)
     const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
 
 ```

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -63,7 +63,7 @@ The bytes representation of the string must be prefixed with 5 pieces of informa
 - "0x" add zero-padding
 - "05" indicates that this is a Micheline expression
 - "01" indicates that a string was converted to bytes
-- the number of characters in the bytes (hexadecimal string divided by 2) string encoded on 4 bytes as string 
+- the number of characters in the bytes (hexadecimal string divided by 2) encoded on 4 bytes
 - bytes of formatted input to be signed
 
 Once you have your bytes, you can send them to the wallet to have them signed:

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -53,8 +53,11 @@ After formatting the string properly, you can convert it into bytes, for example
 ```js
 import { char2Bytes } from '@taquito/utils';
 
-const bytes = char2Bytes(formattedInput);
-const payloadBytes = '0x' + '05' + '0100' + char2Bytes((bytes.length / 2).toString()) + bytes;
+    const bytes = char2Bytes(formattedInput);
+    const bytesLength = (bytes.length / 2).toString(16)
+    const addPadding = `0000${bytesLength}`
+    const paddedBytesLength = addPadding.slice(addPadding.length - 4)
+    const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
 
 ```
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -60,10 +60,10 @@ const paddedBytesLength = addPadding.slice(addPadding.length - 8);
 const payloadBytes = '05' + '01' + paddedBytesLength + bytes;
 ```
 
-The bytes representation of the string must be prefixed with 4 pieces of information:
+The hexadecimal/Micheline representation of the string must contain 4 pieces of information:
 
 - "05" indicates that this is a Micheline expression
-- "01" indicates that a string was converted to bytes
+- "01" indicates that the data is a Micheline string
 - the number of characters in the bytes (hexadecimal string divided by 2) encoded on 4 bytes
 - bytes of formatted input to be signed
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -54,7 +54,8 @@ After formatting the string properly, you can convert it into bytes, for example
 import { char2Bytes } from '@taquito/utils';
 
 const bytes = char2Bytes(formattedInput);
-const payloadBytes = '0x' + '05' + '0100' + char2Bytes(bytes.length / 2) + bytes;
+const payloadBytes = '0x' + '05' + '0100' + char2Bytes((bytes.length / 2).toString()) + bytes;
+
 ```
 
 The bytes representation of the string must be prefixed with 3 pieces of information:

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -53,17 +53,15 @@ After formatting the string properly, you can convert it into bytes, for example
 ```js
 import { char2Bytes } from '@taquito/utils';
 
-    const bytes = char2Bytes(formattedInput);
-    const bytesLength = (bytes.length / 2).toString(16)
-    const addPadding = `00000000${bytesLength}`
-    const paddedBytesLength = addPadding.slice(addPadding.length - 8)
-    const payloadBytes = '0x' + '05' + '01' + paddedBytesLength + bytes;
-
+const bytes = char2Bytes(formattedInput);
+const bytesLength = (bytes.length / 2).toString(16);
+const addPadding = `00000000${bytesLength}`;
+const paddedBytesLength = addPadding.slice(addPadding.length - 8);
+const payloadBytes = '05' + '01' + paddedBytesLength + bytes;
 ```
 
-The bytes representation of the string must be prefixed with 5 pieces of information:
+The bytes representation of the string must be prefixed with 4 pieces of information:
 
-- "0x" add zero-padding
 - "05" indicates that this is a Micheline expression
 - "01" indicates that a string was converted to bytes
 - the number of characters in the bytes (hexadecimal string divided by 2) encoded on 4 bytes
@@ -131,9 +129,13 @@ const { signature } = signedPayload;
 To verify that the previously generated signature has actually been signed by a wallet, you can use the `veryfySignature` method from the Taquito utils. Here is an example where we check if the payload has been signed by the client wallet, using their public key:
 
 ```js
-import {verifySignature} from "@taquito/utils";
+import { verifySignature } from '@taquito/utils';
 
-const isVerified = verifySignature(payloadBytes, (await wallet.client.getActiveAccount()).publicKey, signature)
+const isVerified = verifySignature(
+  payloadBytes,
+  (await wallet.client.getActiveAccount()).publicKey,
+  signature
+);
 ```
 
 ## Signing Michelson data
@@ -160,9 +162,10 @@ const packed = packDataBytes(
   dataJSON, // as MichelsonData
   typeJSON // as MichelsonType
 );
-Tezos.signer.sign(packed.bytes)
-.then((signed) => println(JSON.stringify(signed, null, 2)))
-.catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
+Tezos.signer
+  .sign(packed.bytes)
+  .then((signed) => println(JSON.stringify(signed, null, 2)))
+  .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
 
 First, you provide the Michelson code to be signed as a string along with its type.  
@@ -180,7 +183,9 @@ After forging a signature, you may want to send it to a contract so it can use i
 
 ```js
 const contract = await Tezos.wallet.at(CONTRACT_ADDRESS);
-const op = await contract.methods.check_signature(public_key, signature, payloadBytes).send();
+const op = await contract.methods
+  .check_signature(public_key, signature, payloadBytes)
+  .send();
 await op.confirmation();
 ```
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -57,7 +57,7 @@ import { char2Bytes } from '@taquito/utils';
     const bytesLength = (bytes.length / 2).toString(16)
     const addPadding = `00000000${bytesLength}`
     const paddedBytesLength = addPadding.slice(addPadding.length - 8)
-    const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
+    const payloadBytes = '0x' + '05' + '01' + paddedBytesLength + bytes;
 
 ```
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -54,7 +54,7 @@ After formatting the string properly, you can convert it into bytes, for example
 import { char2Bytes } from '@taquito/utils';
 
 const bytes = char2Bytes(formattedInput);
-const payloadBytes = '05' + '0100' + char2Bytes(bytes.length) + bytes;
+const payloadBytes = '0x' + '05' + '0100' + char2Bytes(bytes.length / 2) + bytes;
 ```
 
 The bytes representation of the string must be prefixed with 3 pieces of information:

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -54,7 +54,7 @@ After formatting the string properly, you can convert it into bytes, for example
 import { char2Bytes } from '@taquito/utils';
 
 const bytes = char2Bytes(formattedInput);
-const payloadBytes = '0x' + '05' + '01' + `00${char2Bytes((bytes.length / 2).toString())}` + bytes;
+const payloadBytes = '0x' + '05' + '0100' + char2Bytes((bytes.length / 2).toString()) + bytes;
 
 ```
 
@@ -63,8 +63,8 @@ The bytes representation of the string must be prefixed with 5 pieces of informa
 - "0x" add zero-padding
 - "05" indicates that this is a Micheline expression
 - "01" indicates that a string was converted to bytes
-- the number of characters in the byte string encoded on 4 bytes as string
-- bytes of input
+- the number of characters in the bytes (hexadecimal string divided by 2) string encoded on 4 bytes as string 
+- bytes of formatted input to be signed
 
 Once you have your bytes, you can send them to the wallet to have them signed:
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -54,15 +54,17 @@ After formatting the string properly, you can convert it into bytes, for example
 import { char2Bytes } from '@taquito/utils';
 
 const bytes = char2Bytes(formattedInput);
-const payloadBytes = '0x' + '05' + '0100' + char2Bytes((bytes.length / 2).toString()) + bytes;
+const payloadBytes = '0x' + '05' + '01' + `00${char2Bytes((bytes.length / 2).toString())}` + bytes;
 
 ```
 
-The bytes representation of the string must be prefixed with 3 pieces of information:
+The bytes representation of the string must be prefixed with 5 pieces of information:
 
+- "0x" add zero-padding
 - "05" indicates that this is a Micheline expression
 - "01" indicates that a string was converted to bytes
-- the number of characters in the byte string encoded on 4 bytes
+- the number of characters in the byte string encoded on 4 bytes as string
+- bytes of input
 
 Once you have your bytes, you can send them to the wallet to have them signed:
 

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -33,7 +33,7 @@ describe('Format', () => {
 
     const bytes = char2Bytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16)
-    const addPadding = `0000${bytesLength}`
+    const addPadding = `00000000${bytesLength}`
     const paddedBytesLength = addPadding.slice(addPadding.length - 4)
     const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
     expect(payloadBytes).toBeDefined();

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -35,7 +35,9 @@ describe('Format', () => {
     const bytesLength = (bytes.length / 2).toString(16)
     const addPadding = `00000000${bytesLength}`
     const paddedBytesLength = addPadding.slice(addPadding.length - 8)
-    const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
+    const payloadBytes = '0x' + '05' + '01' + paddedBytesLength + bytes;
+
+    console.log(payloadBytes)
     expect(payloadBytes).toBeDefined();
   })
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -32,7 +32,10 @@ describe('Format', () => {
     ].join(' ');
 
     const bytes = char2Bytes(formattedInput);
-    const payloadBytes = '0x' + '05' + '01' + `00${char2Bytes((bytes.length / 2).toString())}` + bytes;
+    const bytesLength = (bytes.length / 2).toString(16)
+    const addPadding = `0000${bytesLength}`
+    const paddedBytesLength = addPadding.slice(addPadding.length - 4)
+    const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
     expect(payloadBytes).toBeDefined();
   })
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -1,6 +1,6 @@
 import { format } from '../src/format';
 import BigNumber from 'bignumber.js';
-import { char2Bytes } from '../src/taquito-utils'
+import { char2Bytes } from '../src/taquito-utils';
 
 describe('Format', () => {
   it('Should convert mutez to tz', () => {
@@ -32,13 +32,13 @@ describe('Format', () => {
     ].join(' ');
 
     const bytes = char2Bytes(formattedInput);
-    const bytesLength = (bytes.length / 2).toString(16)
-    const addPadding = `00000000${bytesLength}`
-    const paddedBytesLength = addPadding.slice(addPadding.length - 8)
-    const payloadBytes = '0x' + '05' + '01' + paddedBytesLength + bytes;
-    const regex = new RegExp('^(0x|0X)?[a-fA-F0-9]+$')
-    const check = regex.test(payloadBytes)
+    const bytesLength = (bytes.length / 2).toString(16);
+    const addPadding = `00000000${bytesLength}`;
+    const paddedBytesLength = addPadding.slice(addPadding.length - 8);
+    const payloadBytes = '05' + '01' + paddedBytesLength + bytes;
+    const regex = new RegExp('^(0x|0X)?[a-fA-F0-9]+$');
+    const check = regex.test(payloadBytes);
     expect(check).toEqual(true);
-    expect(payloadBytes.length % 2).toEqual(0)
-  })
+    expect(payloadBytes.length % 2).toEqual(0);
+  });
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -36,8 +36,9 @@ describe('Format', () => {
     const addPadding = `00000000${bytesLength}`
     const paddedBytesLength = addPadding.slice(addPadding.length - 8)
     const payloadBytes = '0x' + '05' + '01' + paddedBytesLength + bytes;
-
-    console.log(payloadBytes)
-    expect(payloadBytes).toBeDefined();
+    const regex = new RegExp('^(0x|0X)?[a-fA-F0-9]+$')
+    const check = regex.test(payloadBytes)
+    expect(check).toEqual(true);
+    expect(payloadBytes.length % 2).toEqual(0)
   })
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -1,5 +1,6 @@
 import { format } from '../src/format';
 import BigNumber from 'bignumber.js';
+import { char2Bytes } from '../src/taquito-utils'
 
 describe('Format', () => {
   it('Should convert mutez to tz', () => {
@@ -21,4 +22,18 @@ describe('Format', () => {
   it('Should convert tz to mutez', () => {
     expect(format('tz', 'mutez', 1)).toEqual(new BigNumber(1000000));
   });
+
+  it('Should be valid bytes tezostaquito example', () => {
+    const formattedInput: string = [
+      'Tezos Signed Message:',
+      'some url',
+      '18:43:34Z',
+      'something',
+    ].join(' ');
+
+
+    const bytes = char2Bytes(formattedInput);
+    const payloadBytes = '0x' + '05' + '0100' + char2Bytes((bytes.length / 2).toString()) + bytes;
+    expect(payloadBytes).toBeDefined();
+  })
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -23,7 +23,7 @@ describe('Format', () => {
     expect(format('tz', 'mutez', 1)).toEqual(new BigNumber(1000000));
   });
 
-  it('Should be valid bytes tezostaquito example', () => {
+  it('Should be valid bytes tezostaquito example https://tezostaquito.io/docs/next/signing#generating-a-signature-with-beacon-sdk with proper padding for bytes length', () => {
     const formattedInput: string = [
       'Tezos Signed Message:',
       'some url',

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -23,6 +23,9 @@ describe('Format', () => {
     expect(format('tz', 'mutez', 1)).toEqual(new BigNumber(1000000));
   });
 
+});
+
+describe('tezostaquito.io example signing formatting', () => {
   it('Should be valid bytes tezostaquito example https://tezostaquito.io/docs/next/signing#generating-a-signature-with-beacon-sdk with proper padding for bytes length', () => {
     const formattedInput: string = [
       'Tezos Signed Message:',

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -34,7 +34,7 @@ describe('Format', () => {
     const bytes = char2Bytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16)
     const addPadding = `00000000${bytesLength}`
-    const paddedBytesLength = addPadding.slice(addPadding.length - 4)
+    const paddedBytesLength = addPadding.slice(addPadding.length - 8)
     const payloadBytes = '0x' + '05' + '0100' + char2Bytes(paddedBytesLength) + bytes;
     expect(payloadBytes).toBeDefined();
   })

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -31,9 +31,8 @@ describe('Format', () => {
       'something',
     ].join(' ');
 
-
     const bytes = char2Bytes(formattedInput);
-    const payloadBytes = '0x' + '05' + '0100' + char2Bytes((bytes.length / 2).toString()) + bytes;
+    const payloadBytes = '0x' + '05' + '01' + `00${char2Bytes((bytes.length / 2).toString())}` + bytes;
     expect(payloadBytes).toBeDefined();
   })
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -1,6 +1,6 @@
 import { format } from '../src/format';
 import BigNumber from 'bignumber.js';
-import { char2Bytes } from '../src/taquito-utils';
+import { bytes2Char, char2Bytes } from '../src/taquito-utils';
 
 describe('Format', () => {
   it('Should convert mutez to tz', () => {
@@ -40,5 +40,6 @@ describe('Format', () => {
     const check = regex.test(payloadBytes);
     expect(check).toEqual(true);
     expect(payloadBytes.length % 2).toEqual(0);
+    expect(bytes2Char(payloadBytes)).toEqual(bytes2Char('05' + '01' + paddedBytesLength) + formattedInput);
   });
 });


### PR DESCRIPTION
update bytes length to have padding and divide hex string length to bytes length


closes #2185 