### PR TITLE
2020 prepare provider

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,12 +3,17 @@ Thank you for your contribution to Taquito.
 Before submitting this PR, please make sure:
 
 - [ ] Your code builds cleanly without any errors or warnings
-- [ ] You have added unit tests
+- [ ] You have run the linter against the changes
+- [ ] You have added unit tests (if relevant/appropriate)
 - [ ] You have added integration tests (if relevant/appropriate)
 - [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
 - [ ] You have added or updated corresponding documentation
 - [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 
 
+In this PR, please also make sure: 
+
+- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
+- [ ] You have added a concise description on your changes
 ## Release Note Draft Snippet
 
 __If relevant, please write a summary of your change that will be suitable for

--- a/docs/prepare.md
+++ b/docs/prepare.md
@@ -62,11 +62,3 @@ activation({ operation, source }: PrepareOperationParams): Promise<PreparedOpera
 - `source` is the source public key hash if you do wish to override the source. This parameter is optional by design. If you do not wish to override it, the source will be grabbed from the `Context`.
 
 `RPCOperation` is really just a combination of the Operation parameters and the estimates of said operation (fee, gas limit, and storage limit estimates). _**Note**_ that this might be amended in the future to make passing parameters a bit more user friendly. 
-
-
-
-
-
-
-
-

--- a/docs/prepare.md
+++ b/docs/prepare.md
@@ -1,0 +1,72 @@
+---
+title: Preparing Operations
+author: Davis Sawali
+---
+
+
+:::warning
+This feature is currently a work in progress and may be updated in the near future.
+:::
+
+
+Before operations are _forged_, _signed_, and then _injected_, it first needs to go through the _Prepare_ step.
+
+In Taquito, the act of preparing an operation is to create the Operation Object (`opOb`) and the counter in one single object that we name `PreparedOperation`.
+
+A `PreparedOperation` object for a `ballot` operation looks something like this:
+```typescript
+{
+  opOb: {
+    branch: 'test_block_hash',
+    contents: [
+      {
+        kind: 'ballot',
+        ballot: 'yay',
+        period: 103,
+        proposal: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+      },
+    ],
+    protocol: 'test_protocol',
+  },
+  counter: 0,
+}
+```
+
+To promote modularity and extend control to the users, we decided to implement a class that helps in Preparing operations.
+
+## Usage example
+
+### Individual Operations
+The `PrepareProvider` will be accessible via the `TezosToolkit` class as such:
+```typescript
+const Tezos = new TezosToolkit('RPC_ENDPOINT');
+
+const prepared = await Tezos.prepare.transaction({ operation: {
+  kind: OpKind.TRANSACTION,
+  fee: 1,
+  gas_limit: 2,
+  storage_limit: 2,
+  amount: '5',
+  destination: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+}});
+```
+
+Let's break that transaction prepare call down.
+
+The interface of the `transaction` member method is as follows:
+```typescript
+activation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+```
+
+- `operation` is the `RPCOperation` type object. It is a union type of various other Tezos RPCOperation types that we support in Taquito
+- `source` is the source public key hash if you do wish to override the source. This parameter is optional by design. If you do not wish to override it, the source will be grabbed from the `Context`.
+
+`RPCOperation` is really just a combination of the Operation parameters and the estimates of said operation (fee, gas limit, and storage limit estimates). _**Note**_ that this might be amended in the future to make passing parameters a bit more user friendly. 
+
+
+
+
+
+
+
+

--- a/integration-tests/prepare-operation.spec.ts
+++ b/integration-tests/prepare-operation.spec.ts
@@ -1,0 +1,42 @@
+import { 
+  OpKind, 
+  RPCOriginationOperation, 
+  DEFAULT_FEE, 
+  DEFAULT_GAS_LIMIT, 
+  DEFAULT_STORAGE_LIMIT, 
+  RPCBallotOperation,
+  PreparedOperation
+} from '@taquito/taquito';
+import { CONFIGS } from './config';
+
+
+
+CONFIGS().forEach(({ lib, setup }) => {
+  const Tezos = lib;
+
+  describe(`Test Preparation of operations using the PrepareProvider`, () => {
+    beforeEach(async (done) => {
+      await setup();
+      done();
+    });
+
+    it('should be able to prepare a ballot operation', async (done) => {
+      const prepared = await Tezos.prepare.ballot({ operation: 
+        {
+          kind: OpKind.BALLOT,
+          proposal: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+          ballot: 'yay', 
+        } as RPCBallotOperation 
+      });
+
+      expect(prepared).toBeDefined();
+      expect(prepared.counter).toBeDefined();
+      expect(prepared.opOb).toBeDefined();
+      expect(prepared.opOb.branch).toBeDefined();
+      expect(prepared.opOb.contents).toBeDefined();
+      expect(prepared.opOb.protocol).toBeDefined();
+
+      done();
+    });
+  });
+}) 

--- a/integration-tests/prepare-operation.spec.ts
+++ b/integration-tests/prepare-operation.spec.ts
@@ -1,22 +1,39 @@
 import { 
   OpKind, 
-  RPCOriginationOperation, 
-  DEFAULT_FEE, 
-  DEFAULT_GAS_LIMIT, 
-  DEFAULT_STORAGE_LIMIT, 
   RPCBallotOperation,
-  PreparedOperation
 } from '@taquito/taquito';
 import { CONFIGS } from './config';
 
-
-
 CONFIGS().forEach(({ lib, setup }) => {
   const Tezos = lib;
+  let contractAddress: string;
 
   describe(`Test Preparation of operations using the PrepareProvider`, () => {
-    beforeEach(async (done) => {
+    beforeAll(async (done) => {
       await setup();
+      
+      try {
+        const op = await Tezos.contract.originate({
+          code: `{ parameter (or (or (int %decrement) (int %increment)) (unit %reset)) ;
+            storage int ;
+            code { UNPAIR ;
+                   IF_LEFT { IF_LEFT { SWAP ; SUB } { ADD } } { DROP 2 ; PUSH int 0 } ;
+                   NIL operation ;
+                   PAIR } }`,
+          storage: 1
+        });
+        await op.confirmation();
+
+        contractAddress = op.contractAddress!;
+
+      } catch(e: any) {
+        console.log('Unable to originate contract: ', JSON.stringify(e));
+      }
+
+      done();
+    })
+    
+    beforeEach(async (done) => {
       done();
     });
 
@@ -38,5 +55,20 @@ CONFIGS().forEach(({ lib, setup }) => {
 
       done();
     });
+
+    it('should be able to prepare a contractCall', async (done) => {
+      const contractAbs = await Tezos.contract.at(contractAddress);
+      const method = await contractAbs.methods.increment(1);
+      const prepared = await Tezos.prepare.contractCall(method);
+
+      expect(prepared).toBeDefined();
+      expect(prepared.counter).toBeDefined();
+      expect(prepared.opOb.branch).toBeDefined();
+      expect(prepared.opOb.contents).toBeDefined();
+      expect(prepared.opOb.protocol).toBeDefined();
+
+      done();
+    })
   });
+
 }) 

--- a/packages/taquito/src/context.ts
+++ b/packages/taquito/src/context.ts
@@ -24,6 +24,7 @@ import { RpcReadAdapter } from './read-provider/rpc-read-adapter';
 import { SubscribeProvider } from './subscribe/interface';
 import { PollingSubscribeProvider } from './subscribe/polling-subcribe-provider';
 import { TaquitoLocalForger } from './forger/taquito-local-forger';
+import { PrepareProvider } from './prepare/prepare-provider';
 
 export interface TaquitoProvider<T, K extends Array<any>> {
   new (context: Context, ...rest: K): T;
@@ -57,6 +58,7 @@ export class Context {
   public readonly tz = new RpcTzProvider(this);
   public readonly estimate = new RPCEstimateProvider(this);
   public readonly contract = new RpcContractProvider(this, this.estimate);
+  public readonly prepare = new PrepareProvider(this);
   public readonly batch = new RPCBatchProvider(this, this.estimate);
   public readonly wallet = new Wallet(this);
 

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -154,7 +154,16 @@ export interface ContractProvider extends StorageProvider {
    */
   transfer(params: TransferParams): Promise<TransactionOperation>;
 
+  /**
+   *
+   * @description Transfer tickets from L2 to a smart contract address
+   *
+   * @returns An operation handle with the result from the rpc node
+   *
+   * @param TransferTicket operation parameter
+   */
   transferTicket(params: TransferTicketParams): Promise<TransferTicketOperation>;
+
   /**
    *
    * @description Reveal the current address. Will throw an error if the address is already revealed.

--- a/packages/taquito/src/error.ts
+++ b/packages/taquito/src/error.ts
@@ -37,3 +37,10 @@ export class RPCResponseError extends Error {
     super(message);
   }
 }
+
+export class InvalidPrepareParamsError extends Error {
+  public name = 'InvalidOperationParamsError';
+  constructor(public opKind: string) {
+    super(`No '${opKind}' operation parameters have been passed`);
+  }
+}

--- a/packages/taquito/src/error.ts
+++ b/packages/taquito/src/error.ts
@@ -31,6 +31,10 @@ export class InvalidFilterExpressionError extends Error {
   }
 }
 
+/**
+ *  @category Error
+ *  @description Error that indicates an error being returned from the RPC response
+ */
 export class RPCResponseError extends Error {
   public name = 'RPCResponseError';
   constructor(public message: string) {
@@ -38,6 +42,10 @@ export class RPCResponseError extends Error {
   }
 }
 
+/**
+ *  @category Error
+ *  @description Error that indicates invalid Preparation parameters being passed
+ */
 export class InvalidPrepareParamsError extends Error {
   public name = 'InvalidOperationParamsError';
   constructor(public opKind: string) {

--- a/packages/taquito/src/prepare/index.ts
+++ b/packages/taquito/src/prepare/index.ts
@@ -1,0 +1,2 @@
+export * from './interface';
+export * from './prepare-provider';

--- a/packages/taquito/src/prepare/interface.ts
+++ b/packages/taquito/src/prepare/interface.ts
@@ -1,5 +1,8 @@
 import { OperationContents } from '@taquito/rpc';
 import { PrepareOperationParams } from '../operations/types';
+import { ContractMethod } from '../contract/contract-methods/contract-method-flat-param';
+import { ContractMethodObject } from '../contract/contract-methods/contract-method-object-param';
+import { ContractProvider } from '../contract/interface';
 
 /**
  * @description PrepareProvider is a utility class to output the prepared format of an operation
@@ -165,6 +168,18 @@ export interface PreparationProvider {
    * @returns a PreparedOperation object
    */
   batch({ operation }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  /**
+   *
+   * @description Method to prepare a contract call (transfer) operation
+   *
+   * @param contractMethod ContractMethod or ContractMethodObject retrieved from smart contract
+   *
+   * @returns a PreparedOperation object
+   */
+  contractCall(
+    contractMethod: ContractMethod<ContractProvider> | ContractMethodObject<ContractProvider>
+  ): Promise<PreparedOperation>;
 }
 
 export interface PreparedOperation {

--- a/packages/taquito/src/prepare/interface.ts
+++ b/packages/taquito/src/prepare/interface.ts
@@ -1,10 +1,34 @@
 import { OperationContents } from '@taquito/rpc';
-// import { RPCOriginationOperation, RPCTransferOperation } from '../operations';
 import { PrepareOperationParams } from '../operations/types';
-export interface Preparation {
+
+export interface PreparationProvider {
+  reveal({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
   originate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
-  // transaction(op: RPCTransferOperation, source?: string): Promise<PreparedOperation>;
+  transaction({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  activation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  delegation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  registerGlobalConstant({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  txRollupOrigination({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  txRollupSubmitBatch({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  updateConsensusKey({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  transferTicket({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  increasePaidStorage({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  ballot({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  proposals({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  drainDelegate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 }
 
 export interface PreparedOperation {

--- a/packages/taquito/src/prepare/interface.ts
+++ b/packages/taquito/src/prepare/interface.ts
@@ -1,34 +1,170 @@
 import { OperationContents } from '@taquito/rpc';
 import { PrepareOperationParams } from '../operations/types';
 
+/**
+ * @description PrepareProvider is a utility class to output the prepared format of an operation
+ */
 export interface PreparationProvider {
+  /**
+   *
+   * @description Method to prepare a reveal operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   reveal({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a origination operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   originate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a transaction operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   transaction({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare an activation operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   activation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a delegation operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   delegation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a register_global_constant operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   registerGlobalConstant({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a tx_rollup_origination operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   txRollupOrigination({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a tx_rollup_submit_batch operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   txRollupSubmitBatch({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a update_consensus_key operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   updateConsensusKey({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a transfer_ticket operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   transferTicket({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a increase_paid_storage operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   increasePaidStorage({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
-  ballot({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+  /**
+   *
+   * @description Method to prepare a ballot operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
+  ballot({ operation }: PrepareOperationParams): Promise<PreparedOperation>;
 
+  /**
+   *
+   * @description Method to prepare a proposals operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
   proposals({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
-  drainDelegate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
+  /**
+   *
+   * @description Method to prepare a drain_delegate operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
+  drainDelegate({ operation }: PrepareOperationParams): Promise<PreparedOperation>;
+
+  /**
+   *
+   * @description Method to prepare a batch operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
+  batch({ operation }: PrepareOperationParams): Promise<PreparedOperation>;
 }
 
 export interface PreparedOperation {

--- a/packages/taquito/src/prepare/interface.ts
+++ b/packages/taquito/src/prepare/interface.ts
@@ -1,10 +1,10 @@
 import { OperationContents } from '@taquito/rpc';
-import { RPCOriginationOperation, RPCTransferOperation } from '../operations';
-
+// import { RPCOriginationOperation, RPCTransferOperation } from '../operations';
+import { PrepareOperationParams } from '../operations/types';
 export interface Preparation {
-  originate(op: RPCOriginationOperation, source?: string): Promise<PreparedOperation>;
+  originate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation>;
 
-  transaction(op: RPCTransferOperation, source?: string): Promise<PreparedOperation>;
+  // transaction(op: RPCTransferOperation, source?: string): Promise<PreparedOperation>;
 }
 
 export interface PreparedOperation {

--- a/packages/taquito/src/prepare/interface.ts
+++ b/packages/taquito/src/prepare/interface.ts
@@ -1,0 +1,17 @@
+import { OperationContents } from '@taquito/rpc';
+import { RPCOriginationOperation, RPCTransferOperation } from '../operations';
+
+export interface Preparation {
+  originate(op: RPCOriginationOperation, source?: string): Promise<PreparedOperation>;
+
+  transaction(op: RPCTransferOperation, source?: string): Promise<PreparedOperation>;
+}
+
+export interface PreparedOperation {
+  opOb: {
+    branch: string;
+    contents: OperationContents[];
+    protocol: string;
+  };
+  counter: number;
+}

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -1,0 +1,141 @@
+import { RpcClientInterface, OperationContents } from '@taquito/rpc';
+import { Context } from '../context';
+import { RPCOpWithFee, RPCOriginationOperation, RPCTransferOperation } from '../operations';
+import { Preparation, PreparedOperation } from './interface';
+
+export class PrepareProvider implements Preparation {
+  #counters: { [key: string]: number };
+  // context: Context
+  constructor(protected context: Context) {
+    this.#counters = {};
+    // this.context = context;
+  }
+
+  get rpc(): RpcClientInterface {
+    return this.context.rpc;
+  }
+
+  get signer() {
+    return this.context.signer;
+  }
+
+  private async getPkh() {
+    return await this.context.signer.publicKeyHash();
+  }
+
+  private async getBlockHash() {
+    return this.context.readProvider.getBlockHash('head~2');
+  }
+
+  private async getProtocolHash() {
+    return this.context.readProvider.getNextProtocol('head');
+  }
+
+  private async getHeadCounter(pkh: string): Promise<string | undefined> {
+    // const pkh = await this.signer.publicKeyHash();
+    return this.context.readProvider.getCounter(pkh, 'head');
+  }
+
+  private async checkAndUpdateCounter(pkh: string) {
+    const headCounter = await this.getHeadCounter(pkh);
+
+    // assign 0 to counter if it has no operations yet
+    const counter = parseInt(headCounter ?? '0', 10);
+    if (!this.#counters[pkh] || this.#counters[pkh] < counter) {
+      this.#counters[pkh] = counter;
+    }
+
+    return ++this.#counters[pkh];
+  }
+
+  private async getFee(op: RPCOpWithFee, pkh: string) {
+    // const pkh = await this.getPkh()
+
+    // const headCounter = await this.getHeadCounter(pkh);
+
+    // // TODO: figure out if should bring counter out to each operation instead
+
+    // // assign 0 to counter if it has no operations yet
+    // const counter = parseInt(headCounter ?? '0', 10)
+    // if (!this.#counters[pkh] || this.#counters[pkh] < counter) {
+    //   this.#counters[pkh] = counter;
+    // }
+    const opCounter = this.checkAndUpdateCounter(pkh);
+
+    return {
+      counter: `${opCounter}`,
+      fee: typeof op.fee === 'undefined' ? '0' : `${op.fee}`,
+      gas_limit: typeof op.gas_limit === 'undefined' ? '0' : `${op.gas_limit}`,
+      storage_limit: typeof op.storage_limit === 'undefined' ? '0' : `${op.storage_limit}`,
+    };
+  }
+
+  async originate(op: RPCOriginationOperation, source?: string): Promise<PreparedOperation> {
+    // TODO: CHECK REVEAL OP
+    const pkh = await this.signer.publicKeyHash();
+    const balance = typeof op.balance !== 'undefined' ? `${op.balance}` : '0';
+    const checkedSource = { source: typeof op.source === 'undefined' ? source || pkh : op.source };
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+    const fee = await this.getFee(op, pkh);
+
+    // TODO: possibly write updateCounter() instead for consistency instead of using getFee()
+    const contents = [
+      {
+        ...op,
+        balance,
+        ...checkedSource,
+        ...fee,
+      },
+    ] as OperationContents[];
+
+    const counter = this.#counters[pkh];
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter,
+    };
+  }
+
+  async transaction(op: RPCTransferOperation, source?: string): Promise<PreparedOperation> {
+    const pkh = await this.signer.publicKeyHash();
+    const amount = typeof op.amount !== 'undefined' ? `${op.amount}` : '0';
+    const checkedSource = { source: typeof op.source === 'undefined' ? source || pkh : op.source };
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+    const fee = await this.getFee(op, pkh);
+
+    const contents = [
+      {
+        ...op,
+        amount,
+        ...checkedSource,
+        ...fee,
+      },
+    ] as OperationContents[];
+
+    const counter = this.#counters[pkh];
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter,
+    };
+  }
+
+  // async reveal(op: RPCRevealOperation, source?: string): Promise<PreparedOperation> {
+  //   const pkh = await this.signer.publicKeyHash();
+
+  //   const hash
+
+  // }
+}

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -1,7 +1,26 @@
-import { RpcClientInterface, OperationContents } from '@taquito/rpc';
-import { Context } from '../context';
-import { RPCOpWithFee, RPCOriginationOperation, RPCTransferOperation } from '../operations';
+import {
+  RpcClientInterface,
+  OperationContents,
+  OpKind,
+  VotingPeriodBlockResult,
+} from '@taquito/rpc';
+import {
+  PrepareOperationParams,
+  RPCOperation,
+  RPCOpWithFee,
+  RPCOpWithSource,
+} from '../operations/types';
 import { Preparation, PreparedOperation } from './interface';
+import { Protocols } from '../constants';
+import { InvalidOperationKindError, DeprecationError } from '@taquito/utils';
+import { RPCResponseError, InvalidPrepareParamsError } from '../error';
+import { Context } from '../context';
+
+const validateOpKindParams = (operations: RPCOperation[], opKind: string) => {
+  return operations.some((x) => {
+    return x.kind === opKind;
+  });
+};
 
 export class PrepareProvider implements Preparation {
   #counters: { [key: string]: number };
@@ -31,36 +50,15 @@ export class PrepareProvider implements Preparation {
     return this.context.readProvider.getNextProtocol('head');
   }
 
-  private async getHeadCounter(pkh: string): Promise<string | undefined> {
-    // const pkh = await this.signer.publicKeyHash();
-    return this.context.readProvider.getCounter(pkh, 'head');
+  private async getHeadCounter(pkh: string): Promise<string> {
+    return this.context.readProvider.getCounter(pkh, 'head') ?? '0';
   }
 
-  private async checkAndUpdateCounter(pkh: string) {
-    const headCounter = await this.getHeadCounter(pkh);
-
-    // assign 0 to counter if it has no operations yet
-    const counter = parseInt(headCounter ?? '0', 10);
-    if (!this.#counters[pkh] || this.#counters[pkh] < counter) {
-      this.#counters[pkh] = counter;
+  private getFee(op: RPCOpWithFee, pkh: string, headCounter: number) {
+    if (!this.#counters[pkh] || this.#counters[pkh] < headCounter) {
+      this.#counters[pkh] = headCounter;
     }
-
-    return ++this.#counters[pkh];
-  }
-
-  private async getFee(op: RPCOpWithFee, pkh: string) {
-    // const pkh = await this.getPkh()
-
-    // const headCounter = await this.getHeadCounter(pkh);
-
-    // // TODO: figure out if should bring counter out to each operation instead
-
-    // // assign 0 to counter if it has no operations yet
-    // const counter = parseInt(headCounter ?? '0', 10)
-    // if (!this.#counters[pkh] || this.#counters[pkh] < counter) {
-    //   this.#counters[pkh] = counter;
-    // }
-    const opCounter = this.checkAndUpdateCounter(pkh);
+    const opCounter = ++this.#counters[pkh];
 
     return {
       counter: `${opCounter}`,
@@ -70,27 +68,115 @@ export class PrepareProvider implements Preparation {
     };
   }
 
-  async originate(op: RPCOriginationOperation, source?: string): Promise<PreparedOperation> {
-    // TODO: CHECK REVEAL OP
+  private getSource(op: RPCOpWithSource, pkh: string, source: string | undefined) {
+    return { source: typeof op.source === 'undefined' ? source || pkh : op.source };
+  }
+
+  private convertIntoArray(op: RPCOperation | RPCOperation[]): RPCOperation[] {
+    if (Array.isArray(op)) {
+      return [...op];
+    } else {
+      return [op];
+    }
+  }
+
+  private constructOpContents(
+    ops: RPCOperation[],
+    headCounter: number,
+    pkh: string,
+    source?: string | undefined,
+    currentVotingPeriod?: VotingPeriodBlockResult
+  ): OperationContents[] {
+    return ops.map((op: RPCOperation) => {
+      switch (op.kind) {
+        case OpKind.ACTIVATION:
+        case OpKind.DRAIN_DELEGATE:
+          return {
+            ...op,
+          };
+        case OpKind.ORIGINATION:
+          return {
+            ...op,
+            balance: typeof op.balance !== 'undefined' ? `${op.balance}` : '0',
+            ...this.getSource(op, pkh, source),
+            ...this.getFee(op, pkh, headCounter),
+          };
+        case OpKind.TRANSACTION: {
+          const cops = {
+            ...op,
+            amount: typeof op.amount !== 'undefined' ? `${op.amount}` : '0',
+            ...this.getSource(op, pkh, source),
+            ...this.getFee(op, pkh, headCounter),
+          };
+          if (cops.source.toLowerCase().startsWith('kt1')) {
+            throw new DeprecationError(
+              `KT1 addresses are not supported as source since ${Protocols.PsBabyM1}`
+            );
+          }
+          return cops;
+        }
+        case OpKind.REVEAL:
+        case OpKind.DELEGATION:
+        case OpKind.REGISTER_GLOBAL_CONSTANT:
+        case OpKind.TX_ROLLUP_ORIGINATION:
+        case OpKind.TX_ROLLUP_SUBMIT_BATCH:
+        case OpKind.UPDATE_CONSENSUS_KEY:
+          return {
+            ...op,
+            ...this.getSource(op, pkh, source),
+            ...this.getFee(op, pkh, headCounter),
+          };
+        case OpKind.TRANSFER_TICKET:
+          return {
+            ...op,
+            ticket_amount: `${op.ticket_amount}`,
+            ...this.getSource(op, pkh, source),
+            ...this.getFee(op, pkh, headCounter),
+          };
+        case OpKind.INCREASE_PAID_STORAGE:
+          return {
+            ...op,
+            amount: `${op.amount}`,
+            ...this.getSource(op, pkh, source),
+            ...this.getFee(op, pkh, headCounter),
+          };
+        case OpKind.BALLOT:
+          if (currentVotingPeriod === undefined) {
+            throw new RPCResponseError(`Failed to get the current voting period index`);
+          }
+          return {
+            ...op,
+            period: currentVotingPeriod?.voting_period.index,
+          };
+        case OpKind.PROPOSALS:
+          if (currentVotingPeriod === undefined) {
+            throw new RPCResponseError(`Failed to get the current voting period index`);
+          }
+          return {
+            ...op,
+            period: currentVotingPeriod?.voting_period.index,
+          };
+
+        default:
+          throw new InvalidOperationKindError((op as any).kind);
+      }
+    });
+  }
+
+  async reveal({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.REVEAL)) {
+      throw new InvalidPrepareParamsError(OpKind.REVEAL);
+    }
+
     const pkh = await this.signer.publicKeyHash();
-    const balance = typeof op.balance !== 'undefined' ? `${op.balance}` : '0';
-    const checkedSource = { source: typeof op.source === 'undefined' ? source || pkh : op.source };
 
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
-    const fee = await this.getFee(op, pkh);
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
-    // TODO: possibly write updateCounter() instead for consistency instead of using getFee()
-    const contents = [
-      {
-        ...op,
-        balance,
-        ...checkedSource,
-        ...fee,
-      },
-    ] as OperationContents[];
-
-    const counter = this.#counters[pkh];
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
 
     return {
       opOb: {
@@ -98,29 +184,24 @@ export class PrepareProvider implements Preparation {
         contents,
         protocol,
       },
-      counter,
+      counter: headCounter,
     };
   }
 
-  async transaction(op: RPCTransferOperation, source?: string): Promise<PreparedOperation> {
-    const pkh = await this.signer.publicKeyHash();
-    const amount = typeof op.amount !== 'undefined' ? `${op.amount}` : '0';
-    const checkedSource = { source: typeof op.source === 'undefined' ? source || pkh : op.source };
+  async originate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.ORIGINATION)) {
+      throw new InvalidPrepareParamsError(OpKind.ORIGINATION);
+    }
 
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
-    const fee = await this.getFee(op, pkh);
 
-    const contents = [
-      {
-        ...op,
-        amount,
-        ...checkedSource,
-        ...fee,
-      },
-    ] as OperationContents[];
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
-    const counter = this.#counters[pkh];
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
 
     return {
       opOb: {
@@ -128,14 +209,297 @@ export class PrepareProvider implements Preparation {
         contents,
         protocol,
       },
-      counter,
+      counter: headCounter,
     };
   }
 
-  // async reveal(op: RPCRevealOperation, source?: string): Promise<PreparedOperation> {
-  //   const pkh = await this.signer.publicKeyHash();
+  async transaction({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
 
-  //   const hash
+    if (!validateOpKindParams(ops, OpKind.TRANSACTION)) {
+      throw new InvalidPrepareParamsError(OpKind.TRANSACTION);
+    }
 
-  // }
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async activation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.ACTIVATION)) {
+      throw new InvalidPrepareParamsError(OpKind.ACTIVATION);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async delegation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.DELEGATION)) {
+      throw new InvalidPrepareParamsError(OpKind.DELEGATION);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async registerGlobalConstant({
+    operation,
+    source,
+  }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.REGISTER_GLOBAL_CONSTANT)) {
+      throw new InvalidPrepareParamsError(OpKind.REGISTER_GLOBAL_CONSTANT);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async txRollupOrigination({
+    operation,
+    source,
+  }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.TX_ROLLUP_ORIGINATION)) {
+      throw new InvalidPrepareParamsError(OpKind.TX_ROLLUP_ORIGINATION);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async txRollupSubmitBatch({
+    operation,
+    source,
+  }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.TX_ROLLUP_SUBMIT_BATCH)) {
+      throw new InvalidPrepareParamsError(OpKind.TX_ROLLUP_SUBMIT_BATCH);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async updateConsensusKey({
+    operation,
+    source,
+  }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.UPDATE_CONSENSUS_KEY)) {
+      throw new InvalidPrepareParamsError(OpKind.UPDATE_CONSENSUS_KEY);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async transferTicket({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.TRANSFER_TICKET)) {
+      throw new InvalidPrepareParamsError(OpKind.TRANSFER_TICKET);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async increasePaidStorage({
+    operation,
+    source,
+  }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.INCREASE_PAID_STORAGE)) {
+      throw new InvalidPrepareParamsError(OpKind.INCREASE_PAID_STORAGE);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async ballot({ operation }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.BALLOT)) {
+      throw new InvalidPrepareParamsError(OpKind.BALLOT);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  async proposals({ operation }: PrepareOperationParams): Promise<PreparedOperation> {
+    const ops = this.convertIntoArray(operation);
+
+    if (!validateOpKindParams(ops, OpKind.PROPOSALS)) {
+      throw new InvalidPrepareParamsError(OpKind.PROPOSALS);
+    }
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const pkh = await this.signer.publicKeyHash();
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+
+    const contents = this.constructOpContents(ops, headCounter, pkh);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
 }

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -22,6 +22,9 @@ const validateOpKindParams = (operations: RPCOperation[], opKind: string) => {
   });
 };
 
+/**
+ * @description PrepareProvider is a utility class to output the prepared format of an operation
+ */
 export class PrepareProvider implements PreparationProvider {
   #counters: { [key: string]: number };
   // context: Context
@@ -163,6 +166,15 @@ export class PrepareProvider implements PreparationProvider {
     });
   }
 
+  /**
+   *
+   * @description Method to prepare a reveal operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async reveal({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -188,6 +200,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a origination operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async originate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
     if (!validateOpKindParams(ops, OpKind.ORIGINATION)) {
@@ -212,6 +233,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a transaction operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async transaction({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -237,6 +267,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare an activation operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async activation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -262,6 +301,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a delegation operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async delegation({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -287,6 +335,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a register_global_constant operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async registerGlobalConstant({
     operation,
     source,
@@ -315,6 +372,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a tx_rollup_origination operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async txRollupOrigination({
     operation,
     source,
@@ -343,6 +409,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a tx_rollup_submit_batch operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async txRollupSubmitBatch({
     operation,
     source,
@@ -371,6 +446,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a update_consensus_key operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async updateConsensusKey({
     operation,
     source,
@@ -399,6 +483,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a transfer_ticket operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async transferTicket({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -424,6 +517,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a increase_paid_storage operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   *
+   * @returns a PreparedOperation object
+   */
   async increasePaidStorage({
     operation,
     source,
@@ -452,6 +554,14 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a ballot operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
   async ballot({ operation }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -490,6 +600,14 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
+  /**
+   *
+   * @description Method to prepare a proposals operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
   async proposals({ operation }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
@@ -528,7 +646,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
-  async drainDelegate({ operation }: PrepareOperationParams): Promise<PreparedOperation> {
+  /**
+   *
+   * @description Method to prepare a drain_delegate operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
+  async drainDelegate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
     if (!validateOpKindParams(ops, OpKind.DRAIN_DELEGATE)) {
@@ -541,7 +667,7 @@ export class PrepareProvider implements PreparationProvider {
     const pkh = await this.signer.publicKeyHash();
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
-    const contents = this.constructOpContents(ops, headCounter, pkh);
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
 
     return {
       opOb: {
@@ -553,7 +679,15 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
-  async batch({ operation }: PrepareOperationParams): Promise<PreparedOperation> {
+  /**
+   *
+   * @description Method to prepare a batch operation
+   *
+   * @param operation RPCOperation object or RPCOperation array
+   *
+   * @returns a PreparedOperation object
+   */
+  async batch({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
 
     const hash = await this.getBlockHash();
@@ -562,7 +696,7 @@ export class PrepareProvider implements PreparationProvider {
     const pkh = await this.signer.publicKeyHash();
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
-    const contents = this.constructOpContents(ops, headCounter, pkh);
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
 
     return {
       opOb: {

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -190,7 +190,6 @@ export class PrepareProvider implements Preparation {
 
   async originate({ operation, source }: PrepareOperationParams): Promise<PreparedOperation> {
     const ops = this.convertIntoArray(operation);
-    console.log(ops);
     if (!validateOpKindParams(ops, OpKind.ORIGINATION)) {
       throw new InvalidPrepareParamsError(OpKind.ORIGINATION);
     }

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -17,7 +17,7 @@ import { Packer } from './packer/interface';
 import { RpcPacker } from './packer/rpc-packer';
 import { TzReadProvider } from './read-provider/interface';
 import { RpcReadAdapter } from './read-provider/rpc-read-adapter';
-import { PrepareProvider } from './prepare/prepare-provider';
+import { PreparationProvider } from './prepare/interface';
 import { Signer } from './signer/interface';
 import { NoopSigner } from './signer/noop';
 import { SubscribeProvider } from './subscribe/interface';
@@ -68,6 +68,7 @@ export {
 export { RpcReadAdapter } from './read-provider/rpc-read-adapter';
 export * from './estimate';
 export { TaquitoLocalForger } from './forger/taquito-local-forger';
+export * from './prepare';
 
 export interface SetProviderOptions {
   forger?: Forger;
@@ -352,7 +353,7 @@ export class TezosToolkit {
   /**
    * @description Provide access to tezos operation preparation utilities
    */
-  get prepare(): PrepareProvider {
+  get prepare(): PreparationProvider {
     return this._context.prepare;
   }
 

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -17,6 +17,7 @@ import { Packer } from './packer/interface';
 import { RpcPacker } from './packer/rpc-packer';
 import { TzReadProvider } from './read-provider/interface';
 import { RpcReadAdapter } from './read-provider/rpc-read-adapter';
+import { PrepareProvider } from './prepare/prepare-provider';
 import { Signer } from './signer/interface';
 import { NoopSigner } from './signer/noop';
 import { SubscribeProvider } from './subscribe/interface';
@@ -346,6 +347,13 @@ export class TezosToolkit {
    */
   get contract(): ContractProvider {
     return this._context.contract;
+  }
+
+  /**
+   * @description Provide access to tezos operation preparation utilities
+   */
+  get prepare(): PrepareProvider {
+    return this._context.prepare;
   }
 
   get wallet(): Wallet {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -1685,7 +1685,6 @@ describe('RpcContractProvider test', () => {
         delegate: 'tz1MY8g5UqVmQtpAp7qs1cUwEof1GjZCHgVv',
         destination: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
       });
-      console.log(result.raw);
       expect(result.raw).toEqual({
         opbytes: 'test',
         opOb: {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -1685,7 +1685,7 @@ describe('RpcContractProvider test', () => {
         delegate: 'tz1MY8g5UqVmQtpAp7qs1cUwEof1GjZCHgVv',
         destination: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
       });
-
+      console.log(result.raw);
       expect(result.raw).toEqual({
         opbytes: 'test',
         opOb: {
@@ -2236,15 +2236,15 @@ describe('RpcContractProvider test', () => {
     it('Should have defined storage with Nested bigmap in multiple maps', async (done) => {
       mockRpcClient.getEntrypoints.mockResolvedValue({
         entrypoints: {},
-      })
-      mockRpcClient.getContract.mockResolvedValue(smallNestedMapTypecheck)
+      });
+      mockRpcClient.getContract.mockResolvedValue(smallNestedMapTypecheck);
       const rpcContract = await rpcContractProvider.at('KT1SpsNu3hGHN5T5Vt9g9GKUggzvBpxaLxq7');
       expect(rpcContract).toBeDefined();
-      const storage = await rpcContract.storage() as any;
+      const storage = (await rpcContract.storage()) as any;
 
       const keyList = storage.keyMap;
       expect(keyList.size).toEqual(1);
       done();
-    })
-  })
+    });
   });
+});

--- a/packages/taquito/test/operations/origination-operation.spec.ts
+++ b/packages/taquito/test/operations/origination-operation.spec.ts
@@ -118,6 +118,8 @@ describe('Origination operation', () => {
         fakeContext,
         fakeContractProvider
       );
+
+      console.log(op['params']);
       expect(op.contractAddress).toEqual('KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD');
     });
 

--- a/packages/taquito/test/prepare/data.ts
+++ b/packages/taquito/test/prepare/data.ts
@@ -117,7 +117,7 @@ export const txRollupOriginationOp = {} as RPCTxRollupOriginationOperation;
 
 export const txRollupSubmitBatch = {} as RPCTxRollupBatchOperation;
 
-export const UpdateConsensusKeyOp = {
+export const updateConsensusKeyOp = {
   kind: OpKind.UPDATE_CONSENSUS_KEY,
   source: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
   fee: 1,
@@ -126,7 +126,18 @@ export const UpdateConsensusKeyOp = {
   pk: 'edpkti5K5JbdLpp2dCqiTLoLQqs5wqzeVhfHVnNhsSCuoU8zdHYoY7',
 } as RPCUpdateConsensusKeyOperation;
 
-export const transferTicketOp = {} as RPCTransferTicketOperation;
+export const transferTicketOp = {
+  kind: OpKind.TRANSFER_TICKET,
+  fee: 804,
+  gas_limit: 5009,
+  storage_limit: 130,
+  ticket_contents: { string: 'foobar' },
+  ticket_ty: { prim: 'string' },
+  ticket_ticketer: 'KT1AL8we1Bfajn2M7i3gQM5PJEuyD36sXaYb',
+  ticket_amount: 2,
+  destination: 'KT1SUT2TBFPCknkBxLqM5eJZKoYVY6mB26Fg',
+  entrypoint: 'default',
+} as RPCTransferTicketOperation;
 
 export const increasePaidStorageOp = {
   kind: OpKind.INCREASE_PAID_STORAGE,
@@ -138,10 +149,14 @@ export const increasePaidStorageOp = {
 } as RPCIncreasePaidStorageOperation;
 
 export const ballotOp = {
+  kind: OpKind.BALLOT,
+  period: 2,
   proposal: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
   ballot: 'yay',
 } as RPCBallotOperation;
 
 export const proposalsOp = {
+  kind: OpKind.PROPOSALS,
+  period: 1,
   proposals: ['PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg'],
 } as RPCProposalsOperation;

--- a/packages/taquito/test/prepare/data.ts
+++ b/packages/taquito/test/prepare/data.ts
@@ -11,11 +11,14 @@ import {
   RPCIncreasePaidStorageOperation,
   RPCProposalsOperation,
   RPCRegisterGlobalConstantOperation,
+  RPCRevealOperation,
   RPCTransferTicketOperation,
   RPCTxRollupBatchOperation,
   RPCTxRollupOriginationOperation,
   RPCUpdateConsensusKeyOperation,
 } from '../../src/operations/types';
+
+import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT } from '../../src/constants';
 
 export const sampleContract: MichelsonContractStorage = {
   prim: 'storage',
@@ -59,6 +62,15 @@ export const sampleStorage: MichelsonData = {
   ],
 };
 
+export const revealOp = {
+  kind: OpKind.REVEAL,
+  fee: DEFAULT_FEE.REVEAL,
+  public_key: 'test_public_key',
+  source: 'test_pkh_reveal',
+  gas_limit: DEFAULT_GAS_LIMIT.REVEAL,
+  storage_limit: DEFAULT_STORAGE_LIMIT.REVEAL,
+} as RPCRevealOperation;
+
 export const originationOp = {
   kind: OpKind.ORIGINATION,
   fee: 1,
@@ -70,6 +82,223 @@ export const originationOp = {
     storage: sampleStorage,
   },
 } as RPCOriginationOperation;
+
+export const preparedOriginationOp = {
+  opOb: {
+    branch: 'test_block_hash',
+    contents: [
+      {
+        kind: 'origination',
+        fee: '1',
+        gas_limit: '2',
+        storage_limit: '2',
+        balance: '100',
+        script: {
+          code: [
+            {
+              prim: 'storage',
+              args: [
+                {
+                  prim: 'pair',
+                  args: [
+                    {
+                      prim: 'big_map',
+                      args: [
+                        {
+                          prim: 'address',
+                        },
+                        {
+                          prim: 'pair',
+                          args: [
+                            {
+                              prim: 'nat',
+                            },
+                            {
+                              prim: 'map',
+                              args: [
+                                {
+                                  prim: 'address',
+                                },
+                                {
+                                  prim: 'nat',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      prim: 'pair',
+                      args: [
+                        {
+                          prim: 'address',
+                        },
+                        {
+                          prim: 'pair',
+                          args: [
+                            {
+                              prim: 'bool',
+                            },
+                            {
+                              prim: 'nat',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          storage: {
+            prim: 'Pair',
+            args: [
+              [],
+              {
+                prim: 'Pair',
+                args: [
+                  {
+                    string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+                  },
+                  {
+                    prim: 'Pair',
+                    args: [
+                      {
+                        prim: 'False',
+                      },
+                      {
+                        int: '200',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        source: 'test_public_key_hash',
+        counter: '1',
+      },
+    ],
+    protocol: 'test_protocol',
+  },
+  counter: 0,
+};
+
+export const preparedOriginationOpWithReveal = {
+  opOb: {
+    branch: 'test_block_hash',
+    contents: [
+      {
+        kind: 'reveal',
+        fee: '374',
+        public_key: 'test_public_key',
+        source: 'test_pkh_reveal',
+        gas_limit: '1100',
+        storage_limit: '0',
+        counter: '1',
+      },
+      {
+        kind: 'origination',
+        fee: '1',
+        gas_limit: '2',
+        storage_limit: '2',
+        balance: '100',
+        script: {
+          code: [
+            {
+              prim: 'storage',
+              args: [
+                {
+                  prim: 'pair',
+                  args: [
+                    {
+                      prim: 'big_map',
+                      args: [
+                        {
+                          prim: 'address',
+                        },
+                        {
+                          prim: 'pair',
+                          args: [
+                            {
+                              prim: 'nat',
+                            },
+                            {
+                              prim: 'map',
+                              args: [
+                                {
+                                  prim: 'address',
+                                },
+                                {
+                                  prim: 'nat',
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                    {
+                      prim: 'pair',
+                      args: [
+                        {
+                          prim: 'address',
+                        },
+                        {
+                          prim: 'pair',
+                          args: [
+                            {
+                              prim: 'bool',
+                            },
+                            {
+                              prim: 'nat',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+          storage: {
+            prim: 'Pair',
+            args: [
+              [],
+              {
+                prim: 'Pair',
+                args: [
+                  {
+                    string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+                  },
+                  {
+                    prim: 'Pair',
+                    args: [
+                      {
+                        prim: 'False',
+                      },
+                      {
+                        int: '200',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        source: 'test_public_key_hash',
+        counter: '2',
+      },
+    ],
+    protocol: 'test_protocol',
+  },
+  counter: 0,
+};
 
 export const transactionOp = {
   kind: OpKind.TRANSACTION,

--- a/packages/taquito/test/prepare/data.ts
+++ b/packages/taquito/test/prepare/data.ts
@@ -1,0 +1,147 @@
+import { MichelsonData, MichelsonContractStorage } from '@taquito/michel-codec';
+import {
+  RPCDelegateOperation,
+  RPCDrainDelegateOperation,
+  RPCOriginationOperation,
+  RPCTransferOperation,
+} from '../../src/operations';
+import { OpKind } from '@taquito/rpc';
+import {
+  RPCBallotOperation,
+  RPCIncreasePaidStorageOperation,
+  RPCProposalsOperation,
+  RPCRegisterGlobalConstantOperation,
+  RPCTransferTicketOperation,
+  RPCTxRollupBatchOperation,
+  RPCTxRollupOriginationOperation,
+  RPCUpdateConsensusKeyOperation,
+} from '../../src/operations/types';
+
+export const sampleContract: MichelsonContractStorage = {
+  prim: 'storage',
+  args: [
+    {
+      prim: 'pair',
+      args: [
+        {
+          prim: 'big_map',
+          args: [
+            { prim: 'address' },
+            {
+              prim: 'pair',
+              args: [
+                { prim: 'nat' },
+                { prim: 'map', args: [{ prim: 'address' }, { prim: 'nat' }] },
+              ],
+            },
+          ],
+        },
+        {
+          prim: 'pair',
+          args: [{ prim: 'address' }, { prim: 'pair', args: [{ prim: 'bool' }, { prim: 'nat' }] }],
+        },
+      ],
+    },
+  ],
+};
+
+export const sampleStorage: MichelsonData = {
+  prim: 'Pair',
+  args: [
+    [],
+    {
+      prim: 'Pair',
+      args: [
+        { string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn' },
+        { prim: 'Pair', args: [{ prim: 'False' }, { int: '200' }] },
+      ],
+    },
+  ],
+};
+
+export const originationOp = {
+  kind: OpKind.ORIGINATION,
+  fee: 1,
+  gas_limit: 2,
+  storage_limit: 2,
+  balance: '100',
+  script: {
+    code: [sampleContract],
+    storage: sampleStorage,
+  },
+} as RPCOriginationOperation;
+
+export const transactionOp = {
+  kind: OpKind.TRANSACTION,
+  fee: 1,
+  gas_limit: 2,
+  storage_limit: 2,
+  amount: '5',
+  destination: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+} as RPCTransferOperation;
+
+export const drainDelegateOp = {
+  kind: OpKind.DRAIN_DELEGATE,
+  consensus_key: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
+  delegate: 'tz1MY8g5UqVmQtpAp7qs1cUwEof1GjZCHgVv',
+  destination: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
+} as RPCDrainDelegateOperation;
+
+export const delegateOp = {
+  kind: OpKind.DELEGATION,
+  fee: 2,
+  gas_limit: 1,
+  storage_limit: 1,
+  delegate: 'tz1MY8g5UqVmQtpAp7qs1cUwEof1GjZCHgVv',
+} as RPCDelegateOperation;
+
+export const registerGlobalConstantOp = {
+  kind: OpKind.REGISTER_GLOBAL_CONSTANT,
+  fee: 1,
+  gas_limit: 1,
+  storage_limit: 2,
+  value: {
+    prim: 'Pair',
+    args: [
+      {
+        int: '999',
+      },
+      {
+        int: '999',
+      },
+    ],
+  },
+} as RPCRegisterGlobalConstantOperation;
+
+export const txRollupOriginationOp = {} as RPCTxRollupOriginationOperation;
+
+export const txRollupSubmitBatch = {} as RPCTxRollupBatchOperation;
+
+export const UpdateConsensusKeyOp = {
+  kind: OpKind.UPDATE_CONSENSUS_KEY,
+  source: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
+  fee: 1,
+  gas_limit: 1,
+  storage_limit: 2,
+  pk: 'edpkti5K5JbdLpp2dCqiTLoLQqs5wqzeVhfHVnNhsSCuoU8zdHYoY7',
+} as RPCUpdateConsensusKeyOperation;
+
+export const transferTicketOp = {} as RPCTransferTicketOperation;
+
+export const increasePaidStorageOp = {
+  kind: OpKind.INCREASE_PAID_STORAGE,
+  fee: 1,
+  gas_limit: 1,
+  storage_limit: 2,
+  amount: 10,
+  destination: 'KT1Vjr5PFC2Qm5XbSQZ8MdFZLgYMzwG5WZNh',
+} as RPCIncreasePaidStorageOperation;
+
+export const ballotOp = {
+  proposal: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+  ballot: 'yay',
+} as RPCBallotOperation;
+
+export const proposalsOp = {
+  proposals: ['PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg'],
+} as RPCProposalsOperation;

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -734,5 +734,43 @@ describe('PrepareProvider test', () => {
         });
       });
     });
+
+    describe('batch', () => {
+      it('should be able to prepare a batch operation', async () => {
+        const prepared = await prepareProvider.batch({
+          operation: [transactionOp, increasePaidStorageOp],
+        });
+
+        expect(prepared).toEqual({
+          opOb: {
+            branch: 'test_block_hash',
+            contents: [
+              {
+                kind: 'transaction',
+                fee: '1',
+                gas_limit: '2',
+                storage_limit: '2',
+                amount: '5',
+                destination: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+                source: 'test_public_key_hash',
+                counter: '1',
+              },
+              {
+                kind: 'increase_paid_storage',
+                fee: '1',
+                gas_limit: '1',
+                storage_limit: '2',
+                amount: '10',
+                destination: 'KT1Vjr5PFC2Qm5XbSQZ8MdFZLgYMzwG5WZNh',
+                source: 'test_public_key_hash',
+                counter: '2',
+              },
+            ],
+            protocol: 'test_protocol',
+          },
+          counter: 0,
+        });
+      });
+    });
   });
 });

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -1,0 +1,70 @@
+// import { Context } from '../../src/context';
+// import { RPCOriginationOperation } from '../../src/operations';
+// import { PrepareProvider } from '../../src/prepare/prepare-provider';
+
+// describe('PrepareProvider test', () => {
+//   let prepareProvider: PrepareProvider;
+
+//   let mockReadProvider: {
+//     getBlockHash: jest.Mock<any, any>,
+//     getNextProtocol: jest.Mock<any, any>,
+//     getHeadCounter: jest.Mock<any, any>
+//   }
+
+//   let mockSigner: {
+//     publicKeyHash: jest.Mock<any, any>
+//   }
+
+//   let mockContext: {
+//     signer: any,
+//     readProvider: any
+//   };
+
+//   mockReadProvider = {
+//     getBlockHash: jest.fn(),
+//     getNextProtocol: jest.fn(),
+//     getHeadCounter: jest.fn()
+//   }
+
+//   mockSigner = {
+//     publicKeyHash: jest.fn()
+//   }
+
+//   const originationOp = {
+//     kind: 'origination',
+//     fee: 1,
+//     gas_limit: 2,
+//     storage_limit: 2,
+//     balance: '100',
+//     script: {
+//       code: `parameter string;
+//       storage string;
+//       code {CAR;
+//             PUSH string "Hello ";
+//             CONCAT;
+//             NIL operation; PAIR};
+//       `,
+//       storage: '"test"'
+//     }
+//   } as RPCOriginationOperation
+
+//   beforeEach(() => {
+
+//     mockSigner.publicKeyHash.mockResolvedValue('tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu');
+//     mockReadProvider.getBlockHash.mockResolvedValue('test');
+//     mockReadProvider.getHeadCounter.mockResolvedValue('1');
+//     mockReadProvider.getNextProtocol.mockResolvedValue('test');
+
+//     const context = new Context(mockReadProvider as any, mockSigner as any);
+
+//     prepareProvider = new PrepareProvider(context);
+//   })
+//   it('should returned a Prepared origination operation', async () => {
+
+//     const prep = await prepareProvider.originate(originationOp);
+
+//     console.log(prep);
+
+//     expect(prep).toBeDefined();
+//   })
+// })

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -1,284 +1,534 @@
-// import { Context } from '../../src/context';
-// import { PrepareProvider } from '../../src/prepare/prepare-provider';
-// import {
-//   originationOp, transactionOp
-// } from './data';
+import { Context } from '../../src/context';
+import { PrepareProvider } from '../../src/prepare/prepare-provider';
+import {
+  drainDelegateOp,
+  originationOp,
+  transactionOp,
+  delegateOp,
+  registerGlobalConstantOp,
+  updateConsensusKeyOp,
+  increasePaidStorageOp,
+  ballotOp,
+  proposalsOp,
+  transferTicketOp,
+} from './data';
 
-// import { InvalidPrepareParamsError} from '../../src/error';
+describe('PrepareProvider test', () => {
+  let prepareProvider: PrepareProvider;
 
-// describe('PrepareProvider test', () => {
-//   let prepareProvider: PrepareProvider;
+  let mockReadProvider: {
+    getBlockHash: jest.Mock<any, any>;
+    getNextProtocol: jest.Mock<any, any>;
+    getCounter: jest.Mock<any, any>;
+  };
 
-//   let mockReadProvider: {
-//     getBlockHash: jest.Mock<any, any>,
-//     getNextProtocol: jest.Mock<any, any>,
-//     getCounter: jest.Mock<any, any>
-//   }
+  let mockRpcClient: {
+    getBlockHeader: jest.Mock<any, any>;
+    getProtocols: jest.Mock<any, any>;
+    getContract: jest.Mock<any, any>;
+    getCurrentPeriod: jest.Mock<any, any>;
+  };
 
-//   let mockRpcClient: {
-//     getBlockHeader: jest.Mock<any, any>,
-//     getProtocols: jest.Mock<any, any>,
-//     getContract: jest.Mock<any, any>
-//   }
+  let mockSigner: {
+    publicKeyHash: jest.Mock<any, any>;
+  };
 
-//   let mockSigner: {
-//     publicKeyHash: jest.Mock<any, any>
-//   }
+  beforeEach(() => {
+    mockReadProvider = {
+      getBlockHash: jest.fn(),
+      getNextProtocol: jest.fn(),
+      getCounter: jest.fn(),
+    };
 
-//   mockReadProvider = {
-//     getBlockHash: jest.fn(),
-//     getNextProtocol: jest.fn(),
-//     getCounter: jest.fn()
-//   }
+    mockRpcClient = {
+      getBlockHeader: jest.fn(),
+      getProtocols: jest.fn(),
+      getContract: jest.fn(),
+      getCurrentPeriod: jest.fn(),
+    };
 
-//   mockRpcClient = {
-//     getBlockHeader: jest.fn(),
-//     getProtocols: jest.fn(),
-//     getContract: jest.fn(),
-//   }
+    mockSigner = {
+      publicKeyHash: jest.fn(),
+    };
 
-//   mockSigner = {
-//     publicKeyHash: jest.fn()
-//   }
+    mockRpcClient.getContract.mockResolvedValue({
+      counter: 0,
+      script: {
+        code: [],
+        storage: 'sampleStorage',
+      },
+    });
 
-//   beforeAll(() => {
-//     mockRpcClient.getContract.mockResolvedValue({
-//       counter: 0,
-//       script: {
-//         code: [],
-//         storage: 'sampleStorage',
-//       },
-//     });
-//     mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test_block_header' });
-//     mockRpcClient.getProtocols.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test_block_header' });
+    mockRpcClient.getProtocols.mockResolvedValue({ next_protocol: 'test_proto' });
+    mockRpcClient.getCurrentPeriod.mockResolvedValue({
+      voting_period: {
+        index: 103,
+        kind: 'proposal',
+        start_position: 421888,
+      },
+      position: 3413,
+      remaining: 682,
+    });
 
-//     mockSigner.publicKeyHash.mockResolvedValue('test_public_key_hash');
+    mockSigner.publicKeyHash.mockResolvedValue('test_public_key_hash');
 
-//     mockReadProvider.getBlockHash.mockResolvedValue('test_block_hash');
-//     mockReadProvider.getNextProtocol.mockResolvedValue('test_protocol');
-//     mockReadProvider.getCounter.mockResolvedValue('0');
+    mockReadProvider.getBlockHash.mockResolvedValue('test_block_hash');
+    mockReadProvider.getNextProtocol.mockResolvedValue('test_protocol');
+    mockReadProvider.getCounter.mockResolvedValue('0');
 
-//     const context = new Context(mockRpcClient as any, mockSigner as any);
-//     context.readProvider = mockReadProvider as any;
+    const context = new Context(mockRpcClient as any, mockSigner as any);
+    context.readProvider = mockReadProvider as any;
 
-//     prepareProvider = new PrepareProvider(context);
-//   });
+    prepareProvider = new PrepareProvider(context);
+  });
 
-//   describe('originate', () => {
-//     it('should return a prepared Origination operation', async () => {
+  describe('originate', () => {
+    it('should return a prepared Origination operation', async () => {
+      const prepared = await prepareProvider.originate({ operation: originationOp });
 
-//       const prepared = await prepareProvider.originate({ operation: originationOp });
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'origination',
+              fee: '1',
+              gas_limit: '2',
+              storage_limit: '2',
+              balance: '100',
+              script: {
+                code: [
+                  {
+                    prim: 'storage',
+                    args: [
+                      {
+                        prim: 'pair',
+                        args: [
+                          {
+                            prim: 'big_map',
+                            args: [
+                              {
+                                prim: 'address',
+                              },
+                              {
+                                prim: 'pair',
+                                args: [
+                                  {
+                                    prim: 'nat',
+                                  },
+                                  {
+                                    prim: 'map',
+                                    args: [
+                                      {
+                                        prim: 'address',
+                                      },
+                                      {
+                                        prim: 'nat',
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                          {
+                            prim: 'pair',
+                            args: [
+                              {
+                                prim: 'address',
+                              },
+                              {
+                                prim: 'pair',
+                                args: [
+                                  {
+                                    prim: 'bool',
+                                  },
+                                  {
+                                    prim: 'nat',
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+                storage: {
+                  prim: 'Pair',
+                  args: [
+                    [],
+                    {
+                      prim: 'Pair',
+                      args: [
+                        {
+                          string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+                        },
+                        {
+                          prim: 'Pair',
+                          args: [
+                            {
+                              prim: 'False',
+                            },
+                            {
+                              int: '200',
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+              source: 'test_public_key_hash',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//       expect(prepared).toEqual({
-//         opOb: {
-//           branch: 'test_block_hash',
-//           contents: [
-//             {
-//               kind: 'origination',
-//               fee: '1',
-//               gas_limit: '2',
-//               storage_limit: '2',
-//               balance: '100',
-//               script: {
-//                 code: [
-//                   {
-//                     prim: 'storage',
-//                     args: [
-//                       {
-//                         prim: 'pair',
-//                         args: [
-//                           {
-//                             prim: 'big_map',
-//                             args: [
-//                               {
-//                                 prim: 'address'
-//                               },
-//                               {
-//                                 prim: 'pair',
-//                                 args: [
-//                                   {
-//                                     prim: 'nat'
-//                                   },
-//                                   {
-//                                     prim: 'map',
-//                                     args: [
-//                                       {
-//                                         prim: 'address'
-//                                       },
-//                                       {
-//                                         prim: 'nat'
-//                                       }
-//                                     ]
-//                                   }
-//                                 ]
-//                               }
-//                             ]
-//                           },
-//                           {
-//                             prim: 'pair',
-//                             args: [
-//                               {
-//                                 prim: 'address'
-//                               },
-//                               {
-//                                 prim: 'pair',
-//                                 args: [
-//                                   {
-//                                     prim: 'bool'
-//                                   },
-//                                   {
-//                                     prim: 'nat'
-//                                   }
-//                                 ]
-//                               }
-//                             ]
-//                           }
-//                         ]
-//                       }
-//                     ]
-//                   }
-//                 ],
-//                 storage: {
-//                   prim: 'Pair',
-//                   args: [
-//                     [],
-//                     {
-//                       prim: 'Pair',
-//                       args: [
-//                         {
-//                           string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'
-//                         },
-//                         {
-//                           prim: 'Pair',
-//                           args: [
-//                             {
-//                               prim: 'False'
-//                             },
-//                             {
-//                               int: '200'
-//                             }
-//                           ]
-//                         }
-//                       ]
-//                     }
-//                   ]
-//                 }
-//               },
-//               source: 'test_public_key_hash',
-//               counter: '1'
-//             }
-//           ],
-//           protocol: 'test_protocol'
-//         },
-//         counter: 0
-//       });
-//     });
+    it('should throw an error if parameters does not have related operation kind to the method', async () => {
+      try {
+        await prepareProvider.originate({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'origination' operation parameters have been passed`);
+      }
+    });
+  });
 
-//     it('should throw an error if parameters does not have related operation kind to the method', async () => {
-//       expect(
-//         async () => {
-//           await prepareProvider.originate({ operation: transactionOp })
-//         }
-//       ).toThrowError(InvalidPrepareParamsError)
-//     });
-//   });
+  describe('transaction', () => {
+    it('should return a prepared Transaction operation', async () => {
+      const prepared = await prepareProvider.transaction({ operation: transactionOp });
 
-//   describe('transaction', () => {
-//     it('should return a prepared Transaction operation', async () => {
-//       const prepared = await prepareProvider.transaction({ operation: transactionOp })
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '1',
+              gas_limit: '2',
+              storage_limit: '2',
+              amount: '5',
+              destination: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+              source: 'test_public_key_hash',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//       expect(prepared).toEqual({
-//         opOb: {
-//           branch: 'test_block_hash',
-//           contents: [
-//             {
-//               kind: 'transaction',
-//               fee: '1',
-//               gas_limit: '2',
-//               storage_limit: '2',
-//               amount: '5',
-//               destination: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
-//               source: 'test_public_key_hash',
-//               counter: '2'
-//             }
-//           ],
-//           protocol: 'test_protocol'
-//         },
-//         counter: 0
-//       })
+    it('should throw error if params does not include transaction operation', async () => {
+      try {
+        await prepareProvider.transaction({ operation: originationOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'transaction' operation parameters have been passed`);
+      }
+    });
+  });
 
-//     });
-//   });
+  describe('drainDelegate', () => {
+    it('should return a prepared drainDelegate operation', async () => {
+      const prepared = await prepareProvider.drainDelegate({ operation: drainDelegateOp });
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'drain_delegate',
+              consensus_key: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
+              delegate: 'tz1MY8g5UqVmQtpAp7qs1cUwEof1GjZCHgVv',
+              destination: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//   describe('activation', () => {
-//     it('should return a prepared x operation', async () => {
+    it('should throw an error if paramaters does not include a drain_delegate operation', async () => {
+      try {
+        await prepareProvider.drainDelegate({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'drain_delegate' operation parameters have been passed`);
+      }
+    });
+  });
 
-//     });
-//   });
+  describe('delegation', () => {
+    it('should return a prepared delegation operation', async () => {
+      const prepared = await prepareProvider.delegation({ operation: delegateOp });
 
-//   describe('drainDelegate', () => {
-//     it('should return a prepared x operation', async () => {
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              counter: '1',
+              delegate: 'tz1MY8g5UqVmQtpAp7qs1cUwEof1GjZCHgVv',
+              fee: '2',
+              gas_limit: '1',
+              kind: 'delegation',
+              source: 'test_public_key_hash',
+              storage_limit: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//     });
-//   });
+    it('should throw an error when params do not include a delegation operation', async () => {
+      try {
+        await prepareProvider.delegation({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'delegation' operation parameters have been passed`);
+      }
+    });
+  });
 
-//   describe('reveal', () => {
-//     it('should return a prepared x operation', async () => {
+  describe('registerGlobalConstant', () => {
+    it('should return a prepared registerGlobalConstant operation', async () => {
+      const prepared = await prepareProvider.registerGlobalConstant({
+        operation: registerGlobalConstantOp,
+      });
+      console.log(JSON.stringify(prepared));
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              counter: '1',
+              fee: '1',
+              gas_limit: '1',
+              kind: 'register_global_constant',
+              source: 'test_public_key_hash',
+              storage_limit: '2',
+              value: {
+                args: [
+                  {
+                    int: '999',
+                  },
+                  {
+                    int: '999',
+                  },
+                ],
+                prim: 'Pair',
+              },
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//     });
-//   });
+    it('should throw error when params does not include a registerGlobalConstant operation', async () => {
+      try {
+        await prepareProvider.registerGlobalConstant({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(
+          `No 'register_global_constant' operation parameters have been passed`
+        );
+      }
+    });
+  });
 
-//   describe('delegation', () => {
-//     it('should return a prepared x operation', async () => {
+  // describe('txRollupOrigination', () => {
+  //   it('should return a prepared x operation', async () => {
 
-//     });
-//   });
+  //   });
+  // });
 
-//   describe('registerGlobalConstant', () => {
-//     it('should return a prepared x operation', async () => {
+  // describe('txRollupSubmitBatch', () => {
+  //   it('should return a prepared x operation', async () => {
 
-//     });
-//   });
+  //   });
+  // });
 
-//   describe('txRollupOrigination', () => {
-//     it('should return a prepared x operation', async () => {
+  describe('updateConsensusKey', () => {
+    it('should return a prepared udpateConsensusKey operation', async () => {
+      const prepared = await prepareProvider.updateConsensusKey({
+        operation: updateConsensusKeyOp,
+      });
 
-//     });
-//   });
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              counter: '1',
+              fee: '1',
+              gas_limit: '1',
+              kind: 'update_consensus_key',
+              pk: 'edpkti5K5JbdLpp2dCqiTLoLQqs5wqzeVhfHVnNhsSCuoU8zdHYoY7',
+              source: 'tz1KvJCU5cNdz5RAS3diEtdRvS9wfhRC7Cwj',
+              storage_limit: '2',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//   describe('txRollupSubmitBatch', () => {
-//     it('should return a prepared x operation', async () => {
+    it('should throw error when params does not include an updateConsensusKey operation', async () => {
+      try {
+        await prepareProvider.updateConsensusKey({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(
+          `No 'update_consensus_key' operation parameters have been passed`
+        );
+      }
+    });
+  });
 
-//     });
-//   });
+  describe('transferTicket', () => {
+    it('should return a prepared transferTicket operation', async () => {
+      const prepared = await prepareProvider.transferTicket({ operation: transferTicketOp });
 
-//   describe('updateConsensusKey', () => {
-//     it('should return a prepared x operation', async () => {
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              counter: '1',
+              destination: 'KT1SUT2TBFPCknkBxLqM5eJZKoYVY6mB26Fg',
+              entrypoint: 'default',
+              fee: '804',
+              gas_limit: '5009',
+              kind: 'transfer_ticket',
+              source: 'test_public_key_hash',
+              storage_limit: '130',
+              ticket_amount: '2',
+              ticket_contents: {
+                string: 'foobar',
+              },
+              ticket_ticketer: 'KT1AL8we1Bfajn2M7i3gQM5PJEuyD36sXaYb',
+              ticket_ty: {
+                prim: 'string',
+              },
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//     });
-//   });
+    it('should throw error when params does not include a transferTicket operation', async () => {
+      try {
+        await prepareProvider.transferTicket({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'transfer_ticket' operation parameters have been passed`);
+      }
+    });
+  });
 
-//   describe('transferTicket', () => {
-//     it('should return a prepared x operation', async () => {
+  describe('increasePaidStorage', () => {
+    it('should return a prepared increasePaidStorage operation', async () => {
+      const prepared = await prepareProvider.increasePaidStorage({
+        operation: increasePaidStorageOp,
+      });
 
-//     });
-//   });
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              amount: '10',
+              counter: '1',
+              destination: 'KT1Vjr5PFC2Qm5XbSQZ8MdFZLgYMzwG5WZNh',
+              fee: '1',
+              gas_limit: '1',
+              kind: 'increase_paid_storage',
+              source: 'test_public_key_hash',
+              storage_limit: '2',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//   describe('increasePaidStorage', () => {
-//     it('should return a prepared x operation', async () => {
+    it('should throw error when params does not include an increasePaidStorage operation', async () => {
+      try {
+        await prepareProvider.increasePaidStorage({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(
+          `No 'increase_paid_storage' operation parameters have been passed`
+        );
+      }
+    });
+  });
 
-//     });
-//   });
+  describe('ballot', () => {
+    it('should return a prepared ballot operation', async () => {
+      const prepared = await prepareProvider.ballot({ operation: ballotOp });
 
-//   describe('ballot', () => {
-//     it('should return a prepared x operation', async () => {
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              ballot: 'yay',
+              kind: 'ballot',
+              period: 103,
+              proposal: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
 
-//     });
-//   });
+    it('should throw error when params does not include a ballot operation', async () => {
+      try {
+        await prepareProvider.ballot({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'ballot' operation parameters have been passed`);
+      }
+    });
+  });
 
-//   describe('proposals', () => {
-//     it('should return a prepared x operation', async () => {
+  describe('proposals', () => {
+    it('should return a prepared proposals operation', async () => {
+      const prepared = await prepareProvider.proposals({ operation: proposalsOp });
 
-//     });
-//   });
-// });
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'proposals',
+              period: 103,
+              proposals: ['PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg'],
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should throw error when params does not include a proposals operation', async () => {
+      try {
+        await prepareProvider.proposals({ operation: transactionOp });
+      } catch (e) {
+        expect(e.message).toEqual(`No 'proposals' operation parameters have been passed`);
+      }
+    });
+  });
+});

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -1,6 +1,10 @@
 // import { Context } from '../../src/context';
-// import { RPCOriginationOperation } from '../../src/operations';
 // import { PrepareProvider } from '../../src/prepare/prepare-provider';
+// import {
+//   originationOp, transactionOp
+// } from './data';
+
+// import { InvalidPrepareParamsError} from '../../src/error';
 
 // describe('PrepareProvider test', () => {
 //   let prepareProvider: PrepareProvider;
@@ -8,63 +12,273 @@
 //   let mockReadProvider: {
 //     getBlockHash: jest.Mock<any, any>,
 //     getNextProtocol: jest.Mock<any, any>,
-//     getHeadCounter: jest.Mock<any, any>
+//     getCounter: jest.Mock<any, any>
+//   }
+
+//   let mockRpcClient: {
+//     getBlockHeader: jest.Mock<any, any>,
+//     getProtocols: jest.Mock<any, any>,
+//     getContract: jest.Mock<any, any>
 //   }
 
 //   let mockSigner: {
 //     publicKeyHash: jest.Mock<any, any>
 //   }
 
-//   let mockContext: {
-//     signer: any,
-//     readProvider: any
-//   };
-
 //   mockReadProvider = {
 //     getBlockHash: jest.fn(),
 //     getNextProtocol: jest.fn(),
-//     getHeadCounter: jest.fn()
+//     getCounter: jest.fn()
+//   }
+
+//   mockRpcClient = {
+//     getBlockHeader: jest.fn(),
+//     getProtocols: jest.fn(),
+//     getContract: jest.fn(),
 //   }
 
 //   mockSigner = {
 //     publicKeyHash: jest.fn()
 //   }
 
-//   const originationOp = {
-//     kind: 'origination',
-//     fee: 1,
-//     gas_limit: 2,
-//     storage_limit: 2,
-//     balance: '100',
-//     script: {
-//       code: `parameter string;
-//       storage string;
-//       code {CAR;
-//             PUSH string "Hello ";
-//             CONCAT;
-//             NIL operation; PAIR};
-//       `,
-//       storage: '"test"'
-//     }
-//   } as RPCOriginationOperation
+//   beforeAll(() => {
+//     mockRpcClient.getContract.mockResolvedValue({
+//       counter: 0,
+//       script: {
+//         code: [],
+//         storage: 'sampleStorage',
+//       },
+//     });
+//     mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test_block_header' });
+//     mockRpcClient.getProtocols.mockResolvedValue({ next_protocol: 'test_proto' });
 
-//   beforeEach(() => {
+//     mockSigner.publicKeyHash.mockResolvedValue('test_public_key_hash');
 
-//     mockSigner.publicKeyHash.mockResolvedValue('tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu');
-//     mockReadProvider.getBlockHash.mockResolvedValue('test');
-//     mockReadProvider.getHeadCounter.mockResolvedValue('1');
-//     mockReadProvider.getNextProtocol.mockResolvedValue('test');
+//     mockReadProvider.getBlockHash.mockResolvedValue('test_block_hash');
+//     mockReadProvider.getNextProtocol.mockResolvedValue('test_protocol');
+//     mockReadProvider.getCounter.mockResolvedValue('0');
 
-//     const context = new Context(mockReadProvider as any, mockSigner as any);
+//     const context = new Context(mockRpcClient as any, mockSigner as any);
+//     context.readProvider = mockReadProvider as any;
 
 //     prepareProvider = new PrepareProvider(context);
-//   })
-//   it('should returned a Prepared origination operation', async () => {
+//   });
 
-//     const prep = await prepareProvider.originate(originationOp);
+//   describe('originate', () => {
+//     it('should return a prepared Origination operation', async () => {
 
-//     console.log(prep);
+//       const prepared = await prepareProvider.originate({ operation: originationOp });
 
-//     expect(prep).toBeDefined();
-//   })
-// })
+//       expect(prepared).toEqual({
+//         opOb: {
+//           branch: 'test_block_hash',
+//           contents: [
+//             {
+//               kind: 'origination',
+//               fee: '1',
+//               gas_limit: '2',
+//               storage_limit: '2',
+//               balance: '100',
+//               script: {
+//                 code: [
+//                   {
+//                     prim: 'storage',
+//                     args: [
+//                       {
+//                         prim: 'pair',
+//                         args: [
+//                           {
+//                             prim: 'big_map',
+//                             args: [
+//                               {
+//                                 prim: 'address'
+//                               },
+//                               {
+//                                 prim: 'pair',
+//                                 args: [
+//                                   {
+//                                     prim: 'nat'
+//                                   },
+//                                   {
+//                                     prim: 'map',
+//                                     args: [
+//                                       {
+//                                         prim: 'address'
+//                                       },
+//                                       {
+//                                         prim: 'nat'
+//                                       }
+//                                     ]
+//                                   }
+//                                 ]
+//                               }
+//                             ]
+//                           },
+//                           {
+//                             prim: 'pair',
+//                             args: [
+//                               {
+//                                 prim: 'address'
+//                               },
+//                               {
+//                                 prim: 'pair',
+//                                 args: [
+//                                   {
+//                                     prim: 'bool'
+//                                   },
+//                                   {
+//                                     prim: 'nat'
+//                                   }
+//                                 ]
+//                               }
+//                             ]
+//                           }
+//                         ]
+//                       }
+//                     ]
+//                   }
+//                 ],
+//                 storage: {
+//                   prim: 'Pair',
+//                   args: [
+//                     [],
+//                     {
+//                       prim: 'Pair',
+//                       args: [
+//                         {
+//                           string: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn'
+//                         },
+//                         {
+//                           prim: 'Pair',
+//                           args: [
+//                             {
+//                               prim: 'False'
+//                             },
+//                             {
+//                               int: '200'
+//                             }
+//                           ]
+//                         }
+//                       ]
+//                     }
+//                   ]
+//                 }
+//               },
+//               source: 'test_public_key_hash',
+//               counter: '1'
+//             }
+//           ],
+//           protocol: 'test_protocol'
+//         },
+//         counter: 0
+//       });
+//     });
+
+//     it('should throw an error if parameters does not have related operation kind to the method', async () => {
+//       expect(
+//         async () => {
+//           await prepareProvider.originate({ operation: transactionOp })
+//         }
+//       ).toThrowError(InvalidPrepareParamsError)
+//     });
+//   });
+
+//   describe('transaction', () => {
+//     it('should return a prepared Transaction operation', async () => {
+//       const prepared = await prepareProvider.transaction({ operation: transactionOp })
+
+//       expect(prepared).toEqual({
+//         opOb: {
+//           branch: 'test_block_hash',
+//           contents: [
+//             {
+//               kind: 'transaction',
+//               fee: '1',
+//               gas_limit: '2',
+//               storage_limit: '2',
+//               amount: '5',
+//               destination: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+//               source: 'test_public_key_hash',
+//               counter: '2'
+//             }
+//           ],
+//           protocol: 'test_protocol'
+//         },
+//         counter: 0
+//       })
+
+//     });
+//   });
+
+//   describe('activation', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('drainDelegate', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('reveal', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('delegation', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('registerGlobalConstant', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('txRollupOrigination', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('txRollupSubmitBatch', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('updateConsensusKey', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('transferTicket', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('increasePaidStorage', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('ballot', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+
+//   describe('proposals', () => {
+//     it('should return a prepared x operation', async () => {
+
+//     });
+//   });
+// });

--- a/packages/taquito/test/taquito.spec.ts
+++ b/packages/taquito/test/taquito.spec.ts
@@ -1,6 +1,7 @@
 import { TezosToolkit, SetProviderOptions, Wallet, RpcPacker } from '../src/taquito';
 import { RpcTzProvider } from '../src/tz/rpc-tz-provider';
 import { RpcContractProvider } from '../src/contract/rpc-contract-provider';
+import { PrepareProvider } from '../src/prepare/prepare-provider';
 import { PollingSubscribeProvider } from '../src/subscribe/polling-subcribe-provider';
 import { NoopSigner } from '../src/signer/noop';
 import { RpcClient } from '@taquito/rpc';
@@ -54,6 +55,7 @@ describe('TezosToolkit test', () => {
     expect(tezos.stream).toBeInstanceOf(PollingSubscribeProvider);
     expect(tezos.tz).toBeInstanceOf(RpcTzProvider);
     expect(tezos.wallet).toBeInstanceOf(Wallet);
+    expect(tezos.prepare).toBeInstanceOf(PrepareProvider);
   });
 
   it('setProvider with string should create rpc provider', () => {


### PR DESCRIPTION
closes #2020 

Added PrepareProvider to modularize the preparation step when conducting Tezos operations.
- Added the `PrepareProvider` class and the interface `PreparationProvider`
- Added member methods that support the preparation of Tezos operations
- Added unit tests and integration test required
- Updated the Context to pass the `PrepareProvider`
- TypeDoc update (WIP)
- Added documentation (WIP)

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have added unit tests
- [x] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
