### PR TITLE
Add null to MichelsonMapKey

### DIFF
--- a/packages/taquito-michelson-encoder/src/michelson-map.ts
+++ b/packages/taquito-michelson-encoder/src/michelson-map.ts
@@ -17,7 +17,7 @@ export class InvalidMapTypeError extends Error {
 // Used in order to identify all object that are of type MichelsonMap even if they come from different module
 const michelsonMapTypeSymbol = Symbol.for('taquito-michelson-map-type-symbol');
 
-export type MichelsonMapKey = Array<any> | object | string | boolean | number;
+export type MichelsonMapKey = Array<any> | object | string | boolean | number | null;
 
 const isMapType = (
   value: MichelsonV1Expression


### PR DESCRIPTION
Fixes #2251 by adding null to `MichelsonMapKey`.

I considered adding a test for (for example) `string | null`, but it seems the `MichelsonMap` tests are rather general and options are well-tested in tokens.

Please let me know if I should add a test that simply ensures the typescript type checks pass.