### PR TITLE
Update all Github Workflows to use Node LTS Gallium (v16)

### DIFF
--- a/.github/workflows/algolia.yml
+++ b/.github/workflows/algolia.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: lts/gallium
     - run: npm ci
     - name: Run delete script
       run: npm -w @taquito/website run delete-index

--- a/.github/workflows/bundle_webpack.yml
+++ b/.github/workflows/bundle_webpack.yml
@@ -19,7 +19,7 @@ jobs:
     -
       uses: actions/setup-node@v2
       with:
-        node-version: 16.13.1
+        node-version: lts/gallium
     - run: npm ci
     - run: npm run build
     - run: cd packages/taquito-local-forging && npm run build-webpack

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 16.19.0
+        node-version: lts/gallium
     - run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
     - run: echo "PACKAGE_VERSION=`node -p "require('./packages/taquito/package.json').version"`" >> $GITHUB_ENV
     - run: echo "BRANCH_NAME=$(git branch --show-current)" >> $GITHUB_ENV

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v2
       with:
-        node-version: 16.13.1
+        node-version: 16.19.0
     - run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
     - run: echo "PACKAGE_VERSION=`node -p "require('./packages/taquito/package.json').version"`" >> $GITHUB_ENV
     - run: echo "BRANCH_NAME=$(git branch --show-current)" >> $GITHUB_ENV

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: lts/gallium
     - run: npm ci
     - run: npm run build
     - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         node:
-          - '16'
-          - '18'
+          - 'lts/gallium'
+          - 'lts/hydrogen'
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
@@ -49,7 +49,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: lts/gallium
     - run: npm ci
     - run: npm run build
     - if: ${{ !github.event.pull_request.head.repo.fork }}
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: lts/gallium
 
     ## The 4 Bootstrap Accounts (alias, pk, pkh, sk)
     # alice,edpkvGfYw3LyB1UcCahKQk4rF2tvbMUk8GFiTuMjL75uGXrpvKXhjn,tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb,unencrypted:edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq

--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16.13.1'
+        node-version: lts/gallium
     - run: npm ci
     - run: npm run build
     -


### PR DESCRIPTION
Updated node version to 16.19.0 to fix `lerna version` command failing