### PR TITLE
feat(michel-codec): add support for bytes 

### DIFF
--- a/integration-tests/data/instructions-with-bytes-contracts.ts
+++ b/integration-tests/data/instructions-with-bytes-contracts.ts
@@ -1,9 +1,9 @@
-import fs from 'fs'
+import fs from 'fs';
+import path from 'path';
 
-
-export const addContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/and_bytes.tz').toString();
-export const lslContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/lsl_bytes.tz').toString();
-export const lsrContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/lsr_bytes.tz').toString();
-export const notContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/not_bytes.tz').toString();
-export const orContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/or_bytes.tz').toString();
-export const xorContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/xor_bytes.tz').toString();
+export const addContract =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/and_bytes.tz`)).toString();
+export const lslContract =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/lsl_bytes.tz`)).toString();
+export const lsrContract =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/lsr_bytes.tz`)).toString();
+export const notContract =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/not_bytes.tz`)).toString();
+export const orContract =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/or_bytes.tz`)).toString();
+export const xorContract =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/xor_bytes.tz`)).toString();

--- a/integration-tests/data/instructions-with-bytes-contracts.ts
+++ b/integration-tests/data/instructions-with-bytes-contracts.ts
@@ -1,0 +1,9 @@
+import fs from 'fs'
+
+
+export const addContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/and_bytes.tz').toString();
+export const lslContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/lsl_bytes.tz').toString();
+export const lsrContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/lsr_bytes.tz').toString();
+export const notContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/not_bytes.tz').toString();
+export const orContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/or_bytes.tz').toString();
+export const xorContract =  fs.readFileSync(__dirname + '/../../packages/taquito-michel-codec/test/contracts_016/opcodes/xor_bytes.tz').toString();

--- a/integration-tests/instructions-with-bytes.spec.ts
+++ b/integration-tests/instructions-with-bytes.spec.ts
@@ -22,6 +22,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       await contract.confirmation();
       expect(contract).toBeDefined();
       expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
       done();
     });
 
@@ -33,6 +34,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       await contract.confirmation();
       expect(contract).toBeDefined();
       expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
       done();
     });
 
@@ -44,6 +46,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       await contract.confirmation();
       expect(contract).toBeDefined();
       expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
       done();
     });
 
@@ -55,6 +58,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       await contract.confirmation();
       expect(contract).toBeDefined();
       expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
       done();
     });
 
@@ -66,6 +70,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       await contract.confirmation();
       expect(contract).toBeDefined();
       expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
       done();
     });
 
@@ -77,6 +82,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       await contract.confirmation();
       expect(contract).toBeDefined();
       expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
       done();
     });
 

--- a/integration-tests/instructions-with-bytes.spec.ts
+++ b/integration-tests/instructions-with-bytes.spec.ts
@@ -4,10 +4,8 @@ import { addContract, lslContract, lsrContract, notContract, orContract, xorCont
 
 CONFIGS().forEach(({ lib, protocol, setup }) => {
   const Tezos = lib
-  const Mondaynet = protocol === Protocols.ProtoALpha ? test: test.skip;
   const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
-  // TODO add mumbai tests
-  // const MumbaiAndMonday = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test: test.skip;
+  const MumbaiAndMonday = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test: test.skip;
 
   describe(`Test origination of contract with instructions now supporting bytes`, () => {
 
@@ -16,7 +14,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    Mondaynet(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
+    MumbaiAndMonday(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: addContract,
         storage: 0
@@ -26,7 +24,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    Mondaynet(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
+    MumbaiAndMonday(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: lslContract,
         storage: 0
@@ -36,7 +34,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    Mondaynet(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
+    MumbaiAndMonday(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: lsrContract,
         storage: 0
@@ -46,7 +44,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    Mondaynet(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
+    MumbaiAndMonday(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: notContract,
         storage: 0
@@ -56,7 +54,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    Mondaynet(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
+    MumbaiAndMonday(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: orContract,
         storage: 0
@@ -66,7 +64,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    Mondaynet(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
+    MumbaiAndMonday(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: xorContract,
         storage: 0

--- a/integration-tests/instructions-with-bytes.spec.ts
+++ b/integration-tests/instructions-with-bytes.spec.ts
@@ -5,7 +5,7 @@ import { addContract, lslContract, lsrContract, notContract, orContract, xorCont
 CONFIGS().forEach(({ lib, protocol, setup }) => {
   const Tezos = lib;
   const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
-  const mumbaiAndMonday = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test origination of contract with instructions now supporting bytes`, () => {
 
@@ -14,7 +14,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndMonday(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: addContract,
         storage: 0
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndMonday(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: lslContract,
         storage: 0
@@ -36,7 +36,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndMonday(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: lsrContract,
         storage: 0
@@ -47,7 +47,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndMonday(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: notContract,
         storage: 0
@@ -58,7 +58,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndMonday(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: orContract,
         storage: 0
@@ -69,7 +69,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndMonday(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: xorContract,
         storage: 0

--- a/integration-tests/instructions-with-bytes.spec.ts
+++ b/integration-tests/instructions-with-bytes.spec.ts
@@ -3,9 +3,9 @@ import { Protocols, TezosOperationError } from "@taquito/taquito";
 import { addContract, lslContract, lsrContract, notContract, orContract, xorContract } from "./data/instructions-with-bytes-contracts";
 
 CONFIGS().forEach(({ lib, protocol, setup }) => {
-  const Tezos = lib
+  const Tezos = lib;
   const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
-  const MumbaiAndMonday = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test: test.skip;
+  const mumbaiAndMonday = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test origination of contract with instructions now supporting bytes`, () => {
 
@@ -14,7 +14,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    MumbaiAndMonday(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
+    mumbaiAndMonday(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: addContract,
         storage: 0
@@ -24,7 +24,8 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    MumbaiAndMonday(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
+
+    mumbaiAndMonday(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: lslContract,
         storage: 0
@@ -34,7 +35,8 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    MumbaiAndMonday(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
+
+    mumbaiAndMonday(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: lsrContract,
         storage: 0
@@ -44,7 +46,8 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    MumbaiAndMonday(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
+
+    mumbaiAndMonday(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: notContract,
         storage: 0
@@ -54,7 +57,8 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    MumbaiAndMonday(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
+
+    mumbaiAndMonday(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: orContract,
         storage: 0
@@ -64,7 +68,8 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
-    MumbaiAndMonday(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
+
+    mumbaiAndMonday(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
       const contract = await Tezos.contract.originate({
         code: xorContract,
         storage: 0
@@ -74,6 +79,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       expect(contract.contractAddress).toContain("KT1");
       done();
     });
+
     limanet('Should fail to originate a contract for AND with bytes', async (done) => {
       try {
         const contract = await Tezos.contract.originate({
@@ -85,6 +91,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
         expect(err).toBeInstanceOf(TezosOperationError);
       }
       done();
-    })
+    });
+
   });
-})
+});

--- a/integration-tests/instructions-with-bytes.spec.ts
+++ b/integration-tests/instructions-with-bytes.spec.ts
@@ -1,0 +1,92 @@
+import { CONFIGS } from "./config";
+import { Protocols, TezosOperationError } from "@taquito/taquito";
+import { addContract, lslContract, lsrContract, notContract, orContract, xorContract } from "./data/instructions-with-bytes-contracts";
+
+CONFIGS().forEach(({ lib, protocol, setup }) => {
+  const Tezos = lib
+  const Mondaynet = protocol === Protocols.ProtoALpha ? test: test.skip;
+  const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
+  // TODO add mumbai tests
+  // const MumbaiAndMonday = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test: test.skip;
+
+  describe(`Test origination of contract with instructions now supporting bytes`, () => {
+
+    beforeEach(async (done) => {
+      await setup();
+      done();
+    });
+
+    Mondaynet(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: addContract,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      done();
+    });
+    Mondaynet(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: lslContract,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      done();
+    });
+    Mondaynet(`Should be able to orignate contract with LSR parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: lsrContract,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      done();
+    });
+    Mondaynet(`Should be able to orignate contract with NOT parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: notContract,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      done();
+    });
+    Mondaynet(`Should be able to orignate contract with OR parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: orContract,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      done();
+    });
+    Mondaynet(`Should be able to orignate contract with XOR parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: xorContract,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      done();
+    });
+    limanet('Should fail to originate a contract for AND with bytes', async (done) => {
+      try {
+        const contract = await Tezos.contract.originate({
+          code: addContract,
+          storage: 0
+        });
+        await contract.confirmation();
+      } catch (err) {
+        expect(err).toBeInstanceOf(TezosOperationError);
+      }
+      done();
+    })
+  });
+})

--- a/packages/taquito-michel-codec/src/michelson-typecheck.ts
+++ b/packages/taquito-michel-codec/src/michelson-typecheck.ts
@@ -424,7 +424,7 @@ function assertDataValidInternal(d: MichelsonData, t: MichelsonType, ctx: Contex
       if (
         'string' in d &&
         checkDecodeTezosID(d.string, 'ED25519PublicKey', 'SECP256K1PublicKey', 'P256PublicKey') !==
-        null
+          null
       ) {
         return;
       } else if ('bytes' in d) {
@@ -696,7 +696,7 @@ function functionTypeInternal(
 
   // unpack instruction annotations and assert their maximum number
   function instructionAnn(
-    num: { f?: number; t?: number; v?: number; },
+    num: { f?: number; t?: number; v?: number },
     opt?: UnpackAnnotationsOptions
   ) {
     const a = argAnn(instruction, {
@@ -727,10 +727,10 @@ function functionTypeInternal(
     const ann =
       a.v !== undefined || a.t !== undefined || a.f !== undefined
         ? [
-          ...((a.v === null ? src.v : a.v) || []),
-          ...((a.t === null ? src.t : a.t) || []),
-          ...((a.f === null ? src.f : a.f) || []),
-        ]
+            ...((a.v === null ? src.v : a.v) || []),
+            ...((a.t === null ? src.t : a.t) || []),
+            ...((a.f === null ? src.f : a.f) || []),
+          ]
         : undefined;
 
     const { annots: _annots, ...rest } = t;
@@ -778,12 +778,12 @@ function functionTypeInternal(
             ? ['@' + fieldAnn.slice(1)]
             : undefined
           : insVarAnn === '@%%'
-            ? varAnn
-              ? ['@' + varAnn.slice(1) + '.' + (fieldAnn ? fieldAnn.slice(1) : defField)]
-              : fieldAnn
-                ? ['@' + fieldAnn.slice(1)]
-                : undefined
-            : [insVarAnn]
+          ? varAnn
+            ? ['@' + varAnn.slice(1) + '.' + (fieldAnn ? fieldAnn.slice(1) : defField)]
+            : fieldAnn
+            ? ['@' + fieldAnn.slice(1)]
+            : undefined
+          : [insVarAnn]
         : null,
     });
   }
@@ -1309,12 +1309,12 @@ function functionTypeInternal(
 
       case 'LSL':
       case 'LSR':
-        args(0, ['nat'], ['nat']);
+        args(0, ['nat', 'bytes'], ['nat', 'bytes']);
         return [annotateVar({ prim: 'nat' }), ...stack.slice(2)];
 
       case 'OR':
       case 'XOR': {
-        const s = args(0, ['nat', 'bool'], ['nat', 'bool']);
+        const s = args(0, ['nat', 'bytes', 'bool'], ['nat', 'bytes', 'bool']);
         if (s[0].prim !== s[1].prim) {
           throw new MichelsonInstructionError(
             instruction,
@@ -1326,7 +1326,7 @@ function functionTypeInternal(
       }
 
       case 'AND': {
-        const s = args(0, ['nat', 'bool', 'int'], ['nat', 'bool']);
+        const s = args(0, ['nat', 'bytes', 'bool', 'int'], ['nat', 'bytes', 'bool']);
         if ((s[0].prim !== 'int' || s[1].prim !== 'nat') && s[0].prim !== s[1].prim) {
           throw new MichelsonInstructionError(
             instruction,
@@ -1338,7 +1338,7 @@ function functionTypeInternal(
       }
 
       case 'NOT': {
-        const s = args(0, ['nat', 'bool', 'int'])[0];
+        const s = args(0, ['nat', 'bytes', 'bool', 'int'])[0];
         if (s.prim === 'bool') {
           return [annotateVar({ prim: 'bool' }), ...stack.slice(1)];
         }
@@ -1676,8 +1676,8 @@ function functionTypeInternal(
         return s.prim === 'list'
           ? [annotateVar({ prim: 'list', args: [body[0]] }), ...tail]
           : s.prim === 'map'
-            ? [annotateVar({ prim: 'map', args: [s.args[0], body[0]] }), ...tail]
-            : [annotateVar({ prim: 'option', args: [body[0]] }), ...tail];
+          ? [annotateVar({ prim: 'map', args: [s.args[0], body[0]] }), ...tail]
+          : [annotateVar({ prim: 'option', args: [body[0]] }), ...tail];
       }
 
       case 'ITER': {
@@ -1814,7 +1814,7 @@ function functionTypeInternal(
         assertTypeAnnotationsValid(instruction.args[0]);
         assertTypeAnnotationsValid(instruction.args[1]);
         const s = [instruction.args[0]];
-        if (instruction.prim === "LAMBDA_REC") {
+        if (instruction.prim === 'LAMBDA_REC') {
           s.push({ prim: 'lambda', args: [instruction.args[0], instruction.args[1]] });
         }
         const body = functionTypeInternal(instruction.args[2], s, {
@@ -1860,13 +1860,10 @@ function functionTypeInternal(
           return [
             annotateVar({
               prim: 'option',
-              args: [
-                annotate({ prim: 'ticket', args: [s] }, instructionAnn({ t: 1, v: 1 }))
-              ]
+              args: [annotate({ prim: 'ticket', args: [s] }, instructionAnn({ t: 1, v: 1 }))],
             }),
-            ...stack.slice(2)
+            ...stack.slice(2),
           ];
-
         }
       }
 
@@ -1978,35 +1975,35 @@ function functionTypeInternal(
         }
         return ProtoInferiorTo(proto, Protocol.PtJakarta)
           ? [
-            annotateVar({
-              prim: 'option',
-              args: [
-                {
-                  prim: 'pair',
-                  args: [{ prim: 'int' }, annotate(s[1], { t: null })],
-                },
-              ],
-            }),
-            ...stack.slice(2),
-          ]
+              annotateVar({
+                prim: 'option',
+                args: [
+                  {
+                    prim: 'pair',
+                    args: [{ prim: 'int' }, annotate(s[1], { t: null })],
+                  },
+                ],
+              }),
+              ...stack.slice(2),
+            ]
           : [
-            annotateVar({
-              prim: 'option',
-              args: [
-                {
-                  prim: 'pair',
-                  args: [
-                    { prim: 'bytes' },
-                    {
-                      prim: 'pair',
-                      args: [{ prim: 'int' }, annotate(s[1], { t: null })],
-                    },
-                  ],
-                },
-              ],
-            }),
-            ...stack.slice(2),
-          ];
+              annotateVar({
+                prim: 'option',
+                args: [
+                  {
+                    prim: 'pair',
+                    args: [
+                      { prim: 'bytes' },
+                      {
+                        prim: 'pair',
+                        args: [{ prim: 'int' }, annotate(s[1], { t: null })],
+                      },
+                    ],
+                  },
+                ],
+              }),
+              ...stack.slice(2),
+            ];
       }
 
       case 'OPEN_CHEST':
@@ -2070,7 +2067,7 @@ export function contractSection<T extends 'parameter' | 'storage' | 'code'>(
 export function contractViews(contract: MichelsonContract): {
   [name: string]: MichelsonContractView;
 } {
-  const views: { [name: string]: MichelsonContractView; } = {};
+  const views: { [name: string]: MichelsonContractView } = {};
   for (const s of contract) {
     if (s.prim === 'view') {
       views[s.args[0].string] = s;

--- a/packages/taquito-michel-codec/test/contracts_016.spec.ts
+++ b/packages/taquito-michel-codec/test/contracts_016.spec.ts
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { inspect } from 'util';
+import { Contract, ContractOptions } from '../src/michelson-contract';
+import { Protocol } from '../src/michelson-types';
+import { MichelsonError } from '../src/utils';
+
+const contracts: {
+  [group: string]: string[];
+} = {
+  attic: [],
+  entrypoints: [],
+  ill_typed: [],
+  lib_protocol: [],
+  macros: [],
+  mini_scenarios: [],
+  non_regression: [],
+  opcodes: [
+    'and_bytes.tz',
+    'lsl_bytes.tz',
+    'lsr_bytes.tz',
+    'not_bytes.tz',
+    'or_bytes.tz',
+    'xor_bytes.tz',
+  ],
+};
+
+describe('PtMumbaii', () => {
+  for (const [group, list] of Object.entries(contracts)) {
+    describe(group, () => {
+      for (const contract of list) {
+        it(contract, () => {
+          const options: ContractOptions = {
+            protocol: Protocol.PtLimaPtL,
+          };
+
+          const filename = path.resolve(__dirname, 'contracts_016', group, contract);
+          const src = fs.readFileSync(filename).toString();
+          if (group === 'ill_typed') {
+            expect(() => Contract.parse(src, options)).toThrow();
+            return;
+          }
+
+          try {
+            Contract.parse(src, options);
+          } catch (err) {
+            if (err instanceof MichelsonError) {
+              console.log(inspect(err, false, null));
+            }
+            throw err;
+          }
+        });
+      }
+    });
+  }
+});

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/and_bytes.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/and_bytes.tz
@@ -1,0 +1,15 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       # 0x05 & 0x06 = 0x04
+       PUSH bytes 0x05; PUSH bytes 0x06; AND; PUSH bytes 0x04; ASSERT_CMPEQ;
+
+       # 0x0005 & 0x0106 = 0x0004, not 0x04
+       PUSH bytes 0x0005; PUSH bytes 0x0106; AND; PUSH bytes 0x0004; ASSERT_CMPEQ;
+
+       # Longer bytes is cut its prefix to have the same length as the shorter one
+       # 0x05 & 0x0106 = 0x05 & 0x06 = 0x04, not 0x0004
+       PUSH bytes 0x05; PUSH bytes 0x0106; AND; PUSH bytes 0x04; ASSERT_CMPEQ;
+
+       UNIT; NIL @noop operation; PAIR; };

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/lsl_bytes.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/lsl_bytes.tz
@@ -1,0 +1,19 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       # If shift is 0, LSL returns the bytes untouched
+       # 0x06 LSL 0 = 0x06
+       PUSH nat 0; PUSH bytes 0x06; LSL; PUSH bytes 0x06; ASSERT_CMPEQ;
+
+       # If shift is not 0, LSL returns a bytes longer than the original
+       # 0x06 LSL 1 = 0x000c  (not 0x0c)
+       PUSH nat 1; PUSH bytes 0x06; LSL; PUSH bytes 0x000c; ASSERT_CMPEQ;
+
+       # 0x06 LSL 8 = 0x0600
+       PUSH nat 8; PUSH bytes 0x06; LSL; PUSH bytes 0x0600; ASSERT_CMPEQ;
+
+       # 0x0006 LSL 1 = 0x00000c  (not 0x0c nor 0x000c)
+       PUSH nat 1; PUSH bytes 0x0006; LSL; PUSH bytes 0x00000c; ASSERT_CMPEQ;
+
+       UNIT; NIL @noop operation; PAIR; };

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/lsr_bytes.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/lsr_bytes.tz
@@ -1,0 +1,23 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       # 0x06 LSR 1 = 0x03
+       PUSH nat 1; PUSH bytes 0x06; LSR; PUSH bytes 0x03; ASSERT_CMPEQ;
+
+       # 0x06 LSR 8 = 0x (empty bytes)
+       PUSH nat 8; PUSH bytes 0x06; LSR; PUSH bytes 0x; ASSERT_CMPEQ;
+
+       # 0x0006 LSR 1 = 0x0003  (not 0x03)
+       PUSH nat 1; PUSH bytes 0x0006; LSR; PUSH bytes 0x0003; ASSERT_CMPEQ;
+
+       # 0x0006 LSR 8 = 0x00
+       PUSH nat 8; PUSH bytes 0x0006; LSR; PUSH bytes 0x00; ASSERT_CMPEQ;
+
+       # 0x001234 LSR 0 = 0x001234
+       PUSH nat 0; PUSH bytes 0x001234; LSR; PUSH bytes 0x001234; ASSERT_CMPEQ;
+
+       # 0x001234 LSR 30 = 0x
+       PUSH nat 30; PUSH bytes 0x001234; LSR; PUSH bytes 0x; ASSERT_CMPEQ;
+
+       UNIT; NIL @noop operation; PAIR; };

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/not_bytes.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/not_bytes.tz
@@ -1,0 +1,14 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       # ~0x05 = 0xfa
+       PUSH bytes 0x05; NOT; PUSH bytes 0xfa; ASSERT_CMPEQ;
+
+       # ~0x0005 = 0xfffa
+       PUSH bytes 0x0005; NOT; PUSH bytes 0xfffa; ASSERT_CMPEQ;
+
+       # ~0xff05 = 0x00fa, not 0xfa
+       PUSH bytes 0xff05; NOT; PUSH bytes 0x00fa; ASSERT_CMPEQ;
+
+       UNIT; NIL @noop operation; PAIR; };

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/or_bytes.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/or_bytes.tz
@@ -1,0 +1,15 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       # 0x05 | 0x06 = 0x07
+       PUSH bytes 0x05; PUSH bytes 0x06; OR; PUSH bytes 0x07; ASSERT_CMPEQ;
+
+       # 0x0005 | 0x0106 = 0x0107
+       PUSH bytes 0x0005; PUSH bytes 0x0106; OR; PUSH bytes 0x0107; ASSERT_CMPEQ;
+
+       # Shorter bytes 0-padded to the left to have the same length as the longer one
+       # 0x05 & 0x0106 = 0x0005 | 0x0106 = 0x0107, not 0x07
+       PUSH bytes 0x05; PUSH bytes 0x0106; OR; PUSH bytes 0x0107; ASSERT_CMPEQ;
+
+       UNIT; NIL @noop operation; PAIR; };

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/xor_bytes.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/xor_bytes.tz
@@ -1,0 +1,15 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       # 0x05 ^ 0x06 = 0x03
+       PUSH bytes 0x05; PUSH bytes 0x06; XOR; PUSH bytes 0x03; ASSERT_CMPEQ;
+
+       # 0x0005 ^ 0x0106 = 0x0103
+       PUSH bytes 0x0005; PUSH bytes 0x0106; XOR; PUSH bytes 0x0103; ASSERT_CMPEQ;
+
+       # Shorter bytes 0-padded to the left to have the same length as the longer one
+       # 0x05 ^ 0x0106 = 0x0005 ^ 0x0106 = 0x0103, not 0x03
+       PUSH bytes 0x05; PUSH bytes 0x0106; XOR; PUSH bytes 0x0103; ASSERT_CMPEQ;
+
+       UNIT; NIL @noop operation; PAIR; };


### PR DESCRIPTION
add support for operations and, lsl/r, x/or and not to accept the type of bytes as a parameter 

closes #2267 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
