### PR TITLE
fix: removed consumed_gas from update_consensus_key return result for…

### DIFF
--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -1280,7 +1280,6 @@ export interface OperationResultIncreasePaidStorage {
 
 export interface OperationResultUpdateConsensusKey {
   status: OperationResultStatusEnum;
-  consumed_gas?: string;
   consumed_milligas?: string;
   errors?: TezosGenericOperationError[];
 }

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -3527,7 +3527,6 @@ describe('RpcClient test', () => {
       expect(content.metadata.balance_updates![1].origin).toEqual('block');
 
       expect(content.metadata.operation_result.status).toEqual('applied');
-      expect(content.metadata.operation_result.consumed_gas).toEqual('1000');
       expect(content.metadata.operation_result.consumed_milligas).toEqual('1000000');
       done();
     });

--- a/packages/taquito/test/operations/update-consensus-key.spec.ts
+++ b/packages/taquito/test/operations/update-consensus-key.spec.ts
@@ -34,7 +34,6 @@ describe('Update Consensus Key operation', () => {
         ],
         operation_result: {
           status: 'applied',
-          consumed_gas: '1000',
           consumed_milligas: '1000000',
         },
       },


### PR DESCRIPTION
… mumbainet

re #2273
closes #2273 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__

removed `consumed_gas` property in return object of update_consensus_key operation