### PR TITLE
feat: start support bytes conversion 2268

### DIFF
--- a/integration-tests/data/instructions-bytes-conversions-contracts.ts
+++ b/integration-tests/data/instructions-bytes-conversions-contracts.ts
@@ -1,0 +1,5 @@
+import fs from 'fs';
+import path from 'path';
+
+export const bytesAndInt =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/bytes_of_int.tz`)).toString();
+export const bytesAndNat =  fs.readFileSync(path.resolve(`${__dirname}/../../packages/taquito-michel-codec/test/contracts_016/opcodes/bytes_of_nat.tz`)).toString();

--- a/integration-tests/instructions-with-bytes-conversion.spec.ts
+++ b/integration-tests/instructions-with-bytes-conversion.spec.ts
@@ -8,14 +8,14 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
   const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
   const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
 
-  describe(`Test origination of contract with instructions now supporting bytes`, () => {
+  describe(`Test origination of contract with instructions now supporting bytes conversion`, () => {
 
     beforeEach(async (done) => {
       await setup();
       done();
     });
 
-    mumbaiAndAlpha(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to originate a contract with BYTES -> INT -> BYTES instructions`, async done => {
       const contract = await Tezos.contract.originate({
         code: bytesAndInt,
         storage: 0
@@ -27,7 +27,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    mumbaiAndAlpha(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
+    mumbaiAndAlpha(`Should be able to originate a contract with BYTES -> NAT -> BYTES instructions`, async done => {
       const contract = await Tezos.contract.originate({
         code: bytesAndNat,
         storage: 0
@@ -39,7 +39,7 @@ CONFIGS().forEach(({ lib, protocol, setup }) => {
       done();
     });
 
-    limanet('Should fail to originate a contract for AND with bytes', async (done) => {
+    limanet('Should fail with non-supported BYTES and NAT instructions', async (done) => {
       try {
         const contract = await Tezos.contract.originate({
           code: bytesAndInt,

--- a/integration-tests/instructions-with-bytes-conversion.spec.ts
+++ b/integration-tests/instructions-with-bytes-conversion.spec.ts
@@ -1,0 +1,56 @@
+import { CONFIGS } from "./config";
+import { Protocols } from "@taquito/taquito";
+import { bytesAndInt, bytesAndNat } from "./data/instructions-bytes-conversions-contracts";
+import { HttpResponseError } from "@taquito/http-utils";
+
+CONFIGS().forEach(({ lib, protocol, setup }) => {
+  const Tezos = lib;
+  const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+
+  describe(`Test origination of contract with instructions now supporting bytes`, () => {
+
+    beforeEach(async (done) => {
+      await setup();
+      done();
+    });
+
+    mumbaiAndAlpha(`Should be able to orignate contract with ADD parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: bytesAndInt,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
+      done();
+    });
+
+    mumbaiAndAlpha(`Should be able to orignate contract with LSL parameter in michelson contract with bytes`, async done => {
+      const contract = await Tezos.contract.originate({
+        code: bytesAndNat,
+        storage: 0
+      });
+      await contract.confirmation();
+      expect(contract).toBeDefined();
+      expect(contract.contractAddress).toContain("KT1");
+      expect(contract.status).toEqual('applied');
+      done();
+    });
+
+    limanet('Should fail to originate a contract for AND with bytes', async (done) => {
+      try {
+        const contract = await Tezos.contract.originate({
+          code: bytesAndInt,
+          storage: 0
+        });
+        await contract.confirmation();
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpResponseError);
+      }
+      done();
+    });
+
+  });
+});

--- a/packages/taquito-local-forging/src/constants.ts
+++ b/packages/taquito-local-forging/src/constants.ts
@@ -210,6 +210,8 @@ export const opMapping: { [key: string]: string } = {
   '98': 'Lambda_rec',
   '99': 'LAMBDA_REC',
   '9a': 'TICKET',
+  '9b': 'BYTES',
+  '9c': 'NAT',
 };
 
 export const opMappingReverse = (() => {

--- a/packages/taquito-michel-codec/src/binary.ts
+++ b/packages/taquito-michel-codec/src/binary.ts
@@ -194,6 +194,8 @@ const primitives: PrimID[] = [
   'Lambda_rec',
   'LAMBDA_REC',
   'TICKET',
+  'BYTES',
+  'NAT',
 ];
 
 const primTags: { [key in PrimID]?: number } & { [key: string]: number | undefined } =

--- a/packages/taquito-michel-codec/src/michelson-typecheck.ts
+++ b/packages/taquito-michel-codec/src/michelson-typecheck.ts
@@ -1296,8 +1296,16 @@ function functionTypeInternal(
         return [annotateVar({ prim: 'option', args: [{ prim: 'nat' }] }), ...stack.slice(1)];
 
       case 'INT':
-        args(0, ['nat', 'bls12_381_fr']);
+        args(0, ['nat', 'bls12_381_fr', 'bytes']);
         return [annotateVar({ prim: 'int' }), ...stack.slice(1)];
+
+      case 'BYTES':
+        args(0, ['nat', 'int']);
+        return [annotateVar({ prim: 'bytes' }), ...stack.slice(1)];
+
+      case 'NAT':
+        args(0, ['bytes']);
+        return [annotateVar({ prim: 'nat' }), ...stack.slice(1)];
 
       case 'NEG': {
         const s = args(0, ['nat', 'int', 'bls12_381_g1', 'bls12_381_g2', 'bls12_381_fr'])[0];

--- a/packages/taquito-michel-codec/src/michelson-types.ts
+++ b/packages/taquito-michel-codec/src/michelson-types.ts
@@ -399,6 +399,7 @@ export enum Protocol {
   PtJakart2 = 'PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY',
   PtKathman = 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
   PtLimaPtL = 'PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW',
+  PtMumbaii = 'PtMumbaiiFFEGbew1rRjzSPyzRbA51Tm3RVZL5suHPxSZYDhCEc',
   ProtoALpha = 'ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK', // temporary protocol hash
 }
 
@@ -428,7 +429,8 @@ const protoLevel: Record<ProtocolID, number> = {
   PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY: 13,
   PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg: 14,
   PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW: 15,
-  ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK: 16,
+  PtMumbaiiFFEGbew1rRjzSPyzRbA51Tm3RVZL5suHPxSZYDhCEc: 16,
+  ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK: 17,
 };
 
 export function ProtoGreaterOfEqual(a: ProtocolID, b: ProtocolID): boolean {

--- a/packages/taquito-michel-codec/src/michelson-types.ts
+++ b/packages/taquito-michel-codec/src/michelson-types.ts
@@ -79,7 +79,9 @@ type MichelsonNoArgInstructionID =
   | 'XOR'
   | 'RENAME'
   | 'OPEN_CHEST'
-  | 'MIN_BLOCK_TIME';
+  | 'MIN_BLOCK_TIME'
+  | 'BYTES'
+  | 'NAT';
 
 type MichelsonRegularInstructionID =
   | 'CONTRACT'

--- a/packages/taquito-michel-codec/src/michelson-validator.ts
+++ b/packages/taquito-michel-codec/src/michelson-validator.ts
@@ -87,6 +87,8 @@ const noArgInstructionIDs: Record<MichelsonNoArgInstruction['prim'], true> = {
   OPEN_CHEST: true,
   SUB_MUTEZ: true,
   MIN_BLOCK_TIME: true,
+  BYTES: true,
+  NAT: true,
 };
 
 export const instructionIDs: Record<MichelsonInstruction['prim'], true> = Object.assign(

--- a/packages/taquito-michel-codec/test/contracts_016.spec.ts
+++ b/packages/taquito-michel-codec/test/contracts_016.spec.ts
@@ -22,6 +22,8 @@ const contracts: {
     'not_bytes.tz',
     'or_bytes.tz',
     'xor_bytes.tz',
+    'bytes_of_int.tz',
+    'bytes_of_nat.tz',
   ],
 };
 

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/bytes_of_int.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/bytes_of_int.tz
@@ -1,0 +1,25 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       PUSH int 0; BYTES; PUSH bytes 0x; ASSERT_CMPEQ;
+       PUSH int 1; BYTES; PUSH bytes 0x01; ASSERT_CMPEQ;
+       PUSH int 1193046; BYTES; PUSH bytes 0x123456; ASSERT_CMPEQ;
+
+       PUSH bytes 0x123456; INT; PUSH int 1193046; ASSERT_CMPEQ;
+       PUSH bytes 0x0000123456; INT; PUSH int 1193046; ASSERT_CMPEQ;
+       PUSH bytes 0x; INT; PUSH int 0; ASSERT_CMPEQ;
+       PUSH bytes 0x0000; INT; PUSH int 0; ASSERT_CMPEQ;
+
+       PUSH int -128; BYTES; PUSH bytes 0x80; ASSERT_CMPEQ;
+       PUSH int -129; BYTES; PUSH bytes 0xff7f; ASSERT_CMPEQ;
+       PUSH int -33024; BYTES; PUSH bytes 0xff7f00; ASSERT_CMPEQ;
+       PUSH int -4294967296; BYTES; PUSH bytes 0xff00000000; ASSERT_CMPEQ;
+
+       PUSH bytes 0x80; INT; PUSH int -128; ASSERT_CMPEQ;
+       PUSH bytes 0xff7f; INT; PUSH int -129; ASSERT_CMPEQ;
+       PUSH bytes 0xff7f00; INT; PUSH int -33024; ASSERT_CMPEQ;
+       PUSH bytes 0xffffff7f00; INT; PUSH int -33024; ASSERT_CMPEQ;
+       PUSH bytes 0xff00000000; INT; PUSH int -4294967296; ASSERT_CMPEQ;
+
+       UNIT; NIL operation; PAIR; }

--- a/packages/taquito-michel-codec/test/contracts_016/opcodes/bytes_of_nat.tz
+++ b/packages/taquito-michel-codec/test/contracts_016/opcodes/bytes_of_nat.tz
@@ -1,0 +1,14 @@
+parameter unit;
+storage unit;
+code { DROP;
+
+       PUSH nat 0; BYTES; PUSH bytes 0x; ASSERT_CMPEQ;
+       PUSH nat 1; BYTES; PUSH bytes 0x01; ASSERT_CMPEQ;
+       PUSH nat 1193046; BYTES; PUSH bytes 0x123456; ASSERT_CMPEQ;
+
+       PUSH bytes 0x123456; NAT; PUSH nat 1193046; ASSERT_CMPEQ;
+       PUSH bytes 0x0000123456; NAT; PUSH nat 1193046; ASSERT_CMPEQ;
+       PUSH bytes 0x; NAT; PUSH nat 0; ASSERT_CMPEQ;
+       PUSH bytes 0x0000; NAT; PUSH nat 0; ASSERT_CMPEQ;
+
+       UNIT; NIL operation; PAIR; }


### PR DESCRIPTION
adds support for bytes conversion bytes -> nat / int and vice versa

adds support to local-forger for the bytes code for BYTES and NAT instructions

close #2268

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
