### PR TITLE
Added support for smart_rollup_add_messages op and relevant tests

### DIFF
--- a/docs/smart_rollups.md
+++ b/docs/smart_rollups.md
@@ -39,4 +39,4 @@ const op = await Tezos.contract.smartRollupAddMessages({
 await op.confirmation();
 ```
 
-- `message` property is an encoded outbox message. For more information on how to encode or what message gets encoded, refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html#sending-an-external-inbox-message)
+- `message` property receives an array of encoded outbox messages. For more information on how to encode or what message gets encoded, refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html#sending-an-external-inbox-message)

--- a/docs/smart_rollups.md
+++ b/docs/smart_rollups.md
@@ -33,13 +33,10 @@ for more information, refer to [this document](https://tezos.gitlab.io/mumbai/sm
 const op = await Tezos.contract.smartRollupAddMessages({
     message: [
         '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74'
-    ],
-    gasLimit: 1100
+    ]
 });
 
 await op.confirmation();
 ```
 
 - `message` property is an encoded outbox message. For more information on how to encode or what message gets encoded, refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html#sending-an-external-inbox-message)
-- `gasLimit` is an optional parameter, but the value might vary depending on the length and the contents of your `message`. So adjust this value according to your needs
-

--- a/docs/smart_rollups.md
+++ b/docs/smart_rollups.md
@@ -5,7 +5,7 @@ author: Davis Sawali
 
 # Smart Optimistic Rollups
 
-Rollups are a permissionless scaling for the Tezos blockchain. The idea is that anyone can originate and operate one or more rollups, increasing the overall throughput of the Tezos blockchain.
+Rollups are a permissionless scaling implementation for the Tezos blockchain. The idea is that anyone can originate and operate one or more rollups, increasing the overall throughput of the Tezos blockchain.
 
 In Taquito, we have implemented some of the operations included in Mumbai protocol update in regards to smart rollups. In this document, we will go through the ones that we support. We will also go over smart rollups in a more high level view, if you'd like to understand the feature a bit deeper, you can refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html).
 

--- a/docs/smart_rollups.md
+++ b/docs/smart_rollups.md
@@ -1,0 +1,45 @@
+---
+title: Smart Rollups
+author: Davis Sawali 
+---
+
+# Smart Optimistic Rollups
+
+Rollups are a permissionless scaling for the Tezos blockchain. The idea is that anyone can originate and operate one or more rollups, increasing the overall throughput of the Tezos blockchain.
+
+In Taquito, we have implemented some of the operations included in Mumbai protocol update in regards to smart rollups. In this document, we will go through the ones that we support. We will also go over smart rollups in a more high level view, if you'd like to understand the feature a bit deeper, you can refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html).
+
+## `smart_rollup_add_messages`
+The add messages operation allows users to send external messages into a rollup inbox. We will go into a bit more detail down below on what that means.
+
+### Usage
+The main use case of sending messages, is usually to denote contract calls. These messages usually takes the form of this object:
+```
+MESSAGE='[{\
+  "destination" : "${CONTRACT}", \
+  "parameters" : "\"Hello world\"", \
+  "entrypoint" : "default" 
+  }]'
+``` 
+
+If you read closely, the message includes a `destination`, a `parameter`, and an `entrypoint` property. All components needed to **call an entrypoint** of a contract.
+
+These messages can then be claimed back into L1 as a legitimate contract call using the `smart_rollup_execute_outbox_message` operation which we will go over in another section of this doc.
+
+for more information, refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html#sending-an-external-inbox-message)
+
+### Example
+```typescript
+const op = await Tezos.contract.smartRollupAddMessages({
+    message: [
+        '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74'
+    ],
+    gasLimit: 1100
+});
+
+await op.confirmation();
+```
+
+- `message` property is an encoded outbox message. For more information on how to encode or what message gets encoded, refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html#sending-an-external-inbox-message)
+- `gasLimit` is an optional parameter, but the value might vary depending on the length and the contents of your `message`. So adjust this value according to your needs
+

--- a/docs/smart_rollups.md
+++ b/docs/smart_rollups.md
@@ -7,7 +7,7 @@ author: Davis Sawali
 
 Rollups are a permissionless scaling implementation for the Tezos blockchain. The idea is that anyone can originate and operate one or more rollups, increasing the overall throughput of the Tezos blockchain.
 
-In Taquito, we have implemented some of the operations included in Mumbai protocol update in regards to smart rollups. In this document, we will go through the ones that we support. We will also go over smart rollups in a more high level view, if you'd like to understand the feature a bit deeper, you can refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html).
+In Taquito, we have implemented some of the operations included in Mumbai protocol update in regards to smart rollups. In this document, we will go through the operations we support. We also won't go too detailed on how rollups work behind the scenes, if you'd like to understand the feature a bit deeper, you can refer to [this document](https://tezos.gitlab.io/mumbai/smart_rollups.html).
 
 ## `smart_rollup_add_messages`
 The add messages operation allows users to send external messages into a rollup inbox. We will go into a bit more detail down below on what that means.

--- a/integration-tests/contract-batch-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-batch-smart-rollup-add-messages.spec.ts
@@ -1,0 +1,34 @@
+import { CONFIGS } from './config';
+import { ligoSample } from './data/ligo-simple-contract';
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+
+  describe(`Test contract.batch with smart rollup add messages using: ${rpc}`, () => {
+    beforeEach(async (done) => {
+      await setup(true);
+      done();
+    });
+
+    it('should be able to batch smart rollup add messages with other operations', async (done) => {
+      const batch = Tezos.contract
+        .batch()
+        .withSmartRollupAddMessages({
+          message: ['0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74'],
+          gasLimit: 1100
+        })
+        .withOrigination({
+          balance: '1',
+          code: ligoSample,
+          storage: 0
+        });
+      const op = await batch.send();
+      await op.confirmation();
+      
+      expect(op.status).toEqual('applied');
+      expect(op.includedInBlock).toBeDefined();
+
+      done();
+    })
+  })
+})

--- a/integration-tests/contract-batch-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-batch-smart-rollup-add-messages.spec.ts
@@ -1,8 +1,10 @@
 import { CONFIGS } from './config';
 import { ligoSample } from './data/ligo-simple-contract';
+import { Protocols } from '@taquito/taquito';
 
-CONFIGS().forEach(({ lib, rpc, setup }) => {
+CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test contract.batch with smart rollup add messages using: ${rpc}`, () => {
     beforeEach(async (done) => {
@@ -10,7 +12,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       done();
     });
 
-    it('should be able to batch smart rollup add messages with other operations', async (done) => {
+    mumbaiAndAlpha('should be able to batch smart rollup add messages with other operations', async (done) => {
       const batch = Tezos.contract
         .batch()
         .withSmartRollupAddMessages({
@@ -29,6 +31,6 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       expect(op.includedInBlock).toBeDefined();
 
       done();
-    })
-  })
-})
+    });
+  });
+});

--- a/integration-tests/contract-batch.spec.ts
+++ b/integration-tests/contract-batch.spec.ts
@@ -4,215 +4,215 @@ import { managerCode } from './data/manager_code';
 import { MANAGER_LAMBDA, OpKind } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }) => {
-    const Tezos = lib;
+  const Tezos = lib;
 
-    describe(`Test contract.batch through contract api using: ${rpc}`, () => {
-        beforeEach(async (done) => {
-            await setup();
-            done();
-        });
-        test('Verify contract.batch simple transfers with origination code in JSON Michelson format',  async (done) => {
-            const batch = Tezos.contract
-                .batch()
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withOrigination({
-                    balance: '1',
-                    code: ligoSample,
-                    storage: 0
-                });
-
-            const op = await batch.send();
-            await op.confirmation();
-            expect(op.status).toEqual('applied');
-            expect(Number(op.consumedGas)).toBeGreaterThan(0);
-            done();
-        });
-
-        test('Verify contract.batch simple transfers with origination code in Michelson format',  async (done) => {
-            const batch = Tezos.contract
-                .batch()
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withOrigination({
-                    balance: '1',
-                    code: ligoSampleMichelson,
-                    storage: 0
-                });
-
-            const op = await batch.send();
-            await op.confirmation();
-            expect(op.status).toEqual('applied');
-            done();
-        });
-
-        test('Verify batch of transfers and origination operation using a combination of the two notations (array of operation with kind mixed with withTransfer method)',  async (done) => {
-            const op = await Tezos.contract.batch([
-                {
-                    kind: OpKind.TRANSACTION,
-                    to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
-                    amount: 0.02
-                },
-                {
-                    kind: OpKind.ORIGINATION,
-                    balance: "1",
-                    code: ligoSample,
-                    storage: 0,
-                }
-            ])
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                .send();
-            await op.confirmation();
-            expect(op.status).toEqual('applied')
-            done();
-        })
-
-        test('Verify handling of contract.batch simple transfers with bad origination',  async (done) => {
-            expect.assertions(1);
-            try {
-                await Tezos.contract
-                    .batch()
-                    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                    .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
-                    .withOrigination({
-                        balance: '1',
-                        code: ligoSample,
-                        storage: 0,
-                        storageLimit: 0
-                    })
-                    .send();
-            } catch (ex) {
-                expect(ex).toEqual(
-                    expect.objectContaining({
-                        message: expect.stringContaining('storage_exhausted.operation')
-                    })
-                );
-            }
-            done();
-        });
-
-        test('Verify transfer and origination for contract.batch simple transfers from an account with low balance',  async (done) => {
-            const LocalTez = await createAddress();
-            const op = await Tezos.contract.transfer({ to: await LocalTez.signer.publicKeyHash(), amount: 2 });
-            await op.confirmation();
-
-            const contract = await Tezos.contract.at(knownContract);
-
-            const batchOp = await LocalTez.contract
-                .batch([
-                    {
-                        kind: OpKind.TRANSACTION,
-                        to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
-                        amount: 0.01
-                    },
-                    {
-                        kind: OpKind.ORIGINATION,
-                        balance: '0',
-                        code: ligoSample,
-                        storage: 0
-                    }
-                ])
-                .send();
-            await batchOp.confirmation();
-            expect(op.status).toEqual('applied');
-            done();
-        });
-
-        test('Verify contract.batch simple transfers with chained contract calls',  async (done) => {
-            const op = await Tezos.contract.originate({
-                balance: '1',
-                code: managerCode,
-                init: { string: await Tezos.signer.publicKeyHash() }
-            });
-
-            const contract = await op.contract();
-            expect(op.status).toEqual('applied');
-
-            const batch = Tezos.contract
-                .batch()
-                .withTransfer({ to: contract.address, amount: 1 })
-                .withContractCall(
-                    contract.methods.do(MANAGER_LAMBDA.transferImplicit('tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh', 5))
-                )
-                .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)))
-                .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()));
-
-            const batchOp = await batch.send();
-
-            await batchOp.confirmation();
-
-            expect(batchOp.status).toEqual('applied');
-            done();
-        });
-
-        test('Verify contract.batch of simple transfers and a contract entrypoint call using the array notation with kind',  async (done) => {
-            const contract = await Tezos.contract.at(knownContract);
-            const batchOp = await Tezos.contract
-                .batch([
-                    { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 },
-                    { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 },
-                    { kind: OpKind.TRANSACTION, ...contract.methods.default([['Unit']]).toTransferParams() }
-                ])
-                .send();
-
-            await batchOp.confirmation();
-
-            expect(batchOp.status).toEqual('applied');
-            done();
-        });
-
-        test('Verify that with a batch of multiple originations contract address info can be got from the getOriginatedContractAddresses member function', async (done) => {
-            const batch = Tezos.contract
-                .batch()
-                .withOrigination({
-                  balance: '1',
-                  code: ligoSample,
-                  storage: 0
-                })
-                .withOrigination({
-                  balance: '1',
-                  code: ligoSampleMichelson,
-                  storage: 0
-                })
-                
-            const op = await batch.send();
-            await op.confirmation();
-            
-            const addresses = op.getOriginatedContractAddresses();
-            expect(op.status).toEqual('applied');
-            expect(addresses.length).toEqual(2);
-            done();
-          })
-        
-        test('Verify batch contract calls can specify amount, fee, gasLimit and storageLimit', async (done) => {
-            const op = await Tezos.contract.originate({
-                balance: "1",
-                code: managerCode,
-                init: { "string": await Tezos.signer.publicKeyHash() },
-            })
-            const contract = await op.contract();
-    
-            const estimateOp = await Tezos.estimate.batch([
-                { ...(contract.methodsObject.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 5)).toTransferParams()), kind: OpKind.TRANSACTION },
-                { ...(contract.methodsObject.do(MANAGER_LAMBDA.setDelegate(knownBaker)).toTransferParams()), kind: OpKind.TRANSACTION },
-                { ...(contract.methodsObject.do(MANAGER_LAMBDA.removeDelegate()).toTransferParams()), kind: OpKind.TRANSACTION },
-            ])
-    
-            const batch = Tezos.contract.batch()
-                .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 5)), { fee: estimateOp[0].suggestedFeeMutez, gasLimit: estimateOp[0].gasLimit, storageLimit: estimateOp[0].storageLimit })
-                .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)), { fee: estimateOp[1].suggestedFeeMutez, gasLimit: estimateOp[1].gasLimit, storageLimit: estimateOp[1].storageLimit })
-                .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()), { fee: estimateOp[2].suggestedFeeMutez, gasLimit: estimateOp[2].gasLimit, storageLimit: estimateOp[2].storageLimit })
-            const batchOp = await batch.send();
-            await batchOp.confirmation();
-
-            expect(batchOp.fee).toEqual(estimateOp[0].suggestedFeeMutez + estimateOp[1].suggestedFeeMutez + estimateOp[2].suggestedFeeMutez)
-            expect(batchOp.gasLimit).toEqual(estimateOp[0].gasLimit + estimateOp[1].gasLimit + estimateOp[2].gasLimit)
-            expect(batchOp.storageLimit).toEqual(estimateOp[0].storageLimit + estimateOp[1].storageLimit + estimateOp[2].storageLimit)
-            done()
-        })
+  describe(`Test contract.batch through contract api using: ${rpc}`, () => {
+    beforeEach(async (done) => {
+      await setup();
+      done();
     });
+    test('Verify contract.batch simple transfers with origination code in JSON Michelson format', async (done) => {
+      const batch = Tezos.contract
+        .batch()
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withOrigination({
+          balance: '1',
+          code: ligoSample,
+          storage: 0
+        });
+
+      const op = await batch.send();
+      await op.confirmation();
+      expect(op.status).toEqual('applied');
+      expect(Number(op.consumedGas)).toBeGreaterThan(0);
+      done();
+    });
+
+    test('Verify contract.batch simple transfers with origination code in Michelson format', async (done) => {
+      const batch = Tezos.contract
+        .batch()
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withOrigination({
+          balance: '1',
+          code: ligoSampleMichelson,
+          storage: 0
+        });
+
+      const op = await batch.send();
+      await op.confirmation();
+      expect(op.status).toEqual('applied');
+      done();
+    });
+
+    test('Verify batch of transfers and origination operation using a combination of the two notations (array of operation with kind mixed with withTransfer method)', async (done) => {
+      const op = await Tezos.contract.batch([
+        {
+          kind: OpKind.TRANSACTION,
+          to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+          amount: 0.02
+        },
+        {
+          kind: OpKind.ORIGINATION,
+          balance: "1",
+          code: ligoSample,
+          storage: 0,
+        }
+      ])
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+        .send();
+      await op.confirmation();
+      expect(op.status).toEqual('applied')
+      done();
+    })
+
+    test('Verify handling of contract.batch simple transfers with bad origination', async (done) => {
+      expect.assertions(1);
+      try {
+        await Tezos.contract
+          .batch()
+          .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+          .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+          .withTransfer({ to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 })
+          .withOrigination({
+            balance: '1',
+            code: ligoSample,
+            storage: 0,
+            storageLimit: 0
+          })
+          .send();
+      } catch (ex) {
+        expect(ex).toEqual(
+          expect.objectContaining({
+            message: expect.stringContaining('storage_exhausted.operation')
+          })
+        );
+      }
+      done();
+    });
+
+    test('Verify transfer and origination for contract.batch simple transfers from an account with low balance', async (done) => {
+      const LocalTez = await createAddress();
+      const op = await Tezos.contract.transfer({ to: await LocalTez.signer.publicKeyHash(), amount: 2 });
+      await op.confirmation();
+
+      const contract = await Tezos.contract.at(knownContract);
+
+      const batchOp = await LocalTez.contract
+        .batch([
+          {
+            kind: OpKind.TRANSACTION,
+            to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+            amount: 0.01
+          },
+          {
+            kind: OpKind.ORIGINATION,
+            balance: '0',
+            code: ligoSample,
+            storage: 0
+          }
+        ])
+        .send();
+      await batchOp.confirmation();
+      expect(op.status).toEqual('applied');
+      done();
+    });
+
+    test('Verify contract.batch simple transfers with chained contract calls', async (done) => {
+      const op = await Tezos.contract.originate({
+        balance: '1',
+        code: managerCode,
+        init: { string: await Tezos.signer.publicKeyHash() }
+      });
+
+      const contract = await op.contract();
+      expect(op.status).toEqual('applied');
+
+      const batch = Tezos.contract
+        .batch()
+        .withTransfer({ to: contract.address, amount: 1 })
+        .withContractCall(
+          contract.methods.do(MANAGER_LAMBDA.transferImplicit('tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh', 5))
+        )
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)))
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()));
+
+      const batchOp = await batch.send();
+
+      await batchOp.confirmation();
+
+      expect(batchOp.status).toEqual('applied');
+      done();
+    });
+
+    test('Verify contract.batch of simple transfers and a contract entrypoint call using the array notation with kind', async (done) => {
+      const contract = await Tezos.contract.at(knownContract);
+      const batchOp = await Tezos.contract
+        .batch([
+          { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 },
+          { kind: OpKind.TRANSACTION, to: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu', amount: 0.02 },
+          { kind: OpKind.TRANSACTION, ...contract.methods.default([['Unit']]).toTransferParams() }
+        ])
+        .send();
+
+      await batchOp.confirmation();
+
+      expect(batchOp.status).toEqual('applied');
+      done();
+    });
+
+    test('Verify that with a batch of multiple originations contract address info can be got from the getOriginatedContractAddresses member function', async (done) => {
+      const batch = Tezos.contract
+        .batch()
+        .withOrigination({
+          balance: '1',
+          code: ligoSample,
+          storage: 0
+        })
+        .withOrigination({
+          balance: '1',
+          code: ligoSampleMichelson,
+          storage: 0
+        })
+
+      const op = await batch.send();
+      await op.confirmation();
+
+      const addresses = op.getOriginatedContractAddresses();
+      expect(op.status).toEqual('applied');
+      expect(addresses.length).toEqual(2);
+      done();
+    })
+
+    test('Verify batch contract calls can specify amount, fee, gasLimit and storageLimit', async (done) => {
+      const op = await Tezos.contract.originate({
+        balance: "1",
+        code: managerCode,
+        init: { "string": await Tezos.signer.publicKeyHash() },
+      })
+      const contract = await op.contract();
+
+      const estimateOp = await Tezos.estimate.batch([
+        { ...(contract.methodsObject.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 5)).toTransferParams()), kind: OpKind.TRANSACTION },
+        { ...(contract.methodsObject.do(MANAGER_LAMBDA.setDelegate(knownBaker)).toTransferParams()), kind: OpKind.TRANSACTION },
+        { ...(contract.methodsObject.do(MANAGER_LAMBDA.removeDelegate()).toTransferParams()), kind: OpKind.TRANSACTION },
+      ])
+
+      const batch = Tezos.contract.batch()
+        .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.transferImplicit("tz1eY5Aqa1kXDFoiebL28emyXFoneAoVg1zh", 5)), { fee: estimateOp[0].suggestedFeeMutez, gasLimit: estimateOp[0].gasLimit, storageLimit: estimateOp[0].storageLimit })
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.setDelegate(knownBaker)), { fee: estimateOp[1].suggestedFeeMutez, gasLimit: estimateOp[1].gasLimit, storageLimit: estimateOp[1].storageLimit })
+        .withContractCall(contract.methods.do(MANAGER_LAMBDA.removeDelegate()), { fee: estimateOp[2].suggestedFeeMutez, gasLimit: estimateOp[2].gasLimit, storageLimit: estimateOp[2].storageLimit })
+      const batchOp = await batch.send();
+      await batchOp.confirmation();
+
+      expect(batchOp.fee).toEqual(estimateOp[0].suggestedFeeMutez + estimateOp[1].suggestedFeeMutez + estimateOp[2].suggestedFeeMutez)
+      expect(batchOp.gasLimit).toEqual(estimateOp[0].gasLimit + estimateOp[1].gasLimit + estimateOp[2].gasLimit)
+      expect(batchOp.storageLimit).toEqual(estimateOp[0].storageLimit + estimateOp[1].storageLimit + estimateOp[2].storageLimit)
+      done()
+    })
+  });
 });

--- a/integration-tests/contract-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-smart-rollup-add-messages.spec.ts
@@ -1,0 +1,28 @@
+import { CONFIGS } from './config';
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+  describe(`Smart Rollup Add Messages operation test using: ${rpc}`, () => {
+    beforeEach(async (done) => {
+      await setup(true);
+
+      done();
+    });
+
+    it('Should be able to inject a Smart Rollup Add Messages operation', async (done) => {
+      const op = await Tezos.contract.smartRollupAddMessages({
+        message: [
+          '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74'
+        ],
+        gasLimit: 1100
+      });
+      await op.confirmation();
+
+      expect(op.status).toEqual('applied');
+      expect(op.message).toEqual(['0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74']);
+      expect(op.results).toBeDefined();
+
+      done();
+    });
+  });
+});

--- a/integration-tests/contract-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-smart-rollup-add-messages.spec.ts
@@ -1,7 +1,10 @@
 import { CONFIGS } from './config';
+import { Protocols } from '@taquito/taquito';
 
-CONFIGS().forEach(({ lib, rpc, setup }) => {
+CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
   const Tezos = lib;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  
   describe(`Smart Rollup Add Messages operation test using: ${rpc}`, () => {
     beforeEach(async (done) => {
       await setup(true);
@@ -9,7 +12,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       done();
     });
 
-    it('Should be able to inject a Smart Rollup Add Messages operation', async (done) => {
+    mumbaiAndAlpha('Should be able to inject a Smart Rollup Add Messages operation', async (done) => {
       const op = await Tezos.contract.smartRollupAddMessages({
         message: [
           '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74'

--- a/integration-tests/contract-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-smart-rollup-add-messages.spec.ts
@@ -17,7 +17,6 @@ CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
         message: [
           '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74'
         ],
-        gasLimit: 1100
       });
       await op.confirmation();
 

--- a/packages/taquito/src/batch/rpc-batch-provider.ts
+++ b/packages/taquito/src/batch/rpc-batch-provider.ts
@@ -13,6 +13,7 @@ import {
   createTxRollupBatchOperation,
   createTransferTicketOperation,
   createIncreasePaidStorageOperation,
+  createSmartRollupAddMessagesOperation,
 } from '../contract/prepare';
 import { BatchOperation } from '../operations/batch-operation';
 import { OperationEmitter } from '../operations/operation-emitter';
@@ -31,6 +32,7 @@ import {
   TxRollupBatchParams,
   TransferTicketParams,
   IncreasePaidStorageParams,
+  SmartRollupAddMessagesParams,
 } from '../operations/types';
 import { OpKind } from '@taquito/rpc';
 import { ContractMethodObject } from '../contract/contract-methods/contract-method-object-param';
@@ -186,6 +188,17 @@ export class OperationBatch extends OperationEmitter {
 
   /**
    *
+   * @description Add an operation to add messages to a smart rollup
+   *
+   * @param params Rollup origination operation parameter
+   */
+  withSmartRollupAddMessages(params: SmartRollupAddMessagesParams) {
+    this.operations.push({ kind: OpKind.SMART_ROLLUP_ADD_MESSAGES, ...params });
+    return this;
+  }
+
+  /**
+   *
    * @description Add an operation to submit a tx rollup batch to the batch
    *
    * @param params Tx rollup batch operation parameter
@@ -235,6 +248,10 @@ export class OperationBatch extends OperationEmitter {
         return createTransferTicketOperation({
           ...param,
         });
+      case OpKind.SMART_ROLLUP_ADD_MESSAGES:
+        return createSmartRollupAddMessagesOperation({
+          ...param,
+        });
       default:
         throw new InvalidOperationKindError((param as any).kind);
     }
@@ -275,6 +292,9 @@ export class OperationBatch extends OperationEmitter {
           break;
         case OpKind.TRANSFER_TICKET:
           this.withTransferTicket(param);
+          break;
+        case OpKind.SMART_ROLLUP_ADD_MESSAGES:
+          this.withSmartRollupAddMessages(param);
           break;
         default:
           throw new InvalidOperationKindError((param as any).kind);

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -24,6 +24,7 @@ import {
   BallotParams,
   ProposalsParams,
   UpdateConsensusKeyParams,
+  SmartRollupAddMessagesParams,
 } from '../operations/types';
 import { ContractAbstraction, ContractStorageType, DefaultContractType } from './contract';
 import { TxRollupBatchOperation } from '../operations/tx-rollup-batch-operation';
@@ -33,6 +34,7 @@ import { DrainDelegateOperation } from '../operations';
 import { BallotOperation } from '../operations';
 import { ProposalsOperation } from '../operations/proposals-operation';
 import { UpdateConsensusKeyOperation } from '../operations/update-consensus-key-operation';
+import { SmartRollupAddMessagesOperation } from '../operations/smart-rollup-add-messages-operation';
 
 export type ContractSchema = Schema | unknown;
 
@@ -271,4 +273,16 @@ export interface ContractProvider extends StorageProvider {
    * @param UpdateConsensusKeyParams UpdateConsensusKey operation parameter
    */
   updateConsensusKey(params: UpdateConsensusKeyParams): Promise<UpdateConsensusKeyOperation>;
+
+  /**
+   *
+   * @description Smart Rollup Add Messages
+   *
+   * @returns An operation handle with the result from the RPC node
+   *
+   * @param SmartRollupAddMessagesParams smartRollupAddMessages operation parameter
+   */
+  smartRollupAddMessages(
+    params: SmartRollupAddMessagesParams
+  ): Promise<SmartRollupAddMessagesOperation>;
 }

--- a/packages/taquito/src/contract/prepare.ts
+++ b/packages/taquito/src/contract/prepare.ts
@@ -29,6 +29,8 @@ import {
   RPCProposalsOperation,
   UpdateConsensusKeyParams,
   RPCUpdateConsensusKeyOperation,
+  SmartRollupAddMessagesParams,
+  RPCSmartRollupAddMessagesOperation,
 } from '../operations/types';
 import { DEFAULT_FEE, DEFAULT_GAS_LIMIT, DEFAULT_STORAGE_LIMIT } from '../constants';
 import { format } from '@taquito/utils';
@@ -318,4 +320,21 @@ export const createUpdateConsensusKeyOperation = async ({
     storage_limit: storageLimit,
     pk,
   } as RPCUpdateConsensusKeyOperation;
+};
+
+export const createSmartRollupAddMessagesOperation = async ({
+  source,
+  fee,
+  gasLimit,
+  storageLimit,
+  message,
+}: SmartRollupAddMessagesParams) => {
+  return {
+    kind: OpKind.SMART_ROLLUP_ADD_MESSAGES,
+    source,
+    fee,
+    gas_limit: gasLimit,
+    storage_limit: storageLimit,
+    message,
+  } as RPCSmartRollupAddMessagesOperation;
 };

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -701,7 +701,7 @@ export class RpcContractProvider
   }
 
   /**
-   * @description
+   * @description Adds messages to the rollup inbox that can be executed/claimed after it gets cemented
    * @param SmartRollupAddMessagesParams
    * @returns An operation handle with results from the RPC node
    */

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -718,7 +718,6 @@ export class RpcContractProvider
 
     const ops = await this.addRevealOperationIfNeeded(operation, publicKeyHash);
     const prepared = await this.prepareOperation({ operation: ops, source: params.source });
-    console.log('PREPARED: ', JSON.stringify(prepared));
     const opBytes = await this.forge(prepared);
     const { hash, context, forgedBytes, opResponse } = await this.signAndInject(opBytes);
 

--- a/packages/taquito/src/estimate/estimate-provider-interface.ts
+++ b/packages/taquito/src/estimate/estimate-provider-interface.ts
@@ -13,6 +13,7 @@ import {
   TransferTicketParams,
   IncreasePaidStorageParams,
   UpdateConsensusKeyParams,
+  SmartRollupAddMessagesParams,
 } from '../operations/types';
 import { Estimate } from './estimate';
 
@@ -128,4 +129,14 @@ export interface EstimationProvider {
    * @param Estimate
    */
   updateConsensusKey(params: UpdateConsensusKeyParams): Promise<Estimate>;
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an Smart Rollup Add Messages operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Estimate
+   */
+  smartRollupAddMessages(params: SmartRollupAddMessagesParams): Promise<Estimate>;
 }

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -456,6 +456,14 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
             })
           );
           break;
+        case OpKind.SMART_ROLLUP_ADD_MESSAGES:
+          operations.push(
+            await createSmartRollupAddMessagesOperation({
+              ...param,
+              ...mergeLimits(param, DEFAULT_PARAMS),
+            })
+          );
+          break;
         default:
           throw new InvalidOperationKindError((params as any).kind);
       }

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -23,6 +23,7 @@ import {
   TransferTicketParams,
   IncreasePaidStorageParams,
   UpdateConsensusKeyParams,
+  SmartRollupAddMessagesParams,
 } from '../operations/types';
 import { Estimate, EstimateProperties } from './estimate';
 import { EstimationProvider } from '../estimate/estimate-provider-interface';
@@ -38,6 +39,7 @@ import {
   createTransferTicketOperation,
   createIncreasePaidStorageOperation,
   createUpdateConsensusKeyOperation,
+  createSmartRollupAddMessagesOperation,
 } from '../contract/prepare';
 import {
   validateAddress,
@@ -679,6 +681,39 @@ export class RPCEstimateProvider extends OperationEmitter implements EstimationP
       protocolConstants,
       pkh
     );
+    if (isRevealNeeded) {
+      estimateProperties.shift();
+    }
+    return Estimate.createEstimateInstanceFromProperties(estimateProperties);
+  }
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for a smart_rollup_add_messages operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Estimate
+   */
+  async smartRollupAddMessages(params: SmartRollupAddMessagesParams) {
+    const { fee, storageLimit, gasLimit, ...rest } = params;
+    const pkh = (await this.getKeys()).publicKeyHash;
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+
+    const DEFAULT_PARAMS = await this.getAccountLimits(pkh, protocolConstants);
+    const op = await createSmartRollupAddMessagesOperation({
+      ...rest,
+      ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
+    });
+
+    const isRevealNeeded = await this.isRevealOpNeeded([op], pkh);
+    const ops = isRevealNeeded ? await this.addRevealOp([op], pkh) : op;
+    const estimateProperties = await this.prepareEstimate(
+      { operation: ops, source: pkh },
+      protocolConstants,
+      pkh
+    );
+
     if (isRevealNeeded) {
       estimateProperties.shift();
     }

--- a/packages/taquito/src/operations/operation-emitter.ts
+++ b/packages/taquito/src/operations/operation-emitter.ts
@@ -173,6 +173,7 @@ export abstract class OperationEmitter {
           case OpKind.TX_ROLLUP_ORIGINATION:
           case OpKind.TX_ROLLUP_SUBMIT_BATCH:
           case OpKind.UPDATE_CONSENSUS_KEY:
+          case OpKind.SMART_ROLLUP_ADD_MESSAGES:
             return {
               ...op,
               ...getSource(op),
@@ -208,7 +209,6 @@ export abstract class OperationEmitter {
               ...op,
               period: currentVotingPeriod?.voting_period.index,
             };
-
           default:
             throw new InvalidOperationKindError((op as any).kind);
         }

--- a/packages/taquito/src/operations/smart-rollup-add-messages-operation.ts
+++ b/packages/taquito/src/operations/smart-rollup-add-messages-operation.ts
@@ -1,0 +1,75 @@
+import {
+  OperationContentsAndResult,
+  OperationContentsAndResultSmartRollupAddMessages,
+} from '@taquito/rpc';
+
+import { Context } from '../context';
+import { Operation } from './operations';
+import {
+  FeeConsumingOperation,
+  ForgedBytes,
+  GasConsumingOperation,
+  StorageConsumingOperation,
+  RPCSmartRollupAddMessagesOperation,
+} from './types';
+
+/**
+ * @description SmartRollupAddMessagesOperation provides utility to fetch properties of SmartRollupAddMessages
+ */
+
+export class SmartRollupAddMessagesOperation
+  extends Operation
+  implements GasConsumingOperation, StorageConsumingOperation, FeeConsumingOperation
+{
+  constructor(
+    hash: string,
+    private readonly params: RPCSmartRollupAddMessagesOperation,
+    public readonly source: string,
+    raw: ForgedBytes,
+    results: OperationContentsAndResult[],
+    context: Context
+  ) {
+    super(hash, raw, results, context);
+  }
+
+  get operationResults() {
+    const smartRollupAddMessagesOp =
+      Array.isArray(this.results) &&
+      (this.results.find(
+        (op) => op.kind === 'smart_rollup_add_messages'
+      ) as OperationContentsAndResultSmartRollupAddMessages);
+    const result =
+      smartRollupAddMessagesOp &&
+      smartRollupAddMessagesOp.metadata &&
+      smartRollupAddMessagesOp.metadata.operation_result;
+    return result ? result : undefined;
+  }
+
+  get status() {
+    return this.operationResults?.status ?? 'unknown';
+  }
+
+  get message() {
+    return this.params.message;
+  }
+
+  get fee() {
+    return this.params.fee;
+  }
+
+  get gasLimit() {
+    return this.params.gas_limit;
+  }
+
+  get storageLimit() {
+    return this.params.storage_limit;
+  }
+
+  get consumedMilliGas() {
+    return this.operationResults?.consumed_milligas;
+  }
+
+  get errors() {
+    return this.operationResults?.errors;
+  }
+}

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -91,7 +91,7 @@ export const isOpWithFee = <T extends { kind: OpKind }>(
       'tx_rollup_submit_batch',
       'transfer_ticket',
       'update_consensus_key',
-      'smart_rollup_add_messagess',
+      'smart_rollup_add_messages',
     ].indexOf(op.kind) !== -1
   );
 };

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -21,7 +21,8 @@ export type ParamsWithKind =
   | withKind<TxRollupOriginateParams, OpKind.TX_ROLLUP_ORIGINATION>
   | withKind<TxRollupBatchParams, OpKind.TX_ROLLUP_SUBMIT_BATCH>
   | withKind<TransferTicketParams, OpKind.TRANSFER_TICKET>
-  | withKind<UpdateConsensusKeyParams, OpKind.UPDATE_CONSENSUS_KEY>;
+  | withKind<UpdateConsensusKeyParams, OpKind.UPDATE_CONSENSUS_KEY>
+  | withKind<SmartRollupAddMessagesParams, OpKind.SMART_ROLLUP_ADD_MESSAGES>;
 
 export type ParamsWithKindExtended = ParamsWithKind | withKind<RevealParams, OpKind.REVEAL>;
 
@@ -59,7 +60,8 @@ export type RPCOpWithFee =
   | RPCTxRollupOriginationOperation
   | RPCTxRollupBatchOperation
   | RPCTransferTicketOperation
-  | RPCUpdateConsensusKeyOperation;
+  | RPCUpdateConsensusKeyOperation
+  | RPCSmartRollupAddMessagesOperation;
 
 export type RPCOpWithSource =
   | RPCTransferOperation
@@ -71,7 +73,8 @@ export type RPCOpWithSource =
   | RPCTxRollupOriginationOperation
   | RPCTxRollupBatchOperation
   | RPCTransferTicketOperation
-  | RPCUpdateConsensusKeyOperation;
+  | RPCUpdateConsensusKeyOperation
+  | RPCSmartRollupAddMessagesOperation;
 
 export const isOpWithFee = <T extends { kind: OpKind }>(
   op: T
@@ -88,6 +91,7 @@ export const isOpWithFee = <T extends { kind: OpKind }>(
       'tx_rollup_submit_batch',
       'transfer_ticket',
       'update_consensus_key',
+      'smart_rollup_add_messagess',
     ].indexOf(op.kind) !== -1
   );
 };
@@ -106,6 +110,7 @@ export const isOpRequireReveal = <T extends { kind: OpKind }>(
       'tx_rollup_submit_batch',
       'transfer_ticket',
       'update_consensus_key',
+      'smart_rollup_add_messages',
     ].indexOf(op.kind) !== -1
   );
 };
@@ -497,6 +502,23 @@ export interface RPCUpdateConsensusKeyOperation {
   pk: string;
 }
 
+export interface RPCSmartRollupAddMessagesOperation {
+  kind: OpKind.SMART_ROLLUP_ADD_MESSAGES;
+  source: string;
+  fee: number;
+  gas_limit: number;
+  storage_limit: number;
+  message: string[];
+}
+
+export interface SmartRollupAddMessagesParams {
+  source?: string;
+  fee?: number;
+  gasLimit?: number;
+  storageLimit?: number;
+  message: string[];
+}
+
 export type RPCOperation =
   | RPCOriginationOperation
   | RPCTransferOperation
@@ -511,7 +533,8 @@ export type RPCOperation =
   | RPCDrainDelegateOperation
   | RPCBallotOperation
   | RPCProposalsOperation
-  | RPCUpdateConsensusKeyOperation;
+  | RPCUpdateConsensusKeyOperation
+  | RPCSmartRollupAddMessagesOperation;
 
 export type PrepareOperationParams = {
   operation: RPCOperation | RPCOperation[];

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -186,6 +186,7 @@ export class PrepareProvider implements PreparationProvider {
         case OpKind.TX_ROLLUP_ORIGINATION:
         case OpKind.TX_ROLLUP_SUBMIT_BATCH:
         case OpKind.UPDATE_CONSENSUS_KEY:
+        case OpKind.SMART_ROLLUP_ADD_MESSAGES:
           return {
             ...op,
             ...this.getSource(op, pkh, source),
@@ -220,12 +221,6 @@ export class PrepareProvider implements PreparationProvider {
           return {
             ...op,
             period: currentVotingPeriod?.voting_period.index,
-          };
-        case OpKind.SMART_ROLLUP_ADD_MESSAGES:
-          return {
-            ...op,
-            ...this.getSource(op, pkh, source),
-            ...this.getFee(op, pkh, headCounter),
           };
         default:
           throw new InvalidOperationKindError((op as any).kind);

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -23,6 +23,7 @@ import {
   ProposalsParams,
   DrainDelegateParams,
   ParamsWithKind,
+  SmartRollupAddMessagesParams,
 } from '../operations/types';
 import { PreparationProvider, PreparedOperation } from './interface';
 import { Protocols } from '../constants';
@@ -49,6 +50,7 @@ import {
   createDrainDelegateOperation,
   DefaultContractType,
   ContractStorageType,
+  createSmartRollupAddMessagesOperation,
 } from '../contract';
 import { Estimate } from '../estimate';
 import { OperationBatch } from '../batch/rpc-batch-provider';
@@ -219,7 +221,12 @@ export class PrepareProvider implements PreparationProvider {
             ...op,
             period: currentVotingPeriod?.voting_period.index,
           };
-
+        case OpKind.SMART_ROLLUP_ADD_MESSAGES:
+          return {
+            ...op,
+            ...this.getSource(op, pkh, source),
+            ...this.getFee(op, pkh, headCounter),
+          };
         default:
           throw new InvalidOperationKindError((op as any).kind);
       }
@@ -744,6 +751,46 @@ export class PrepareProvider implements PreparationProvider {
 
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
+    const contents = this.constructOpContents(ops, headCounter, pkh, source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  /**
+   *
+   * @description Method to prepare a smart_rollup_add_messages operation
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   * @returns a PreparedOperation object
+   */
+  async smartRollupAddMessages(
+    params: SmartRollupAddMessagesParams,
+    source?: string
+  ): Promise<PreparedOperation> {
+    const pkh = await this.signer.publicKeyHash();
+
+    const estimate = await this.estimate.smartRollupAddMessages(params);
+    const estimates = this.buildEstimates(estimate);
+
+    const op = await createSmartRollupAddMessagesOperation({
+      ...params,
+      ...estimates,
+    });
+
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
 
     return {

--- a/packages/taquito/test/batch/rpc-batch-provider.spec.ts
+++ b/packages/taquito/test/batch/rpc-batch-provider.spec.ts
@@ -694,6 +694,143 @@ describe('OperationBatch test', () => {
     });
   });
 
+  describe('withSmartRollupAddMessage op', () => {
+    it('should produce a batch op which contains a smartRollupAddMessages operation', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
+
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.SMART_ROLLUP_ADD_MESSAGES,
+          message: [
+            '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+          ],
+        },
+      ];
+
+      const batchOp = await operationBatch.with(opToBatch).send();
+
+      expect(batchOp.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_pub_key_hash',
+              fee: '475',
+              gas_limit: '1330',
+              storage_limit: '93',
+              message: [
+                '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+              ],
+              counter: '123457',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 123456,
+      });
+      done();
+    });
+
+    it('should produce a batch op with estimate values overridden', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimate]);
+
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.SMART_ROLLUP_ADD_MESSAGES,
+          message: [
+            '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+          ],
+          gasLimit: 1100,
+          fee: 399,
+          storageLimit: 95,
+        },
+      ];
+
+      const batchOp = await operationBatch.with(opToBatch).send();
+
+      expect(batchOp.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_pub_key_hash',
+              fee: '399',
+              gas_limit: '1100',
+              storage_limit: '95',
+              message: [
+                '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+              ],
+              counter: '123457',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 123456,
+      });
+      done();
+    });
+
+    it('should produce a batch op with reveal operation', async (done) => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      const estimateReveal = new Estimate(1000000, 0, 64, 250);
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.batch.mockResolvedValue([estimateReveal, estimate]);
+
+      const opToBatch: ParamsWithKind[] = [
+        {
+          kind: OpKind.SMART_ROLLUP_ADD_MESSAGES,
+          message: [
+            '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+          ],
+        },
+      ];
+
+      const batchOp = await operationBatch.with(opToBatch).send();
+
+      expect(batchOp.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '374',
+              public_key: 'test_pub_key',
+              source: 'test_pub_key_hash',
+              gas_limit: '1100',
+              storage_limit: '0',
+              counter: '123457',
+            },
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_pub_key_hash',
+              fee: '475',
+              gas_limit: '1330',
+              storage_limit: '93',
+              message: [
+                '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+              ],
+              counter: '123458',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 123456,
+      });
+
+      done();
+    });
+  });
+
   describe('with txRollupOriginate operation', () => {
     it('should produce a batch operation which contains an txRollupOriginate operation', async (done) => {
       const estimate = new Estimate(1230000, 93, 142, 250);

--- a/packages/taquito/test/contract/helper.ts
+++ b/packages/taquito/test/contract/helper.ts
@@ -1678,3 +1678,41 @@ export const updateConsensusKeyNoReveal = {
   signature:
     'sigrsWF7LpFpUBrTdvLnKm8DMuijk1LcZovZdKZDgsaafTPZhKsvLzPFHDzZYKCy4kobkgxVL7YPGnU5qzJJBcP2cAu5HW1C',
 };
+
+export const smartRollupAddMessagesNoReveal = {
+  contents: [
+    {
+      kind: 'smart_rollup_add_messages',
+      source: 'tz2Q3yRaczTqZVf3ZQvwiiTqKjhJFyDzeRSz',
+      fee: '398',
+      counter: '12191',
+      gas_limit: '1103',
+      storage_limit: '0',
+      message: [
+        '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+      ],
+      metadata: {
+        balance_updates: [
+          {
+            kind: 'contract',
+            contract: 'tz2Q3yRaczTqZVf3ZQvwiiTqKjhJFyDzeRSz',
+            change: '-398',
+            origin: 'block',
+          },
+          {
+            kind: 'accumulator',
+            category: 'block fees',
+            change: '398',
+            origin: 'block',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          consumed_milligas: '1002777',
+        },
+      },
+    },
+  ],
+  signature:
+    'sigSUjvKxjAZ4dBWbo4idKKwFDVfLtYscMMqHoQY8KgyghtyaswECPaBhjK921vj2uEsdKD7WJTeVVT1ZDcvwp8rkRuEW9kv',
+};

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -1932,8 +1932,6 @@ describe('RpcContractProvider test', () => {
         ],
       });
 
-      console.log(JSON.stringify(op.raw));
-
       expect(op.raw).toEqual({
         opbytes: 'test',
         opOb: {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -85,6 +85,7 @@ describe('RpcContractProvider test', () => {
     transferTicket: jest.Mock<any, any>;
     increasePaidStorage: jest.Mock<any, any>;
     updateConsensusKey: jest.Mock<any, any>;
+    smartRollupAddMessages: jest.Mock<any, any>;
   };
 
   const revealOp = (source: string) => ({
@@ -141,6 +142,7 @@ describe('RpcContractProvider test', () => {
       transferTicket: jest.fn(),
       increasePaidStorage: jest.fn(),
       updateConsensusKey: jest.fn(),
+      smartRollupAddMessages: jest.fn(),
     };
 
     // Required for operations confirmation polling
@@ -1914,6 +1916,83 @@ describe('RpcContractProvider test', () => {
         },
         counter: 0,
       });
+      done();
+    });
+  });
+
+  describe('smartRollupAddMessages', async () => {
+    it('should produce a smartRollupAddMessages op', async (done) => {
+      mockRpcClient.getManagerKey.mockReturnValue('test_pub_key_hash');
+      mockEstimate.reveal.mockResolvedValue(undefined);
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.smartRollupAddMessages.mockResolvedValue(estimate);
+      const op = await rpcContractProvider.smartRollupAddMessages({
+        message: [
+          '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+        ],
+      });
+
+      console.log(JSON.stringify(op.raw));
+
+      expect(op.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_pub_key_hash',
+              fee: '475',
+              gas_limit: '1330',
+              storage_limit: '93',
+              message: [
+                '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+              ],
+              counter: '1',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+
+      done();
+    });
+
+    it('should produce a smartRollupAddMessages op with reveal', async (done) => {
+      const estimate = new Estimate(1230000, 93, 142, 250);
+      mockEstimate.smartRollupAddMessages.mockResolvedValue(estimate);
+      const op = await rpcContractProvider.smartRollupAddMessages({
+        message: [
+          '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+        ],
+      });
+
+      expect(op.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            revealOp('test_pub_key_hash'),
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_pub_key_hash',
+              fee: '475',
+              gas_limit: '1330',
+              storage_limit: '93',
+              message: [
+                '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+              ],
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+
       done();
     });
   });

--- a/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
@@ -1730,9 +1730,9 @@ describe('RPCEstimateProvider test wallet', () => {
         ],
       });
 
-      expect(estimate.gasLimit).toEqual(100);
+      expect(estimate.gasLimit).toEqual(1103);
       expect(estimate.storageLimit).toEqual(0);
-      expect(estimate.suggestedFeeMutez).toEqual(212);
+      expect(estimate.suggestedFeeMutez).toEqual(313);
       done();
     });
 

--- a/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
@@ -23,6 +23,7 @@ import {
   TransferTicketNoReveal,
   TransferTicketWithReveal,
   updateConsensusKeyNoReveal,
+  smartRollupAddMessagesNoReveal,
 } from '../contract/helper';
 import { OpKind } from '@taquito/rpc';
 import { TransferTicketParams } from '../../src/operations/types';
@@ -1710,6 +1711,39 @@ describe('RPCEstimateProvider test wallet', () => {
         await estimateProvider.txRollupSubmitBatch({
           rollup: 'txr1YTdi9BktRmybwhgkhRK7WPrutEWVGJT7w',
           content: '626c6f62',
+        });
+      } catch (e) {
+        expect(e.message).toEqual(
+          'Unable to estimate the reveal operation, the public key is unknown'
+        );
+      }
+      done();
+    });
+  });
+
+  describe('smartRollupAddMessages', () => {
+    it('should return the correct estimate for smartRollupAddMessages op', async (done) => {
+      mockRpcClient.runOperation.mockResolvedValue(smartRollupAddMessagesNoReveal);
+      const estimate = await estimateProvider.smartRollupAddMessages({
+        message: [
+          '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+        ],
+      });
+
+      expect(estimate.gasLimit).toEqual(100);
+      expect(estimate.storageLimit).toEqual(0);
+      expect(estimate.suggestedFeeMutez).toEqual(212);
+      done();
+    });
+
+    it('should return an error if account is unrevealed', async (done) => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+
+      try {
+        await estimateProvider.smartRollupAddMessages({
+          message: [
+            '0000000031010000000b48656c6c6f20776f726c6401cc9e352a850d7475bf9b6cf103aa17ca404bc9dd000000000764656661756c74',
+          ],
         });
       } catch (e) {
         expect(e.message).toEqual(

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -939,7 +939,6 @@ describe('PrepareProvider test', () => {
           '0000000062010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
         ],
       });
-      console.log(JSON.stringify(prepared));
 
       expect(prepared).toEqual({
         opOb: {

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -131,6 +131,7 @@ describe('PrepareProvider test', () => {
     jest.spyOn(context.estimate, 'txRollupOriginate').mockResolvedValue(estimate);
     jest.spyOn(context.estimate, 'txRollupSubmitBatch').mockResolvedValue(estimate);
     jest.spyOn(context.estimate, 'updateConsensusKey').mockResolvedValue(estimate);
+    jest.spyOn(context.estimate, 'smartRollupAddMessages').mockResolvedValue(estimate);
 
     prepareProvider = new PrepareProvider(context);
   });
@@ -879,6 +880,80 @@ describe('PrepareProvider test', () => {
               source: 'test_public_key_hash',
               content: '1234',
               rollup: 'txr1ckoTVCU3FHdcW4VotdBha6pYCcA3wpCXi',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+  });
+
+  describe('smartRollupAddMessages', () => {
+    it('should be able to prepare a smartRollupAddMessages operation', async () => {
+      jest.spyOn(context.estimate, 'reveal').mockResolvedValue(estimate);
+
+      const prepared = await prepareProvider.smartRollupAddMessages({
+        message: [
+          '0000000062010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
+        ],
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '391',
+              public_key: 'test_pub_key',
+              source: 'test_public_key_hash',
+              gas_limit: '101',
+              storage_limit: '1000',
+              counter: '1',
+            },
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_public_key_hash',
+              fee: '391',
+              gas_limit: '101',
+              storage_limit: '1000',
+              message: [
+                '0000000062010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
+              ],
+              counter: '2',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to prepare smartRollupAddMessages op without reveal when estimate is undefined', async () => {
+      jest.spyOn(context.estimate, 'reveal').mockResolvedValue(undefined);
+
+      const prepared = await prepareProvider.smartRollupAddMessages({
+        message: [
+          '0000000062010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
+        ],
+      });
+      console.log(JSON.stringify(prepared));
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'smart_rollup_add_messages',
+              source: 'test_public_key_hash',
+              fee: '391',
+              gas_limit: '101',
+              storage_limit: '1000',
+              message: [
+                '0000000062010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
+              ],
               counter: '1',
             },
           ],

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -64,6 +64,7 @@ const sidebars = {
         'web3js_taquito',
         'contracts_collection',
         'subscribe_event',
+        'smart_rollups'
       ],
     },
     {

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -42,7 +42,8 @@
         "wallet_API",
         "wallets",
         "web3js_taquito",
-        "subscribe_event"
+        "subscribe_event",
+        "smart_rollups"
       ]
     },
     {


### PR DESCRIPTION
Added smart_rollup_add_messages op support in the 
- estimate provider
- contract provider
- prepare provider

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:
closes #2309 

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [x] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [x] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
