### PR TITLE
2350 tz4 validation

### DIFF
--- a/integration-tests/contract-simple-transaction.spec.ts
+++ b/integration-tests/contract-simple-transaction.spec.ts
@@ -1,16 +1,17 @@
 import { CONFIGS } from './config';
+import { Protocols } from '@taquito/taquito';
 
-CONFIGS().forEach(({ lib, rpc, setup }) => {
+CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test simple transaction to tezos public key hashes: ${rpc}`, () => {
-
     beforeEach(async (done) => {
       await setup(true);
       done();
     });
 
-    test('should be able to send to a tz4 address', async (done) => {
+    mumbaiAndAlpha('should be able to send to a tz4 address', async (done) => {
       const op = await Tezos.contract.transfer({
         amount: 1,
         to: 'tz4HQ8VeXAyrZMhES1qLMJAc9uAVXjbMpS8u'

--- a/integration-tests/contract-simple-transaction.spec.ts
+++ b/integration-tests/contract-simple-transaction.spec.ts
@@ -1,0 +1,25 @@
+import { CONFIGS } from './config';
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+
+  describe(`Test simple transaction to tezos public key hashes: ${rpc}`, () => {
+
+    beforeEach(async (done) => {
+      await setup(true);
+      done();
+    });
+
+    test('should be able to send to a tz4 address', async (done) => {
+      const op = await Tezos.contract.transfer({
+        amount: 1,
+        to: 'tz4HQ8VeXAyrZMhES1qLMJAc9uAVXjbMpS8u'
+      });
+
+      await op.confirmation();
+
+      expect(op.status).toEqual('applied');
+      done();
+    });
+  });
+});

--- a/packages/taquito-local-forging/src/codec.ts
+++ b/packages/taquito-local-forging/src/codec.ts
@@ -201,6 +201,8 @@ export const pkhEncoder = (val: string) => {
       return '01' + prefixEncoder(Prefix.TZ2)(val);
     case Prefix.TZ3:
       return '02' + prefixEncoder(Prefix.TZ3)(val);
+    case Prefix.TZ4:
+      return '03' + prefixEncoder(Prefix.TZ4)(val);
     default:
       throw new InvalidKeyHashError(val);
   }
@@ -226,6 +228,7 @@ export const addressEncoder = (val: string): string => {
     case Prefix.TZ1:
     case Prefix.TZ2:
     case Prefix.TZ3:
+    case Prefix.TZ4:
       return '00' + pkhEncoder(val);
     case Prefix.KT1:
       return '01' + prefixEncoder(Prefix.KT1)(val) + '00';

--- a/packages/taquito-local-forging/test/codec.spec.ts
+++ b/packages/taquito-local-forging/test/codec.spec.ts
@@ -67,14 +67,16 @@ describe('Tests for Entrypoint functions and for encode and decoder error messag
     expect(tz2).toEqual('012ffebbf1560632ca767bc960ccdb84669d284c2c');
     const tz3 = pkhEncoder('tz3WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5');
     expect(tz3).toEqual('026fde46af0356a0476dae4e4600172dc9309b3aa4');
-    expect(() => pkhEncoder('tz4WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5')).toThrow(InvalidKeyHashError);
-    expect(() => pkhEncoder('tz4WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5')).toThrow(
-      expect.objectContaining({
-        message: expect.stringContaining(
-          "The public key hash 'tz4WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5' is invalid"
-        ),
-      })
-    );
+    const tz4 = pkhEncoder('tz4HQ8VeXAyrZMhES1qLMJAc9uAVXjbMpS8u');
+    expect(tz4).toEqual('035c14a7a05c10fc8b402fbcdd48dc8136236bf3c1');
+    expect(() => pkhEncoder('tz5WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5')).toThrow(InvalidKeyHashError);
+    try {
+      pkhEncoder('tz5WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5');
+    } catch (e) {
+      expect(e.message).toEqual(
+        "The public key hash 'tz5WXYtyDUNL91qfiCJtVUX746QpNv5i5ve5' is invalid"
+      );
+    }
     done();
   });
 


### PR DESCRIPTION
Open up validation to tz4 addresses so `transaction` operations can send **to** tz4 addresses

closes #2350 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
