### PR TITLE
updated protocol hash in favour of PtMumbai2

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -101,7 +101,7 @@ const mumbainetEphemeral = {
   knownTzip1216Contract: process.env['TEZOS_MUMBAINET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractPtMumbaii,
   knownSaplingContract: process.env['TEZOS_MUMBAINET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractPtMumbaii,
   knownViewContract: process.env['TEZOS_MUMBAINET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtMumbaii,
-  protocol: Protocols.PtMumbaii,
+  protocol: Protocols.PtMumbai2,
   signerConfig: {
     type: SignerType.EPHEMERAL_KEY as SignerType.EPHEMERAL_KEY,
     keyUrl: 'https://api.tez.ie/keys/mumbainet',
@@ -169,7 +169,7 @@ const mumbainetSecretKey = {
   knownTzip1216Contract: process.env['TEZOS_MUMBAINET_TZIP1216CONTRACT_ADDRESS'] || knownTzip12BigMapOffChainContractPtMumbaii,
   knownSaplingContract: process.env['TEZOS_MUMBAINET_SAPLINGCONTRACT_ADDRESS'] || knownSaplingContractPtMumbaii,
   knownViewContract: process.env['TEZOS_MUMBAINET_ON_CHAIN_VIEW_CONTRACT'] || knownOnChainViewContractAddressPtMumbaii,
-  protocol: Protocols.PtMumbaii,
+  protocol: Protocols.PtMumbai2,
   signerConfig: defaultSecretKey
 };
 

--- a/integration-tests/contract-batch-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-batch-smart-rollup-add-messages.spec.ts
@@ -4,7 +4,7 @@ import { Protocols } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test contract.batch with smart rollup add messages using: ${rpc}`, () => {
     beforeEach(async (done) => {

--- a/integration-tests/contract-simple-transaction.spec.ts
+++ b/integration-tests/contract-simple-transaction.spec.ts
@@ -3,7 +3,7 @@ import { Protocols } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test simple transaction to tezos public key hashes: ${rpc}`, () => {
     beforeEach(async (done) => {

--- a/integration-tests/contract-smart-rollup-add-messages.spec.ts
+++ b/integration-tests/contract-smart-rollup-add-messages.spec.ts
@@ -3,7 +3,7 @@ import { Protocols } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, protocol, setup }) => {
   const Tezos = lib;
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
   
   describe(`Smart Rollup Add Messages operation test using: ${rpc}`, () => {
     beforeEach(async (done) => {

--- a/integration-tests/contract-transfer-ticket-between-implicit-and-originated-accounts.spec.ts
+++ b/integration-tests/contract-transfer-ticket-between-implicit-and-originated-accounts.spec.ts
@@ -6,7 +6,7 @@ import { RpcClient, TicketTokenParams } from '@taquito/rpc';
 CONFIGS().forEach(({ lib, protocol, rpc, setup, createAddress }) => {
   const Tezos1 = lib;
   const client = new RpcClient(rpc);
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
   let tezos1Pkh: string;
   let tezos2Pkh: string;
   let Tezos2: TezosToolkit;

--- a/integration-tests/injecting-multiple-manager-operations-in-a-block.spec.ts
+++ b/integration-tests/injecting-multiple-manager-operations-in-a-block.spec.ts
@@ -4,7 +4,7 @@ import { CONFIGS } from "./config";
 CONFIGS().forEach(({ lib, rpc, setup, protocol }) => {
   const Tezos = lib;
   const limanet = (protocol === Protocols.PtLimaPtL) ? test : test.skip;
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;  
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;  
 
   describe(`Test injecting more than one manager operation in a block: ${rpc}`, () => {
 

--- a/integration-tests/instructions-with-bytes-conversion.spec.ts
+++ b/integration-tests/instructions-with-bytes-conversion.spec.ts
@@ -6,7 +6,7 @@ import { HttpResponseError } from "@taquito/http-utils";
 CONFIGS().forEach(({ lib, protocol, setup }) => {
   const Tezos = lib;
   const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test origination of contract with instructions now supporting bytes conversion`, () => {
 

--- a/integration-tests/instructions-with-bytes.spec.ts
+++ b/integration-tests/instructions-with-bytes.spec.ts
@@ -5,7 +5,7 @@ import { addContract, lslContract, lsrContract, notContract, orContract, xorCont
 CONFIGS().forEach(({ lib, protocol, setup }) => {
   const Tezos = lib;
   const limanet = protocol === Protocols.PtLimaPtL ? test : test.skip;
-  const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+  const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
 
   describe(`Test origination of contract with instructions now supporting bytes`, () => {
 

--- a/integration-tests/local-forging.spec.ts
+++ b/integration-tests/local-forging.spec.ts
@@ -7,7 +7,7 @@ CONFIGS().forEach(({ rpc, protocol }) => {
   const Tezos = new TezosToolkit(rpc);
 
   describe(`Test local forger: ${rpc}`, () => {
-    const mumbaiAndAlpha = protocol === Protocols.ProtoALpha || protocol == Protocols.PtMumbaii ? it : it.skip;
+    const mumbaiAndAlpha = protocol === Protocols.ProtoALpha || protocol == Protocols.PtMumbai2 ? it : it.skip;
     // all protocols
     commonCases.forEach(({ name, operation, expected }) => {
       it(`Verify that .forge for local forge will return same result as for network forge for rpc: ${name} (${rpc})`, async done => {

--- a/integration-tests/rpc-get-protocol-constants.spec.ts
+++ b/integration-tests/rpc-get-protocol-constants.spec.ts
@@ -14,7 +14,7 @@ import {
 CONFIGS().forEach(({ lib, protocol, rpc }) => {
   const Tezos = lib;
   const limanet = (protocol === Protocols.PtLimaPtL) ? test : test.skip;
-  const mumbainet = (protocol === Protocols.PtMumbaii) ? test : test.skip;
+  const mumbainet = (protocol === Protocols.PtMumbai2) ? test : test.skip;
   const alpha = (protocol === Protocols.ProtoALpha) ? test : test.skip;
 
   describe('Test fetching constants for all protocols on Mainnet', () => {

--- a/integration-tests/rpc-nodes.spec.ts
+++ b/integration-tests/rpc-nodes.spec.ts
@@ -20,7 +20,7 @@ CONFIGS().forEach(
   }) => {
     const Tezos = lib;
 
-    const mumbaiAndAlpha = protocol === Protocols.PtMumbaii || protocol === Protocols.ProtoALpha ? test : test.skip;
+    const mumbaiAndAlpha = protocol === Protocols.PtMumbai2 || protocol === Protocols.ProtoALpha ? test : test.skip;
     const unrestrictedRPCNode = rpc.endsWith("ecadinfra.com") ? test.skip : test;
 
     let ticketContract: DefaultContractType;

--- a/packages/taquito/src/constants.ts
+++ b/packages/taquito/src/constants.ts
@@ -35,6 +35,7 @@ export enum Protocols {
   PtKathman = 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
   PtLimaPtL = 'PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW',
   PtMumbaii = 'PtMumbaiiFFEGbew1rRjzSPyzRbA51Tm3RVZL5suHPxSZYDhCEc',
+  PtMumbai2 = 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
   ProtoALpha = 'ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK',
 }
 
@@ -51,7 +52,7 @@ export const protocols = {
   '013': [Protocols.PtJakart2],
   '014': [Protocols.PtKathman],
   '015': [Protocols.PtLimaPtL],
-  '016': [Protocols.PtMumbaii],
+  '016': [Protocols.PtMumbaii, Protocols.PtMumbai2],
   '017': [Protocols.ProtoALpha],
 };
 
@@ -69,4 +70,5 @@ export enum ChainIds {
   KATHMANDUNET = 'NetXazhm4yetmff',
   LIMANET = 'NetXizpkH94bocH',
   MUMBAINET = 'NetXQw6nWSnrJ5t',
+  MUMBAINET2 = 'NetXgbcrNtXD2yA',
 }


### PR DESCRIPTION
closes #2380 

- Updated protocol hash from PtMumbaii in favour of PtMumbai2 following up the Mumbai reset.
- Updated references to PtMumbaii into PtMumbai2

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
