### PR TITLE
Implement the ability to filter out events from failed operations

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -43,7 +43,7 @@ try {
 
 - `tag` is the tag string that was defined in the smart contract with the EMIT instruction
 - `address` is the address of the smart contract that was called 
-- `excludeFailedOperations`: In rare cases, events from failed opera can be received by the subscriber. You can use this field to filter out these events (if you pass `true` to this field, only events from successful operations will be received)
+- `excludeFailedOperations`: In rare cases, events from failed operations can be received by the subscriber. You can use this field to filter out these events (if you pass `true` to this field, only events from successful operations will be received)
 
 :::info
 If you would like to subscribe to **_any_** event that goes through, you can call `subscribeEvent()` as is without any parameters

--- a/docs/events.md
+++ b/docs/events.md
@@ -29,7 +29,8 @@ Tezos.setStreamProvider(
 try {
   const sub = Tezos.stream.subscribeEvent({
     tag: 'tagName',
-    address: 'KT1_CONTRACT_ADDRESS'
+    address: 'KT1_CONTRACT_ADDRESS',
+    excludeFailedOperations: true
   });
     
   sub.on('data', console.log);
@@ -42,6 +43,7 @@ try {
 
 - `tag` is the tag string that was defined in the smart contract with the EMIT instruction
 - `address` is the address of the smart contract that was called 
+- `excludeFailedOperations`: In rare cases, events from failed opera can be received by the subscriber. You can use this field to filter out these events (if you pass `true` to this field, only events from successful operations will be received)
 
 :::info
 If you would like to subscribe to **_any_** event that goes through, you can call `subscribeEvent()` as is without any parameters

--- a/integration-tests/polling-subscribe-provider.spec.ts
+++ b/integration-tests/polling-subscribe-provider.spec.ts
@@ -1,18 +1,25 @@
-import { CONFIGS, sleep } from "./config";
-import { PollingSubscribeProvider } from "@taquito/taquito";
+import { CONFIGS, sleep } from './config';
+import { PollingSubscribeProvider } from '@taquito/taquito';
 import { localForger } from '@taquito/local-forging';
-import { send } from "process";
-import { validateAddress } from "@taquito/utils";
+import { send } from 'process';
+import { validateAddress } from '@taquito/utils';
 
-const _mainContractJsLigo = `type storage = unit
-type parameter = {p: int, ad: address, t: tez}
+const _mainContractJsLigo = `type storage = int
+type parameter = {p: int, ad: address, t: tez, newStore: int}
 
-export const main = ({p, ad, t} : parameter, store : storage) => {
+export const main = ({p, ad, t, newStore} : parameter, store : storage) => {
+    if (p == 1) {
+        return [list([]), newStore];
+    }
     assert_with_error(p != 4, "The main contract fails if parameter is four");
     let tran = Tezos.transaction(p, t, Option.unopt(Tezos.get_contract_opt(ad)));
     let event1 = Tezos.emit("%intFromMainContract", p + 1);
-    let event2 = Tezos.emit("%stringFromMainContract", "lorem ipsum");
-    return [list([event1, event2, tran]), store];
+    if (store == 1) {
+        let event2 = Tezos.emit("%stringFromMainContract", "lorem ipsum");
+        return [list([event1, event2, tran]), newStore];
+    } else {
+        return [list([event1, tran]), newStore];
+    }
 }`;
 
 const _calledContractJSLigo = `type storage = unit
@@ -23,7 +30,6 @@ export const main = (param: parameter, store: storage) => {
   return [list([Tezos.emit("%eventFromCalledContract", param + 1)]), store];
 }`;
 
-
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
   let calledContractAddress: string;
@@ -33,7 +39,12 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     beforeAll(async (done) => {
       await setup();
 
-      Tezos.setStreamProvider(Tezos.getFactory(PollingSubscribeProvider)({ shouldObservableSubscriptionRetry: true, pollingIntervalMilliseconds: 1000 }));
+      Tezos.setStreamProvider(
+        Tezos.getFactory(PollingSubscribeProvider)({
+          shouldObservableSubscriptionRetry: true,
+          pollingIntervalMilliseconds: 1000,
+        })
+      );
 
       try {
         const calledContract = await Tezos.contract.originate({
@@ -54,50 +65,75 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
                    EMIT %eventFromCalledContract int ;
                    CONS ;
                    PAIR } }`,
-          storage: 0  
+          storage: 0,
         });
         await calledContract.confirmation();
         calledContractAddress = calledContract.contractAddress!;
 
         let mainContract = await Tezos.contract.originate({
-          code: `{ parameter (pair (pair (address %ad) (int %p)) (mutez %t)) ;
-            storage unit ;
+          code: `{ parameter (pair (pair (address %ad) (int %newStore)) (int %p) (mutez %t)) ;
+            storage int ;
             code { UNPAIR ;
                    UNPAIR ;
                    UNPAIR ;
-                   PUSH int 4 ;
-                   DUP 3 ;
-                   COMPARE ;
-                   NEQ ;
-                   IF {}
-                      { PUSH string "The main contract fails if parameter is four" ; FAILWITH } ;
-                   CONTRACT int ;
-                   IF_NONE { PUSH string "option is None" ; FAILWITH } {} ;
                    DIG 2 ;
-                   DUP 3 ;
-                   TRANSFER_TOKENS ;
+                   UNPAIR ;
                    PUSH int 1 ;
-                   DIG 2 ;
-                   ADD ;
-                   EMIT %intFromMainContract int ;
-                   PUSH string "lorem ipsum" ;
-                   EMIT %stringFromMainContract string ;
-                   DIG 3 ;
-                   NIL operation ;
-                   DIG 4 ;
-                   CONS ;
-                   DIG 2 ;
-                   CONS ;
-                   DIG 2 ;
-                   CONS ;
+                   DUP 2 ;
+                   COMPARE ;
+                   EQ ;
+                   IF { SWAP ; DIG 2 ; DIG 4 ; DROP 4 ; NIL operation }
+                      { PUSH int 4 ;
+                        DUP 2 ;
+                        COMPARE ;
+                        NEQ ;
+                        IF {}
+                           { PUSH string "The main contract fails if parameter is four" ; FAILWITH } ;
+                        DIG 2 ;
+                        CONTRACT int ;
+                        IF_NONE { PUSH string "option is None" ; FAILWITH } {} ;
+                        DIG 2 ;
+                        DUP 3 ;
+                        TRANSFER_TOKENS ;
+                        PUSH int 1 ;
+                        DIG 2 ;
+                        ADD ;
+                        EMIT %intFromMainContract int ;
+                        PUSH int 1 ;
+                        DIG 4 ;
+                        COMPARE ;
+                        EQ ;
+                        IF { PUSH string "lorem ipsum" ;
+                             EMIT %stringFromMainContract string ;
+                             DIG 3 ;
+                             NIL operation ;
+                             DIG 4 ;
+                             CONS ;
+                             DIG 2 }
+                           { DIG 2 ; NIL operation ; DIG 3 } ;
+                        CONS ;
+                        DIG 2 ;
+                        CONS } ;
                    PAIR } }`,
-          storage: 0
+          storage: 0,
         });
         await mainContract.confirmation();
         mainContractAddress = mainContract.contractAddress!;
-      } catch(e) {
+      } catch (e) {
         console.log(e);
       }
+      done();
+    });
+
+    beforeEach(async (done) => {
+      const contract = await Tezos.contract.at(mainContractAddress!);
+      const resetStorageOperation = await contract.methodsObject.default({
+        ad: calledContractAddress,
+        newStore: 0,
+        p: 1,
+        t: 0
+      }).send();
+      await resetStorageOperation.confirmation();
       done();
     });
 
@@ -106,7 +142,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       const eventSub = Tezos.stream.subscribeEvent({
         tag: 'intFromMainContract',
-        address: mainContractAddress
+        address: mainContractAddress,
       });
 
       eventSub.on('data', (x) => {
@@ -114,17 +150,32 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       });
 
       const contract = await Tezos.contract.at(mainContractAddress!);
-      const op = await contract.methods.default(calledContractAddress, 2, 0).send();
+      console.log(`Storage is: ${await contract.storage()}`);
+
+      const batch = Tezos.contract
+        .batch()
+        .withContractCall(contract.methodsObject.default({
+          ad: calledContractAddress,
+          newStore: 0,
+          p: 0,
+          t: 0
+        }))
+        .withContractCall(contract.methodsObject.default({
+          ad: calledContractAddress,
+          newStore: 0,
+          p: 0,
+          t: 0
+        }));
+
+      const op = await batch.send();
 
       await op.confirmation();
-
-      console.log(op);
 
       await sleep(3000);
 
       eventSub.close();
 
-      expect(data.length).toEqual(1);
+      expect(data.length).toEqual(2);
       expect(data[0].opHash).toBeDefined();
       expect(data[0].blockHash).toBeDefined();
       expect(data[0].level).toBeDefined();
@@ -148,46 +199,69 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       eventSub.on('error', (x) => {
         data.push({
           type: 'error',
-          x
+          x,
         });
       });
 
       eventSub.on('data', (x) => {
         data.push({
           type: 'data',
-          x
+          x,
         });
       });
 
       const contract = await Tezos.contract.at(mainContractAddress!);
+      console.log(`Storage is: ${await contract.storage()}`);
       try {
-        const startingBlock = await Tezos.rpc.getBlockHeader();
-        console.log(`Starting Block: ${startingBlock.level}`);
-        const call = contract.methods.default(calledContractAddress, 2, 0);
-        const op = await call.send({
-          fee: 1124,
-          gasLimit: 7000, //7835,
-          storageLimit: 10000,
-        });
+        const batch = Tezos.contract
+          .batch()
+          .withContractCall(contract.methodsObject.default({
+            ad: calledContractAddress,
+            newStore: 1,
+            p: 0,
+            t: 0
+          }))
+          .withContractCall(
+            contract.methodsObject.default({
+              ad: calledContractAddress,
+              newStore: 0,
+              p: 0,
+              t: 0
+            })
+            // , {
+            //   fee: 926,
+            //   gasLimit: 5850, // Estimte was: 5972,
+            //   storageLimit: 0,
+            // }
+          );
+        const op = await batch.send();
 
         await op.confirmation();
         console.log(op);
-        console.log(`It succeeded!`);
-      } catch(e) {
-        const endingBlock = await Tezos.rpc.getBlockHeader();
-        console.log(`Ending Block: ${endingBlock.level}`);
-        console.log(mainContractAddress);
+      } catch (e) {
         console.log(e);
         // Failure is expected
+        console.log(e);
       }
-      
+
       await sleep(5000);
       eventSub.close();
 
       console.log(JSON.stringify(data));
-      expect(data.length).toEqual(1);
+      expect(data.length).toEqual(3);
       done();
     });
+  });
+});
 
-  })
-})
+/* 
+1- Send a batch of transactions with two transactions
+2- The first transaction will change a value in storage
+3- The second transaction depends on that value and does an extra thing
+4- Because of the extra thing (emits the event), the gas cost will be higher than estimated
+5- The second transaction will fail (gas exhaustion, backtracked)
+6- The second transaction ends up on the block (as backtracked)
+7- The event emitted from the second transaction will be received
+
+8- check that the cost estimation of the two transactions are equal, but in reality, the second transaction costs more gas
+*/

--- a/integration-tests/polling-subscribe-provider.spec.ts
+++ b/integration-tests/polling-subscribe-provider.spec.ts
@@ -1,39 +1,100 @@
 import { CONFIGS, sleep } from "./config";
 import { PollingSubscribeProvider } from "@taquito/taquito";
+import { localForger } from '@taquito/local-forging';
+import { send } from "process";
+import { validateAddress } from "@taquito/utils";
+
+const _mainContractJsLigo = `type storage = unit
+type parameter = {p: int, ad: address, t: tez}
+
+export const main = ({p, ad, t} : parameter, store : storage) => {
+    assert_with_error(p != 4, "The main contract fails if parameter is four");
+    let tran = Tezos.transaction(p, t, Option.unopt(Tezos.get_contract_opt(ad)));
+    let event1 = Tezos.emit("%intFromMainContract", p + 1);
+    let event2 = Tezos.emit("%stringFromMainContract", "lorem ipsum");
+    return [list([event1, event2, tran]), store];
+}`;
+
+const _calledContractJSLigo = `type storage = unit
+type parameter = int
+
+export const main = (param: parameter, store: storage) => {
+  assert_with_error(param != 5, "The called contract fails if parameter is five");
+  return [list([Tezos.emit("%eventFromCalledContract", param + 1)]), store];
+}`;
+
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
-  let eventContractAddress: string;
+  let calledContractAddress: string;
+  let mainContractAddress: string;
 
   describe(`Polling Subscribe Provider using ${rpc}`, () => {
-    beforeEach(async (done) => {
+    beforeAll(async (done) => {
       await setup();
 
       Tezos.setStreamProvider(Tezos.getFactory(PollingSubscribeProvider)({ shouldObservableSubscriptionRetry: true, pollingIntervalMilliseconds: 1000 }));
 
       try {
-        const op = await Tezos.contract.originate({
-          code: `{ parameter unit ;
+        const calledContract = await Tezos.contract.originate({
+          code: `{ parameter int ;
             storage unit ;
-            code { DROP ;
-                   UNIT ;
-                   PUSH nat 10 ;
-                   LEFT string ;
-                   EMIT %first ;
-                   PUSH string "lorem ipsum" ;
-                   RIGHT nat ;
-                   EMIT %second (or (nat %number) (string %words)) ;
+            code { UNPAIR ;
+                   PUSH int 5 ;
+                   DUP 2 ;
+                   COMPARE ;
+                   NEQ ;
+                   IF {}
+                      { PUSH string "The called contract fails if parameter is five" ; FAILWITH } ;
+                   SWAP ;
                    NIL operation ;
-                   SWAP ;
+                   PUSH int 1 ;
+                   DIG 3 ;
+                   ADD ;
+                   EMIT %eventFromCalledContract int ;
                    CONS ;
-                   SWAP ;
+                   PAIR } }`,
+          storage: 0  
+        });
+        await calledContract.confirmation();
+        calledContractAddress = calledContract.contractAddress!;
+
+        let mainContract = await Tezos.contract.originate({
+          code: `{ parameter (pair (pair (address %ad) (int %p)) (mutez %t)) ;
+            storage unit ;
+            code { UNPAIR ;
+                   UNPAIR ;
+                   UNPAIR ;
+                   PUSH int 4 ;
+                   DUP 3 ;
+                   COMPARE ;
+                   NEQ ;
+                   IF {}
+                      { PUSH string "The main contract fails if parameter is four" ; FAILWITH } ;
+                   CONTRACT int ;
+                   IF_NONE { PUSH string "option is None" ; FAILWITH } {} ;
+                   DIG 2 ;
+                   DUP 3 ;
+                   TRANSFER_TOKENS ;
+                   PUSH int 1 ;
+                   DIG 2 ;
+                   ADD ;
+                   EMIT %intFromMainContract int ;
+                   PUSH string "lorem ipsum" ;
+                   EMIT %stringFromMainContract string ;
+                   DIG 3 ;
+                   NIL operation ;
+                   DIG 4 ;
+                   CONS ;
+                   DIG 2 ;
+                   CONS ;
+                   DIG 2 ;
                    CONS ;
                    PAIR } }`,
           storage: 0
         });
-        await op.confirmation();
-
-        eventContractAddress = op.contractAddress!;
+        await mainContract.confirmation();
+        mainContractAddress = mainContract.contractAddress!;
       } catch(e) {
         console.log(e);
       }
@@ -44,18 +105,20 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const data: any = [];
 
       const eventSub = Tezos.stream.subscribeEvent({
-        tag: 'first',
-        address: eventContractAddress
+        tag: 'intFromMainContract',
+        address: mainContractAddress
       });
 
       eventSub.on('data', (x) => {
         data.push(x);
       });
 
-      const contract = await Tezos.contract.at(eventContractAddress!);
-      const op = await contract.methods.default().send();
+      const contract = await Tezos.contract.at(mainContractAddress!);
+      const op = await contract.methods.default(calledContractAddress, 2, 0).send();
 
       await op.confirmation();
+
+      console.log(op);
 
       await sleep(3000);
 
@@ -66,13 +129,65 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       expect(data[0].blockHash).toBeDefined();
       expect(data[0].level).toBeDefined();
       expect(data[0].kind).toEqual('event');
-      expect(data[0].source).toEqual(eventContractAddress);
-      expect(data[0].tag).toEqual('first');
+      expect(data[0].source).toEqual(mainContractAddress);
+      expect(data[0].tag).toEqual('intFromMainContract');
       expect(data[0].type).toBeDefined();
       expect(data[0].payload).toBeDefined();
       expect(data[0].result).toBeDefined();
 
       done();
     });
+
+    it('should include events from failed operations when not filtering', async (done) => {
+      const data: any = [];
+
+      const eventSub = Tezos.stream.subscribeEvent({
+        address: mainContractAddress,
+      });
+
+      eventSub.on('error', (x) => {
+        data.push({
+          type: 'error',
+          x
+        });
+      });
+
+      eventSub.on('data', (x) => {
+        data.push({
+          type: 'data',
+          x
+        });
+      });
+
+      const contract = await Tezos.contract.at(mainContractAddress!);
+      try {
+        const startingBlock = await Tezos.rpc.getBlockHeader();
+        console.log(`Starting Block: ${startingBlock.level}`);
+        const call = contract.methods.default(calledContractAddress, 2, 0);
+        const op = await call.send({
+          fee: 1124,
+          gasLimit: 7000, //7835,
+          storageLimit: 10000,
+        });
+
+        await op.confirmation();
+        console.log(op);
+        console.log(`It succeeded!`);
+      } catch(e) {
+        const endingBlock = await Tezos.rpc.getBlockHeader();
+        console.log(`Ending Block: ${endingBlock.level}`);
+        console.log(mainContractAddress);
+        console.log(e);
+        // Failure is expected
+      }
+      
+      await sleep(5000);
+      eventSub.close();
+
+      console.log(JSON.stringify(data));
+      expect(data.length).toEqual(1);
+      done();
+    });
+
   })
 })

--- a/packages/taquito/src/subscribe/filters.ts
+++ b/packages/taquito/src/subscribe/filters.ts
@@ -52,20 +52,20 @@ const destinationFilter = (x: OperationContent, filter: DestinationFilter) => {
   }
 };
 
-export const eventFilter = (result: InternalOperationResult, address?: string, tag?: string) => {
-  if (result.kind === 'event') {
-    if (address && tag) {
-      return result.source === address && result.tag === tag;
-    } else if (address && !tag) {
-      return result.source === address;
-    } else if (tag) {
-      return result.tag === tag;
-    } else {
-      return true;
-    }
-  } else {
+export const eventFilter = (result: InternalOperationResult, address?: string, tag?: string, excludeFailedOperations?: boolean) => {
+  if (result.kind !== 'event') {
     return false;
   }
+  if (tag && result.tag !== tag) {
+    return false;
+  }
+  if (address && result.source !== address) {
+    return false;
+  }
+  if (excludeFailedOperations && result.result.status !== 'applied') {
+    return false;
+  }
+  return true;
 };
 
 export const evaluateOpFilter = (op: OperationContent, filter: OpFilter) => {

--- a/packages/taquito/src/subscribe/interface.ts
+++ b/packages/taquito/src/subscribe/interface.ts
@@ -24,6 +24,7 @@ export interface DestinationFilter {
 export interface EventFilter {
   address?: string;
   tag?: string;
+  excludeFailedOperations?: boolean;
 }
 
 export interface EventSubscription extends InternalOperationResult {

--- a/packages/taquito/src/subscribe/polling-subcribe-provider.ts
+++ b/packages/taquito/src/subscribe/polling-subcribe-provider.ts
@@ -68,7 +68,7 @@ const applyEventFilter = (filter?: EventFilter) =>
             const internalOpResults = tx.metadata.internal_operation_results;
             if (internalOpResults) {
               for (const event of internalOpResults) {
-                if (eventFilter(event, filter?.address, filter?.tag)) {
+                if (eventFilter(event, filter?.address, filter?.tag, filter?.excludeFailedOperations)) {
                   sub.next({
                     opHash: op.hash,
                     blockHash: block.hash,

--- a/packages/taquito/test/subscribe/filters.spec.ts
+++ b/packages/taquito/test/subscribe/filters.spec.ts
@@ -31,6 +31,36 @@ const mockInternalOperationResult = {
   },
 };
 
+const mockFailedInternalOperationResult = {
+  kind: 'event',
+  source: 'KT1TzvwJxn8dNHc8M2FLvTiUg6LwjUfC4X94',
+  nonce: 2,
+  type: {
+    prim: 'or',
+    args: [
+      {
+        prim: 'nat',
+      },
+      {
+        prim: 'string',
+      },
+    ],
+  },
+  tag: 'test',
+  payload: {
+    prim: 'Left',
+    args: [
+      {
+        int: '10',
+      },
+    ],
+  },
+  result: {
+    status: 'failed',
+    consumed_milligas: '1000000',
+  },
+};
+
 const mockNonEventInternalOperationResult = {
   kind: 'transaction',
   source: 'KT1TzvwJxn8dNHc8M2FLvTiUg6LwjUfC4X94',
@@ -139,6 +169,46 @@ describe('Event filter', () => {
     );
     expect(result).toBeFalsy();
   });
+
+  it('should return true for a failed operation when not filtering failed operations', () => {
+    const result = eventFilter(
+      mockFailedInternalOperationResult as InternalOperationResult,
+      'KT1TzvwJxn8dNHc8M2FLvTiUg6LwjUfC4X94',
+      'test',
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for a failed operation when passing false to excludeFailedOperations', () => {
+    const result = eventFilter(
+      mockFailedInternalOperationResult as InternalOperationResult,
+      'KT1TzvwJxn8dNHc8M2FLvTiUg6LwjUfC4X94',
+      'test',
+      false
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true for a successful operation when passing true to excludeFailedOperations', () => {
+    const result = eventFilter(
+      mockInternalOperationResult as InternalOperationResult,
+      'KT1TzvwJxn8dNHc8M2FLvTiUg6LwjUfC4X94',
+      'test',
+      true
+    );
+    expect(result).toBeTruthy();
+  });
+
+  it('should return false for a failed operation when passing true to excludeFailedOperations', () => {
+    const result = eventFilter(
+      mockFailedInternalOperationResult as InternalOperationResult,
+      'KT1TzvwJxn8dNHc8M2FLvTiUg6LwjUfC4X94',
+      'test',
+      true
+    );
+    expect(result).toBeFalsy();
+  });
+
 });
 
 describe('Evaluate expression', () => {


### PR DESCRIPTION
closes #2319 

An optional field `excludeFailedOperations: boolean` is added to `EventFilter`. If this field is set to `true`, event will be propagated to the Dapp only when the result's `result.status` is `applied`.


- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

An optional field `excludeFailedOperations: boolean` is added to `EventFilter`. If this field is set to `true`, event will be propagated to the Dapp only when the result's `result.status` is `applied`.
