### PR TITLE
updated validation conditions for contractAddress

### DIFF
--- a/packages/taquito-utils/src/validators.ts
+++ b/packages/taquito-utils/src/validators.ts
@@ -38,10 +38,14 @@ function validatePrefixedValue(value: string, prefixes: Prefix[]) {
     return ValidationResult.NO_PREFIX_MATCHED;
   }
 
-  // Remove annotation from contract address before doing the validation
-  const contractAddress = /^(KT1\w{33})(%(.*))?/.exec(value);
-  if (contractAddress) {
-    value = contractAddress[1];
+  // Check whether annotation exist before starting validation
+  if (value.includes('%')) {
+    value = value.split('%')[0];
+  }
+
+  const kt1Regex = /^(KT1\w{33})$/;
+  if (!kt1Regex.test(value) && prefixKey === 'KT1') {
+    return ValidationResult.INVALID_CHECKSUM;
   }
 
   // decodeUnsafe return undefined if decoding fail

--- a/packages/taquito-utils/test/validators.spec.ts
+++ b/packages/taquito-utils/test/validators.spec.ts
@@ -36,6 +36,9 @@ describe('validateAddress', () => {
     expect(validateAddress('tz4')).toEqual(ValidationResult.INVALID_CHECKSUM);
     expect(validateAddress('test')).toEqual(ValidationResult.NO_PREFIX_MATCHED);
     expect(validateAddress('')).toEqual(ValidationResult.NO_PREFIX_MATCHED);
+    expect(validateAddress('tz2TSvNTh2epDMhZHrw73nV9piBX7kLZ9K9mAAAAAAAAAA')).toEqual(
+      ValidationResult.INVALID_CHECKSUM
+    );
   });
 });
 
@@ -86,6 +89,12 @@ describe('validateContractAddress', () => {
       ValidationResult.NO_PREFIX_MATCHED
     );
     expect(validateContractAddress('txr1YNMEtkj5Vkqsbdmt7xaxBTMRZjzS96UAu')).toEqual(
+      ValidationResult.INVALID_CHECKSUM
+    );
+    expect(
+      validateContractAddress('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4Dasdasdasdasdadasd')
+    ).toEqual(ValidationResult.INVALID_CHECKSUM);
+    expect(validateContractAddress('KT1Fe71jyjrxFg9ZrYqtvaX7uQ')).toEqual(
       ValidationResult.INVALID_CHECKSUM
     );
   });


### PR DESCRIPTION
closes #2398 

Fixed validation condition that allowed contract addresses to be more than the valid length

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
