### PR TITLE
2409 remaining smart rollup operation types

### DIFF
--- a/packages/taquito-rpc/src/opkind.ts
+++ b/packages/taquito-rpc/src/opkind.ts
@@ -34,4 +34,9 @@ export enum OpKind {
   SMART_ROLLUP_ORIGINATE = 'smart_rollup_originate',
   SMART_ROLLUP_ADD_MESSAGES = 'smart_rollup_add_messages',
   SMART_ROLLUP_EXECUTE_OUTBOX_MESSAGE = 'smart_rollup_execute_outbox_message',
+  SMART_ROLLUP_PUBLISH = 'smart_rollup_publish',
+  SMART_ROLLUP_CEMENT = 'smart_rollup_cement',
+  SMART_ROLLUP_RECOVER_BOND = 'smart_rollup_recover_bond',
+  SMART_ROLLUP_REFUTE = 'smart_rollup_refute',
+  SMART_ROLLUP_TIMEOUT = 'smart_rollup_timeout',
 }

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -508,6 +508,62 @@ export interface OperationContentsSmartRollupExecuteOutboxMessage {
   output_proof: string;
 }
 
+export interface OperationContentsSmartRollupPublish {
+  kind: OpKind.SMART_ROLLUP_PUBLISH;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  commitment: SmartRollupPublishCommitment;
+}
+
+export interface OperationContentsSmartRollupCement {
+  kind: OpKind.SMART_ROLLUP_CEMENT;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  commitment: string;
+}
+
+export interface OperationContentsSmartRollupRefute {
+  kind: OpKind.SMART_ROLLUP_REFUTE;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  opponent: string;
+  refutation: SmartRollupRefutation;
+}
+
+export interface OperationContentsSmartRollupRecoverBond {
+  kind: OpKind.SMART_ROLLUP_RECOVER_BOND;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  staker: string;
+}
+
+export interface OperationContentsSmartRollupTimeout {
+  kind: OpKind.SMART_ROLLUP_TIMEOUT;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  stakers: SmartRollupTimeoutStakers;
+}
+
 export type OperationContents =
   | OperationContentsEndorsement
   | OperationContentsPreEndorsement
@@ -540,7 +596,12 @@ export type OperationContents =
   | OperationContentsIncreasePaidStorage
   | OperationContentsSmartRollupOriginate
   | OperationContentsSmartRollupAddMessages
-  | OperationContentsSmartRollupExecuteOutboxMessage;
+  | OperationContentsSmartRollupExecuteOutboxMessage
+  | OperationContentsSmartRollupPublish
+  | OperationContentsSmartRollupCement
+  | OperationContentsSmartRollupRefute
+  | OperationContentsSmartRollupRecoverBond
+  | OperationContentsSmartRollupTimeout;
 
 export interface OperationContentsAndResultMetadataExtended {
   balance_updates?: OperationMetadataBalanceUpdates[];
@@ -677,6 +738,36 @@ export interface OperationContentsAndResultMetadataSmartRollupAddMessages {
 export interface OperationContentsAndResultMetadataSmartRollupExecuteOutboxMessage {
   balance_updates?: OperationMetadataBalanceUpdates[];
   operation_result: OperationResultSmartRollupExecuteOutboxMessage;
+  internal_operation_results?: InternalOperationResult[];
+}
+
+export interface OperationContentsAndResultMetadataSmartRollupPublish {
+  balance_updates?: OperationMetadataBalanceUpdates[];
+  operation_result: OperationResultSmartRollupPublish;
+  internal_operation_results?: InternalOperationResult[];
+}
+
+export interface OperationContentsAndResultMetadataSmartRollupCement {
+  balance_updates?: OperationMetadataBalanceUpdates[];
+  operation_result: OperationResultSmartRollupCement;
+  internal_operation_results?: InternalOperationResult[];
+}
+
+export interface OperationContentsAndResultMetadataSmartRollupRefute {
+  balance_updates?: OperationMetadataBalanceUpdates[];
+  operation_result: OperationResultSmartRollupRefute;
+  internal_operation_results?: InternalOperationResult[];
+}
+
+export interface OperationContentsAndResultMetadataSmartRollupRecoverBond {
+  balance_updates?: OperationMetadataBalanceUpdates[];
+  operation_result: OperationResultSmartRollupRecoverBond;
+  internal_operation_results?: InternalOperationResult[];
+}
+
+export interface OperationContentsAndResultMetadataSmartRollupTimeout {
+  balance_updates?: OperationMetadataBalanceUpdates[];
+  operation_result: OperationResultSmartRollupTimeout;
   internal_operation_results?: InternalOperationResult[];
 }
 
@@ -1008,6 +1099,67 @@ export interface OperationContentsAndResultSmartRollupExecuteOutboxMessage {
   metadata: OperationContentsAndResultMetadataSmartRollupExecuteOutboxMessage;
 }
 
+export interface OperationContentsAndResultSmartRollupPublish {
+  kind: OpKind.SMART_ROLLUP_PUBLISH;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  commitment: SmartRollupPublishCommitment;
+  metadata: OperationContentsAndResultMetadataSmartRollupPublish;
+}
+
+export interface OperationContentsAndResultSmartRollupCement {
+  kind: OpKind.SMART_ROLLUP_CEMENT;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  commitment: string;
+  metadata: OperationContentsAndResultMetadataSmartRollupCement;
+}
+
+export interface OperationContentsAndResultSmartRollupRefute {
+  kind: OpKind.SMART_ROLLUP_REFUTE;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  opponent: string;
+  refutation: SmartRollupRefutation;
+  metadata: OperationContentsAndResultMetadataSmartRollupRefute;
+}
+
+export interface OperationContentsAndResultSmartRollupRecoverBond {
+  kind: OpKind.SMART_ROLLUP_RECOVER_BOND;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  staker: string;
+  metadata: OperationContentsAndResultMetadataSmartRollupRecoverBond;
+}
+
+export interface OperationContentsAndResultSmartRollupTimeout {
+  kind: OpKind.SMART_ROLLUP_TIMEOUT;
+  source: string;
+  fee: string;
+  counter: string;
+  gas_limit: string;
+  storage_limit: string;
+  rollup: string;
+  stakers: SmartRollupTimeoutStakers;
+  metadata: OperationContentsAndResultMetadataSmartRollupTimeout;
+}
+
 export type OperationContentsAndResult =
   | OperationContentsAndResultEndorsement
   | OperationContentsAndResultPreEndorsement
@@ -1040,7 +1192,12 @@ export type OperationContentsAndResult =
   | OperationContentsAndResultVdfRevelation
   | OperationContentsAndResultSmartRollupOriginate
   | OperationContentsAndResultSmartRollupAddMessages
-  | OperationContentsAndResultSmartRollupExecuteOutboxMessage;
+  | OperationContentsAndResultSmartRollupExecuteOutboxMessage
+  | OperationContentsAndResultSmartRollupPublish
+  | OperationContentsAndResultSmartRollupCement
+  | OperationContentsAndResultSmartRollupRefute
+  | OperationContentsAndResultSmartRollupRecoverBond
+  | OperationContentsAndResultSmartRollupTimeout;
 
 export enum OPERATION_METADATA {
   TOO_LARGE = 'too large',
@@ -1254,11 +1411,11 @@ export interface ScriptedContracts {
 
 export type BondId =
   | {
-      sc_rollup?: never;
+      smart_rollup?: never;
       tx_rollup: string;
     }
   | {
-      sc_rollup: string;
+      smart_rollup: string;
       tx_rollup?: never;
     };
 
@@ -1422,9 +1579,9 @@ export interface OperationResultRegisterGlobalConstant {
 
 export interface OperationResultSmartRollupOriginate {
   status: OperationResultStatusEnum;
-  balance_updates: OperationBalanceUpdates;
-  address: string;
-  genesis_commitment_hash: string;
+  balance_updates?: OperationBalanceUpdates;
+  address?: string;
+  genesis_commitment_hash?: string;
   consumed_milligas?: string;
   size: string;
   errors?: TezosGenericOperationError[];
@@ -1438,10 +1595,49 @@ export interface OperationResultSmartRollupAddMessages {
 
 export interface OperationResultSmartRollupExecuteOutboxMessage {
   status: OperationResultStatusEnum;
-  balance_updates: OperationBalanceUpdates;
-  ticket_updates: TicketUpdates[];
+  balance_updates?: OperationBalanceUpdates;
+  ticket_updates?: TicketUpdates[];
   consumed_milligas?: string;
   paid_storage_size_diff?: string;
+  errors?: TezosGenericOperationError[];
+}
+
+export interface OperationResultSmartRollupPublish {
+  status: OperationResultStatusEnum;
+  consumed_milligas?: string;
+  staked_hash?: string;
+  published_at_level?: number;
+  balance_updates?: OperationBalanceUpdates;
+  errors?: TezosGenericOperationError[];
+}
+
+export interface OperationResultSmartRollupCement {
+  status: OperationResultStatusEnum;
+  consumed_milligas?: string;
+  inbox_level?: number;
+  errors?: TezosGenericOperationError[];
+}
+
+export interface OperationResultSmartRollupRefute {
+  status: OperationResultStatusEnum;
+  consumed_milligas?: string;
+  game_status?: SmartRollupGameStatus;
+  balance_updates?: OperationBalanceUpdates;
+  errors?: TezosGenericOperationError[];
+}
+
+export interface OperationResultSmartRollupRecoverBond {
+  status: OperationResultStatusEnum;
+  balance_updates?: OperationBalanceUpdates;
+  consumed_milligas?: string;
+  errors?: TezosGenericOperationError[];
+}
+
+export interface OperationResultSmartRollupTimeout {
+  status: OperationResultStatusEnum;
+  consumed_milligas?: string;
+  game_status?: SmartRollupGameStatus;
+  balance_updates?: OperationBalanceUpdates;
   errors?: TezosGenericOperationError[];
 }
 
@@ -1871,7 +2067,7 @@ export interface ConstantsResponseProto011 extends ConstantsResponseProto010 {
   max_micheline_bytes_limit?: number;
   cache_layout?: BigNumber[];
 }
-export interface ConstantsResponseProto010 extends ConstantsResponseProto007 {
+export interface ConstantsResponseProto010 extends ConstantsResponseProto009 {
   minimal_block_delay?: BigNumber;
   liquidity_baking_subsidy?: BigNumber;
   liquidity_baking_sunset_level?: number;
@@ -1879,7 +2075,7 @@ export interface ConstantsResponseProto010 extends ConstantsResponseProto007 {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ConstantsResponseProto009 extends ConstantsResponseProto007 {}
+export interface ConstantsResponseProto009 extends ConstantsResponseProto008 {}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ConstantsResponseProto008 extends ConstantsResponseProto007 {}
@@ -2116,7 +2312,6 @@ export interface TxRollupInboxResponse {
   merkle_root: string;
 }
 
-
 export interface PendingOperationsQueryArguments {
   version?: '1';
   applied?: boolean;
@@ -2142,6 +2337,7 @@ export interface PendingOperations {
   branch_delayed: FailedProcessedOperation[];
   unprocessed: Pick<OperationEntry, 'hash' | 'protocol' | 'branch' | 'contents' | 'signature'>[];
 }
+
 export enum PvmKind {
   WASM2 = 'wasm_2_0_0',
   ARITH = 'arith',
@@ -2150,4 +2346,141 @@ export enum PvmKind {
 export interface OriginationProofParams {
   kind: PvmKind;
   kernel: string;
+}
+
+export interface SmartRollupPublishCommitment {
+  compressed_state: string;
+  inbox_level: number;
+  predecessor: string;
+  number_of_ticks: number;
+}
+
+export enum SmartRollupRefutationOptions {
+  START = 'start',
+  MOVE = 'move',
+}
+
+export type SmartRollupRefutation = SmartRollupRefutationStart | SmartRollupRefutationMove;
+
+export interface SmartRollupRefutationStart {
+  refutation_kind: SmartRollupRefutationOptions.START;
+  player_commitment_hash: string;
+  opponent_commitment_hash: string;
+}
+
+export interface SmartRollupRefutationMove {
+  refutation_kind: SmartRollupRefutationOptions.MOVE;
+  choice: number;
+  step: SmartRollupRefutationMoveStep;
+}
+
+export type SmartRollupRefutationMoveStep =
+  | SmartRollupRefutationMoveStepDissection[]
+  | SmartRollupRefutationMoveStepProof;
+
+export interface SmartRollupRefutationMoveStepDissection {
+  state?: string;
+  tick: number;
+}
+
+export interface SmartRollupRefutationMoveStepProof {
+  pvm_step: string;
+  input_proof?: SmartRollupRefutationMoveInputProof;
+}
+
+export enum SmartRollupInputProofKind {
+  INBOX_PROOF = 'inbox_proof',
+  REVEAL_PROOF = 'reveal_proof',
+  FIRST_INPUT = 'first_input',
+}
+
+export interface SmartRollupRefutationMoveInputProofInbox {
+  input_proof_kind: SmartRollupInputProofKind.INBOX_PROOF;
+  level: number;
+  message_counter: string;
+  serialized_proof: string;
+}
+
+export interface SmartRollupRefutationMoveInputProofReveal {
+  input_proof_kind: SmartRollupInputProofKind.REVEAL_PROOF;
+  reveal_proof: SmartRollupRefuteRevealProofOptions;
+}
+
+export interface SmartRollupRefutationMoveInputProofFirstInput {
+  input_proof_kind: SmartRollupInputProofKind.FIRST_INPUT;
+}
+
+export type SmartRollupRefutationMoveInputProof =
+  | SmartRollupRefutationMoveInputProofInbox
+  | SmartRollupRefutationMoveInputProofReveal
+  | SmartRollupRefutationMoveInputProofFirstInput;
+
+export enum SmartRollupRefuteRevealProofKind {
+  RAW_DATA_PROOF = 'raw_data_proof',
+  METADATA_PROOF = 'metadata_proof',
+  DAL_PAGE_PROOF = 'dal_page_proof',
+}
+
+export interface SmartRollupRefuteRevealProofRaw {
+  reveal_proof_kind: SmartRollupRefuteRevealProofKind.RAW_DATA_PROOF;
+  raw_data: string;
+}
+export interface SmartRollupRefuteRevealProofMetadata {
+  reveal_proof_kind: SmartRollupRefuteRevealProofKind.METADATA_PROOF;
+}
+export interface SmartRollupRefuteRevealProofDalPage {
+  reveal_proof_kind: SmartRollupRefuteRevealProofKind.DAL_PAGE_PROOF;
+  dal_page_id: {
+    published_level: number;
+    slot_index: number;
+    page_index: number;
+  };
+  dal_proof: string;
+}
+
+export type SmartRollupRefuteRevealProofOptions =
+  | SmartRollupRefuteRevealProofRaw
+  | SmartRollupRefuteRevealProofMetadata
+  | SmartRollupRefuteRevealProofDalPage;
+
+export type SmartRollupGameStatus =
+  | SmartRollupRefuteGameStatusOptions.ONGOING
+  | SmartRollupRefuteGameStatusEnded;
+
+export enum SmartRollupRefuteGameStatusOptions {
+  ONGOING = 'ongoing',
+  ENDED = 'ended',
+}
+
+export interface SmartRollupRefuteGameStatusEnded {
+  result: SmartRollupRefuteGameStatusResult;
+}
+
+export type SmartRollupRefuteGameStatusResult =
+  | SmartRollupRefuteGameEndedResultLoser
+  | SmartRollupRefuteGameEndedResultDraw;
+
+export interface SmartRollupRefuteGameEndedResultLoser {
+  kind: SmartRollupRefuteGameEndedPlayerOutcomes.LOSER;
+  reason: SmartRollupRefuteGameEndedReason;
+  player: string;
+}
+
+export interface SmartRollupRefuteGameEndedResultDraw {
+  kind: SmartRollupRefuteGameEndedPlayerOutcomes.DRAW;
+}
+
+export enum SmartRollupRefuteGameEndedPlayerOutcomes {
+  LOSER = 'loser',
+  DRAW = 'draw',
+}
+
+export enum SmartRollupRefuteGameEndedReason {
+  CONFLICT_RESOLVED = 'conflict_resolved',
+  TIMEOUT = 'timeout',
+}
+
+export interface SmartRollupTimeoutStakers {
+  alice: string;
+  bob: string;
 }

--- a/packages/taquito-rpc/test/data/rpc-responses.ts
+++ b/packages/taquito-rpc/test/data/rpc-responses.ts
@@ -2489,7 +2489,7 @@ export const protocols = {
   next_protocol: 'PtHangz2aRngywmSRGGvrcTyMbbdpWdpFKuS4uMWxg2RaH9i1qx',
 };
 
-export const delegatesIthacanetSample = {
+export const delegatesIthacanetResponse = {
   full_balance: '1198951292321',
   current_frozen_deposits: '120167343864',
   frozen_deposits: '120167343864',
@@ -2501,7 +2501,7 @@ export const delegatesIthacanetSample = {
   voting_power: 199,
 };
 
-export const delegatesKathmandunetSample = {
+export const delegatesKathmandunetResponse = {
   full_balance: '965532868030',
   current_frozen_deposits: '96350095609',
   frozen_deposits: '96350095609',
@@ -2514,12 +2514,12 @@ export const delegatesKathmandunetSample = {
   remaining_proposals: 20,
 };
 
-export const votingInfoKathmandunetSample = {
+export const votingInfoKathmandunetResponse = {
   voting_power: '1054404383333',
   remaining_proposals: 20,
 };
 
-export const blockIthacanetSample = {
+export const blockIthacanetResponse = {
   protocol: 'Psithaca2MLRFYargivpo7YvUr7wUDqyxrdhC5CQq78mRvimz6A',
   chain_id: 'NetXnHfVqm9iesp',
   hash: 'BMGdK16iMkm4YmgAneYuvd7B4R5S8nYQKFfKzXCKMHP1FqS5hXQ',
@@ -3434,7 +3434,7 @@ export const blockIthacanetSample = {
   ],
 };
 
-export const blockJakartanetSample = {
+export const blockJakartanetResponse = {
   protocol: 'PtJakart2xVj7pYXJBXrqHgd82rdkLey5ZeeGwDgPp9rhQUbSqY',
   chain_id: 'NetXLH1uAxK7CCh',
   hash: 'BLivfHQoHCtixrwXCNnsMQj33F3mLukQBBh4KoJ9AT6ADvLz7Ev',
@@ -4504,7 +4504,7 @@ export const blockJakartanetSample = {
   ],
 };
 
-export const blockKathmandunetSample = {
+export const blockKathmandunetResponse = {
   protocol: 'PtKathmankSpLLDALzWw7CGD2j2MtyveTwboEYokqUCP4a1LxMg',
   chain_id: 'NetXi2ZagzEsXbZ',
   hash: 'BLHBkJLRFwRhs1Nvrbrf8gVnVgSxx5515iTdizVnagm97baSXNF',
@@ -4833,7 +4833,7 @@ export const blockKathmandunetSample = {
   ],
 };
 
-export const blockLimanetSample = {
+export const blockLimanetResponse = {
   protocol: 'PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW',
   chain_id: 'NetXizpkH94bocH',
   hash: 'BM5sGpbt1rEiNmfbbo8jcQHJaUZQYwKUXe4MK6B8hcxHDeEfuJx',
@@ -5048,7 +5048,7 @@ export const blockLimanetSample = {
   ],
 };
 
-export const blockMondaynetSample = {
+export const blockMondaynetResponse = {
   protocol: 'ProtoALphaALphaALphaALphaALphaALphaALphaALphaDdp3zK',
   chain_id: 'NetXrxsLyu6hTHx',
   hash: 'BLxSQZzbnjL8yWqo8fJDE6cy2ATPmqQSaLKtheFBzAz4QVTcm5h',
@@ -5507,7 +5507,7 @@ export const pendingOperationsResponse = {
   unprocessed: [],
 };
 
-export const ticketUpdatesSample = {
+export const ticketUpdatesResponse = {
   protocol: 'PtLimaPtLMwfNinJi9rCfDPWea8dFgTZ1MeJ9f1m2SRic6ayiwW',
   chain_id: 'NetXizpkH94bocH',
   hash: 'BLAoXLidLrRnUQaUNPanuiaGTS3Ce2azZQysz2mMTCUnFg2799j',
@@ -5868,6 +5868,413 @@ export const smartRollupExecuteOutboxMessageResponse = {
         ],
         signature:
           'sigs8LVwSkqcMLzTVZWa1yS8aNz26A8bzR6QUHws5uVELh6kcmH7dWz5aKPqW3RXoFfynf5kVCvLJcsP3ucB5P6DEbD2YcQR',
+      },
+    ],
+  ],
+};
+
+export const smartRollupCementResponse = {
+  protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+  chain_id: 'NetXgbcrNtXD2yA',
+  hash: 'BLs7YR6xRt4pBu7f9B8ndikSU7KwjqAAFkd8mMWBxgLVidY3Z62',
+  header: {},
+  metadata: {},
+  operations: [
+    [
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'oohRSufw6kfFxX1kA3zWqzQMbo8q69DGY9ACvLW5FpvWxPYKxeg',
+        branch: 'BMLa28j2y5QjbVHpkUpdZGg1Sddfa99YXJNCagQ9dhzK6d3dHCb',
+        contents: [
+          {
+            kind: 'smart_rollup_cement',
+            source: 'tz1gCe1sFpppbGGVwCt5jLRqDS9FD1W4Qca4',
+            fee: '922',
+            counter: '41267',
+            gas_limit: '6432',
+            storage_limit: '0',
+            rollup: 'sr1AE6U3GNzE8iKzj6sKS5wh1U32ogeULCoN',
+            commitment: 'src13w2EBEZmVg4jsDd5PfYNakBRZ6GqSGDgWLz7EHZGeeG1gm7HT5',
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz1gCe1sFpppbGGVwCt5jLRqDS9FD1W4Qca4',
+                  change: '-922',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '922',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                consumed_milligas: '6331052',
+                inbox_level: 197111,
+              },
+            },
+          },
+        ],
+        signature:
+          'sigjozz364ebVDu7w8upHMfYwGShKHVpAGSi8LjaX7bzU6eipEW8qZ5ctiLeX8PYDvpCzgwQy7SW4HbcWbsH5oQyjWZk7HZy',
+      },
+    ],
+  ],
+};
+
+export const smartRollupPublishResponse = {
+  protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+  chain_id: 'NetXgbcrNtXD2yA',
+  hash: 'BL9UBPLykShAAvAebxCiZxELFjSJBxhbQXC12pfZb2ddwtCa1XU',
+  header: {},
+  metadata: {},
+  operations: [
+    [
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'opaTRLSsdqtd8APeDHqU3BxvqYDg4Lor3roR2cdh3V3Hv1VXucm',
+        branch: 'BM8ZBBpLnURFuRB1Wd6s7Z6iN3LiddUkKM4vsTS3LgqSmFMtCLE',
+        contents: [
+          {
+            kind: 'smart_rollup_publish',
+            source: 'tz1gCe1sFpppbGGVwCt5jLRqDS9FD1W4Qca4',
+            fee: '964',
+            counter: '41266',
+            gas_limit: '6418',
+            storage_limit: '0',
+            rollup: 'sr1AE6U3GNzE8iKzj6sKS5wh1U32ogeULCoN',
+            commitment: {
+              compressed_state: 'srs13FywcbcZV9VvHxdVkYK83Ch4477cqHMgM8d5oT955yf4XXMvKS',
+              inbox_level: 197151,
+              predecessor: 'src12i7dL2z9VbgshFDdGFP5TPBoJu6WnZNWJXGa1QQgPTErVPPtd8',
+              number_of_ticks: '880000000000',
+            },
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz1gCe1sFpppbGGVwCt5jLRqDS9FD1W4Qca4',
+                  change: '-964',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '964',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                consumed_milligas: '6317837',
+                staked_hash: 'src13TanyZ7RvSULqVb2tjx1zRVw2jyJC2ToHLz1ZKg38sZ4HBYdSN',
+                published_at_level: 197154,
+                balance_updates: [],
+              },
+            },
+          },
+        ],
+        signature:
+          'sigiYrQFjQLnYe94Vc9VH1jGEkfSAsBGkZzBVL8jLgBK88vhbLM6fBD2x24wBhBdN718WRRTSMBqCGR7Zp9Z5eDmDotgGaTu',
+      },
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'onjnz6RP5FPXafHfWupSb9Hv3uJZt5BGpVHPTisJkLsYEjP114H',
+        branch: 'BKyGmNai1eFrUv3BBMz1ZNhtmMVW7KQH9x8DEj2egDZEH86ajno',
+        contents: [
+          {
+            kind: 'smart_rollup_publish',
+            source: 'tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC',
+            fee: '956',
+            counter: '32544',
+            gas_limit: '7298',
+            storage_limit: '0',
+            rollup: 'sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x',
+            commitment: {
+              compressed_state: 'srs12r6jebz4VTuP1C58mHGzezqFQdV6n5pdaqEamDo4FvD9omn9YJ',
+              inbox_level: 41806,
+              predecessor: 'src12rCbiTAvYntPQXcMoqdNh6ZXXBmfxzhaxZsxsbRKGC7bE3L1mD',
+              number_of_ticks: '880000000000',
+            },
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC',
+                  change: '-956',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '956',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                consumed_milligas: '7197891',
+                staked_hash: 'src14ErSMhBhf3Hi6isN3cEdR4RgxT5egSjQYtgHEc5NP9qVFgmcpE',
+                published_at_level: 41809,
+                balance_updates: [
+                  {
+                    kind: 'contract',
+                    contract: 'tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC',
+                    change: '-10000000000',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'freezer',
+                    category: 'bonds',
+                    contract: 'tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC',
+                    bond_id: {
+                      smart_rollup: 'sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x',
+                    },
+                    change: '10000000000',
+                    origin: 'block',
+                  },
+                ],
+              },
+            },
+          },
+        ],
+        signature:
+          'sigosbVhqFLPBoXUhtjwZ7UBDq4veP1pGECDm2nc7iviBE8gqmzGFgh9tPMviTDhETd4rjCwcRCCMwEL5hBu3tfgNJcydnrS',
+      },
+    ],
+  ],
+};
+
+export const smartRollupRefuteResponse = {
+  protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+  chain_id: 'NetXgbcrNtXD2yA',
+  hash: 'BMRMq4e7QgU2xw5hHyFtDgv4rZCGCRbF9Z8FhWoAwmprSsJKPGx',
+  header: {},
+  operations: [
+    [
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'oofTxRxHWQCYo9B4vmpLY7FZfQXrH9s1n7rRU7wHjazhrqVu2oJ',
+        branch: 'BLDgHuXsD2qtEPy8SYcYCk1Wt2uDdDXUYXYmbfX6g1s1an8L5u6',
+        contents: [
+          {
+            kind: 'smart_rollup_refute',
+            source: 'tz1ZpuBypK6G754crXDZyoMPaVPoBmBsPda2',
+            fee: '2096',
+            counter: '32553',
+            gas_limit: '6299',
+            storage_limit: '0',
+            rollup: 'sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x',
+            opponent: 'tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC',
+            refutation: {
+              refutation_kind: 'move',
+              choice: '176000000003',
+              step: {
+                pvm_step:
+                  '03000298e4e3d5c88da366e885edf675ffd7a5087c8e0a2fcd508e7951113fe4c1491810067c06a78b88cb7c3e60c56b47ba9e14c922dbdbd4811ac6fee80a309620630005820764757261626c6582066b65726e656cd07d20c53bdd5b536a6be9c4cdad16e69a9af40b93a6564655fffd88bba050519008726561646f6e6c7982066b65726e656cd0a645771d9d5228a31312b282119c596699ccb6b60b93d759c2072a493ddbb5740c7761736d5f76657273696f6e8101408208636f6e74656e7473810130c10200322e302e30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066c656e677468c008000000000000000503746167c00800000004536f6d650003810370766d00050004000381166f7574626f785f76616c69646974795f706572696f64c00400013b0082136c6173745f746f705f6c6576656c5f63616c6cc00680c0abd38f05196d6178696d756d5f7265626f6f74735f7065725f696e707574c002e80781146f7574626f785f6d6573736167655f6c696d6974c002a401810c6d61785f6e625f7469636b73c00580dc9afd28820576616c7565810370766d8107627566666572738205696e7075740003810468656164c001008208636f6e74656e7473d06e2c0a5b371a53e76a9b7f221a5baa67170b3f9f43205fb06c0649123cec2358066c656e677468c00103066f75747075740004820132810a6c6173745f6c6576656cc0040000a33f0133810f76616c69646974795f706572696f64c00400013b0082013181086f7574626f786573d0ccbff4c181451166adb153f7a1631e9f036832f8e5c82acd8e8c12876eeeda870134810d6d6573736167655f6c696d6974c002a401047761736d00048205696e707574c0050000a33f0203746167c00b0000000770616464696e67820c63757272656e745f7469636bc00683c0abd38f050e7265626f6f745f636f756e746572c002e907',
+              },
+            },
+          },
+        ],
+        signature:
+          'sigQYS3D4Ppabx7MhsmJyHkQUo9cmAfieSykZXWnGmvVbn6W4cQvVvxbRXDPSnaNVn72N2ih9QwovsPw7Cv1eoELapdNjLTB',
+      },
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'opUUHJwTXLDe2jMwvTWtC3bwoEQukhBjdPiYa5Ri1qBo7TiYJpq',
+        branch: 'BMJcT8gh5PgoTvjWi6SQSUGn7gbx3Bb2rSKcdJQKB9PbzpS7FvH',
+        contents: [
+          {
+            kind: 'smart_rollup_refute',
+            source: 'tz1Qn5AXWB5vYPgzDXsunDbZ7tTUp9cFDaRp',
+            fee: '943',
+            counter: '25002',
+            gas_limit: '6109',
+            storage_limit: '0',
+            rollup: 'sr1Ce7znpA1ea2YZca3v1CefxqXMhqYgDEXR',
+            opponent: 'tz1VN3J6DyH712W1y13Uu1N8fxkt8RvMyqzm',
+            refutation: {
+              refutation_kind: 'start',
+              player_commitment_hash: 'src14Liog4xxPoZ55AgpBpeDweFSxHK6b3zbybhp7ChsWbM9g1Jsrd',
+              opponent_commitment_hash: 'src12q2zZyxuK5UeYPQYSutA6RPMv7sZDtJ7oAWxAytuJC3rjvWct6',
+            },
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz1Qn5AXWB5vYPgzDXsunDbZ7tTUp9cFDaRp',
+                  change: '-943',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '943',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                consumed_milligas: '6008940',
+                game_status: 'ongoing',
+                balance_updates: [],
+              },
+            },
+          },
+        ],
+        signature:
+          'sigg9W1bDVuvKgs7WDq9Q4wKp2oTtMwWsm1tt7khCYYCa4PZ3fvsWUWktuAR8SyTzmywKmBWX752VcDb28JzHUmYJ7De94Kt',
+      },
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'onqrLmUkjEowxhiS3t2CmxBCKQAEUf3PA4d8RD3zja9v2PtU11a',
+        branch: 'BMbQxrYG4uUmjqy2Dht5FUeskoiQcebXqN46H9kt26hSzZ5W3Qs',
+        contents: [
+          {
+            kind: 'smart_rollup_refute',
+            source: 'tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC',
+            fee: '1989',
+            counter: '32546',
+            gas_limit: '4333',
+            storage_limit: '0',
+            rollup: 'sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x',
+            opponent: 'tz1ZpuBypK6G754crXDZyoMPaVPoBmBsPda2',
+            refutation: {
+              refutation_kind: 'move',
+              choice: '0',
+              step: [
+                {
+                  state: 'srs11y1ZCJfeWnHzoX3rAjcTXiphwg8NvqQhvishP3PU68jgSREuk6',
+                  tick: '0',
+                },
+                {
+                  state: 'srs12ti4nRqiqahBZedqjgnFx9ZK88KkSgpYD8ns5Q41UMEXGg9w3b',
+                  tick: '22000000000',
+                },
+                {
+                  state: 'srs12zdMUHiLiqTAuN81f1NS3rgD1M7fqUtMq4RpWq3wf3QDvsPCxa',
+                  tick: '44000000000',
+                },
+              ],
+            },
+          },
+        ],
+        signature:
+          'sigojctsjFdB6nv51JNAyRdANvbnSB5NyrfNq5KBnov58Hcqi9d1CHPWYwEJeQgBjjJv5vgQJC37tKMSUJZZoY4pPQj6A2X5',
+      },
+    ],
+  ],
+};
+
+export const smartRollupRecoverBondResponse = {
+  protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+  chain_id: 'NetXgbcrNtXD2yA',
+  hash: 'BLxusPoX4vzCKAc9qmfS4myFs8KKEJpvwgAuMrccqqPXcn8Rxon',
+  header: {},
+  metadata: {},
+  operations: [
+    [
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'opWkyTZEwh5929VqXC4BZgrBSRQ7JvomNTv71rdkx1QAiRLpYAu',
+        branch: 'BL5EYnuHPXMTq9s1HR8CcFWkgNHCvoZyVQCU2H2DjSudr6GXgXf',
+        contents: [
+          {
+            kind: 'smart_rollup_recover_bond',
+            source: 'tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw',
+            fee: '1000000',
+            counter: '25156',
+            gas_limit: '4016',
+            storage_limit: '0',
+            rollup: 'sr1EYxm4fQjr15TASs2Q7PgZ1LqS6unkZhHL',
+            staker: 'tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw',
+            metadata: {
+              balance_updates: [
+                {
+                  kind: 'contract',
+                  contract: 'tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw',
+                  change: '-1000000',
+                  origin: 'block',
+                },
+                {
+                  kind: 'accumulator',
+                  category: 'block fees',
+                  change: '1000000',
+                  origin: 'block',
+                },
+              ],
+              operation_result: {
+                status: 'applied',
+                balance_updates: [
+                  {
+                    kind: 'freezer',
+                    category: 'bonds',
+                    contract: 'tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw',
+                    bond_id: {
+                      smart_rollup: 'sr1EYxm4fQjr15TASs2Q7PgZ1LqS6unkZhHL',
+                    },
+                    change: '-10000000000',
+                    origin: 'block',
+                  },
+                  {
+                    kind: 'contract',
+                    contract: 'tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw',
+                    change: '10000000000',
+                    origin: 'block',
+                  },
+                ],
+                consumed_milligas: '3915240',
+              },
+            },
+          },
+        ],
+        signature:
+          'sigPbtnebwMZD1CZUEfFnhcjGuhyLhX2WPEFvQEFKaD6DKeYjMSBD6pc4UkR4zkAw5KdifSH7QdJ7wg9CmsruSi9cUGvqEap',
+      },
+    ],
+  ],
+};
+
+export const smartRollupTimeoutResponse = {
+  protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+  chain_id: 'NetXgbcrNtXD2yA',
+  hash: 'BM5txTKWoRptQ7k8M4hF2SjLQjz7ezriNfaHZQZxNjHsqzESjMu',
+  header: {},
+  metadata: {},
+  operations: [
+    [
+      {
+        protocol: 'PtMumbai2TmsJHNGRkD8v8YDbtao7BLUC3wjASn1inAKLFCjaH1',
+        chain_id: 'NetXgbcrNtXD2yA',
+        hash: 'opZMSbsYYSL1tMKYxgPoDvtaehAt24PSbwuNeQo8ry52KpWwzqa',
+        branch: 'BLpiGot997JRMKyrYoP8MmjVMWHHXMiLj17gue86uNaRnip8jux',
+        contents: [
+          {
+            kind: 'smart_rollup_timeout',
+            source: 'tz1TecRhYLVV9bTKRKU9g1Hhpb1Ymw3ynzWS',
+            fee: '753',
+            counter: '23077',
+            gas_limit: '4647',
+            storage_limit: '0',
+            rollup: 'sr1QZkk1swognQW3dmiXvga3wVkEgBq7QFjE',
+            stakers: {
+              alice: 'tz1TecRhYLVV9bTKRKU9g1Hhpb1Ymw3ynzWS',
+              bob: 'tz1iFnSQ6V2d8piVMPMjtDNdkYNMaUfKwsoy',
+            },
+          },
+        ],
+        signature:
+          'sigN53ibLsMQAnkeE7EQZY9ZFkiBgtdsLKtsPdswdvGHU4kPAMh3Arz2fFDGKT3EyKHuYy5G9T6pJtTdfkRuWpN2fgvmH1Pr',
       },
     ],
   ],

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -44,12 +44,10 @@ import {
   OperationContentsAndResultSmartRollupPublish,
   OperationContentsAndResultSmartRollupRefute,
   SmartRollupRefutationMove,
-  SmartRollupRefutationMoveStepProof,
   OperationContentsAndResultSmartRollupRecoverBond,
   OperationContentsAndResultSmartRollupTimeout,
-  SmartRollupTimeoutStakers,
   SmartRollupRefutationStart,
-  SmartRollupRefutationMoveStepDissection,
+  SmartRollupRefutationOptions,
 } from '../src/types';
 import {
   blockIthacanetResponse,
@@ -4492,10 +4490,18 @@ describe('RpcClient test', () => {
       expect(content.opponent).toEqual('tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC');
 
       const refutation = content.refutation as SmartRollupRefutationMove;
-      const step = refutation.step as SmartRollupRefutationMoveStepProof;
+      if (refutation.refutation_kind !== SmartRollupRefutationOptions.MOVE) {
+        fail('expected refutation_kind: "move"');
+      }
 
       expect(refutation.refutation_kind).toEqual('move');
       expect(refutation.choice).toEqual('176000000003');
+
+      const step = refutation.step;
+      if (Array.isArray(step)) {
+        fail('expected an object not an array');
+      }
+
       expect(step.pvm_step).toEqual(
         '03000298e4e3d5c88da366e885edf675ffd7a5087c8e0a2fcd508e7951113fe4c1491810067c06a78b88cb7c3e60c56b47ba9e14c922dbdbd4811ac6fee80a309620630005820764757261626c6582066b65726e656cd07d20c53bdd5b536a6be9c4cdad16e69a9af40b93a6564655fffd88bba050519008726561646f6e6c7982066b65726e656cd0a645771d9d5228a31312b282119c596699ccb6b60b93d759c2072a493ddbb5740c7761736d5f76657273696f6e8101408208636f6e74656e7473810130c10200322e302e30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066c656e677468c008000000000000000503746167c00800000004536f6d650003810370766d00050004000381166f7574626f785f76616c69646974795f706572696f64c00400013b0082136c6173745f746f705f6c6576656c5f63616c6cc00680c0abd38f05196d6178696d756d5f7265626f6f74735f7065725f696e707574c002e80781146f7574626f785f6d6573736167655f6c696d6974c002a401810c6d61785f6e625f7469636b73c00580dc9afd28820576616c7565810370766d8107627566666572738205696e7075740003810468656164c001008208636f6e74656e7473d06e2c0a5b371a53e76a9b7f221a5baa67170b3f9f43205fb06c0649123cec2358066c656e677468c00103066f75747075740004820132810a6c6173745f6c6576656cc0040000a33f0133810f76616c69646974795f706572696f64c00400013b0082013181086f7574626f786573d0ccbff4c181451166adb153f7a1631e9f036832f8e5c82acd8e8c12876eeeda870134810d6d6573736167655f6c696d6974c002a401047761736d00048205696e707574c0050000a33f0203746167c00b0000000770616464696e67820c63757272656e745f7469636bc00683c0abd38f050e7265626f6f745f636f756e746572c002e907'
       );
@@ -4543,11 +4549,18 @@ describe('RpcClient test', () => {
       expect(content.rollup).toEqual('sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x');
       expect(content.opponent).toEqual('tz1ZpuBypK6G754crXDZyoMPaVPoBmBsPda2');
 
-      const refutation = content.refutation as SmartRollupRefutationMove;
-      const step = refutation.step as SmartRollupRefutationMoveStepDissection[];
+      const refutation = content.refutation;
+      if (refutation.refutation_kind !== SmartRollupRefutationOptions.MOVE) {
+        fail('Expected Refutation kind: "move"');
+      }
 
       expect(refutation.refutation_kind).toEqual('move');
       expect(refutation.choice).toEqual('0');
+
+      const step = refutation.step;
+      if (!Array.isArray(step)) {
+        fail('expected step to be an array');
+      }
       expect(step[0]).toEqual({
         state: 'srs11y1ZCJfeWnHzoX3rAjcTXiphwg8NvqQhvishP3PU68jgSREuk6',
         tick: '0',
@@ -4594,7 +4607,7 @@ describe('RpcClient test', () => {
       expect(content.storage_limit).toEqual('0');
       expect(content.rollup).toEqual('sr1QZkk1swognQW3dmiXvga3wVkEgBq7QFjE');
 
-      const stakers = content.stakers as SmartRollupTimeoutStakers;
+      const stakers = content.stakers;
 
       expect(stakers.alice).toEqual('tz1TecRhYLVV9bTKRKU9g1Hhpb1Ymw3ynzWS');
       expect(stakers.bob).toEqual('tz1iFnSQ6V2d8piVMPMjtDNdkYNMaUfKwsoy');

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -40,22 +40,37 @@ import {
   RPCRunOperationParam,
   OperationMetadataBalanceUpdates,
   PendingOperations,
+  OperationContentsAndResultSmartRollupCement,
+  OperationContentsAndResultSmartRollupPublish,
+  OperationContentsAndResultSmartRollupRefute,
+  SmartRollupRefutationMove,
+  SmartRollupRefutationMoveStepProof,
+  OperationContentsAndResultSmartRollupRecoverBond,
+  OperationContentsAndResultSmartRollupTimeout,
+  SmartRollupTimeoutStakers,
+  SmartRollupRefutationStart,
+  SmartRollupRefutationMoveStepDissection,
 } from '../src/types';
 import {
-  blockIthacanetSample,
-  blockJakartanetSample,
-  blockKathmandunetSample,
-  blockLimanetSample,
-  blockMondaynetSample,
-  delegatesIthacanetSample,
-  delegatesKathmandunetSample,
-  votingInfoKathmandunetSample,
-  ticketUpdatesSample,
+  blockIthacanetResponse,
+  blockJakartanetResponse,
+  blockKathmandunetResponse,
+  blockLimanetResponse,
+  blockMondaynetResponse,
+  delegatesIthacanetResponse,
+  delegatesKathmandunetResponse,
+  votingInfoKathmandunetResponse,
+  ticketUpdatesResponse,
   ticketBalancesResponse,
   smartRollupOriginateResponse,
   smartRollupAddMessagesResponse,
   smartRollupExecuteOutboxMessageResponse,
   pendingOperationsResponse,
+  smartRollupCementResponse,
+  smartRollupPublishResponse,
+  smartRollupRefuteResponse,
+  smartRollupRecoverBondResponse,
+  smartRollupTimeoutResponse,
 } from './data/rpc-responses';
 
 /**
@@ -361,7 +376,7 @@ describe('RpcClient test', () => {
     });
 
     it('should parse the response properly, proto12', async (done) => {
-      httpBackend.createRequest.mockResolvedValue(delegatesIthacanetSample);
+      httpBackend.createRequest.mockResolvedValue(delegatesIthacanetResponse);
       const response = await client.getDelegates(contractAddress);
 
       expect(response).toEqual({
@@ -380,7 +395,7 @@ describe('RpcClient test', () => {
     });
 
     it('should parse the response properly, proto14', async (done) => {
-      httpBackend.createRequest.mockResolvedValue(delegatesKathmandunetSample);
+      httpBackend.createRequest.mockResolvedValue(delegatesKathmandunetResponse);
       const response = await client.getDelegates(contractAddress);
 
       expect(response).toEqual({
@@ -402,7 +417,7 @@ describe('RpcClient test', () => {
 
   describe('getVotingInfo', () => {
     it('should query the right url', async (done) => {
-      httpBackend.createRequest.mockResolvedValue(votingInfoKathmandunetSample);
+      httpBackend.createRequest.mockResolvedValue(votingInfoKathmandunetResponse);
       await client.getVotingInfo(contractAddress);
 
       expect(httpBackend.createRequest.mock.calls[0][0]).toEqual({
@@ -414,7 +429,7 @@ describe('RpcClient test', () => {
     });
 
     it('should parse the response properly', async (done) => {
-      httpBackend.createRequest.mockResolvedValue(votingInfoKathmandunetSample);
+      httpBackend.createRequest.mockResolvedValue(votingInfoKathmandunetResponse);
       const response = await client.getVotingInfo(contractAddress);
 
       expect(response).toEqual({
@@ -2800,7 +2815,7 @@ describe('RpcClient test', () => {
     });
 
     it('should use enum to represent property category in balance_updates, proto 12', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetResponse));
 
       const response = await client.getBlock();
 
@@ -2822,7 +2837,7 @@ describe('RpcClient test', () => {
     });
 
     it('should fetch a block and access new properties in header, proto 12', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetResponse));
 
       const response = await client.getBlock();
 
@@ -2839,7 +2854,7 @@ describe('RpcClient test', () => {
     });
 
     it('should fetch a block and access new properties in metadata, proto 12', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetResponse));
 
       const response = await client.getBlock();
 
@@ -2851,7 +2866,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access new properties of the operation type endorsement, proto 12', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetResponse));
 
       const response = await client.getBlock();
 
@@ -2875,7 +2890,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access new properties of the operation type set_deposits_limit, proto 12', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockIthacanetResponse));
 
       const response = await client.getBlock();
 
@@ -2912,7 +2927,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_origination, proto 13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -2965,7 +2980,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_submit_batch, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3001,7 +3016,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_commit, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3049,7 +3064,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_finalize_commitment, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3086,7 +3101,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_dispatch_tickets, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3121,7 +3136,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_remove_commitment, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3156,7 +3171,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of the operation type tx_rollup_rejection, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3297,7 +3312,7 @@ describe('RpcClient test', () => {
     });
 
     it('should access the properties of operation type tx_rollup_return_bond, proto13', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockJakartanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3341,7 +3356,7 @@ describe('RpcClient test', () => {
     });
 
     it('should be able to access the properties of operation type transfer_ticket, proto14', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockMondaynetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockMondaynetResponse));
       const response = await client.getBlock();
       const content = response.operations[3][0]
         .contents[1] as OperationContentsAndResultTransferTicket;
@@ -3380,7 +3395,7 @@ describe('RpcClient test', () => {
     });
 
     it('should be able to access the properties of operation type increase_paid_storage, proto14', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockKathmandunetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockKathmandunetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3416,7 +3431,7 @@ describe('RpcClient test', () => {
     });
 
     it('should be able to access the properties of internal operation type event, proto14', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockKathmandunetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockKathmandunetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][1]
@@ -3464,7 +3479,7 @@ describe('RpcClient test', () => {
     });
 
     it('should be able to access the properties of operation type drain_delegate, proto15', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockLimanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockLimanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3509,7 +3524,7 @@ describe('RpcClient test', () => {
     });
 
     it('should be able to access the properties of operation type update_consensus_key, proto15', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockLimanetSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(blockLimanetResponse));
 
       const response = await client.getBlock();
       const content = response.operations[3][0]
@@ -3542,7 +3557,7 @@ describe('RpcClient test', () => {
       done();
     });
     it('should contain ticket_updates for transactions updating ticket storage', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(ticketUpdatesSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(ticketUpdatesResponse));
 
       const response = await client.getBlock();
       const content = response.operations[0][0]
@@ -3559,7 +3574,7 @@ describe('RpcClient test', () => {
     });
     // may be removed
     it('should contain ticket_receipt for transactions updating ticket storage', async (done) => {
-      httpBackend.createRequest.mockReturnValue(Promise.resolve(ticketUpdatesSample));
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(ticketUpdatesResponse));
 
       const response = await client.getBlock();
       const content = response.operations[0][0]
@@ -4377,6 +4392,212 @@ describe('RpcClient test', () => {
       expect(soruResult.consumed_milligas).toEqual('4731015');
       expect(soruResult.ticket_updates).toEqual([]);
       expect(soruResult.paid_storage_size_diff).toEqual('5');
+      done();
+    });
+  });
+
+  describe('smartRollupPublish', () => {
+    it('should have correct types to access smart_rollup_publish results', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupPublishResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][0]
+        .contents[0] as OperationContentsAndResultSmartRollupPublish;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_PUBLISH);
+      expect(content.source).toEqual('tz1gCe1sFpppbGGVwCt5jLRqDS9FD1W4Qca4');
+      expect(content.fee).toEqual('964');
+      expect(content.counter).toEqual('41266');
+      expect(content.gas_limit).toEqual('6418');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1AE6U3GNzE8iKzj6sKS5wh1U32ogeULCoN');
+
+      const commitment = content.commitment;
+      expect(commitment.compressed_state).toEqual(
+        'srs13FywcbcZV9VvHxdVkYK83Ch4477cqHMgM8d5oT955yf4XXMvKS'
+      );
+      expect(commitment.inbox_level).toEqual(197151);
+      expect(commitment.predecessor).toEqual(
+        'src12i7dL2z9VbgshFDdGFP5TPBoJu6WnZNWJXGa1QQgPTErVPPtd8'
+      );
+      expect(commitment.number_of_ticks).toEqual('880000000000');
+
+      const soruResult = content.metadata.operation_result;
+      expect(soruResult.status).toEqual('applied');
+      expect(soruResult.consumed_milligas).toEqual('6317837');
+      expect(soruResult.staked_hash).toEqual(
+        'src13TanyZ7RvSULqVb2tjx1zRVw2jyJC2ToHLz1ZKg38sZ4HBYdSN'
+      );
+      expect(soruResult.published_at_level).toEqual(197154);
+      expect(soruResult.balance_updates).toEqual([]);
+
+      done();
+    });
+
+    it('should have correct access to metadata.operation_result.balanceUpdate in smart_rollup_publish', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupPublishResponse));
+      const response = await client.getBlock();
+      const contentWithDiffBalanceUpdate = response.operations[0][1]
+        .contents[0] as OperationContentsAndResultSmartRollupPublish;
+
+      const balanceUpdates =
+        contentWithDiffBalanceUpdate.metadata.operation_result.balance_updates ?? [];
+
+      const diffBalanceUpdate = balanceUpdates[1];
+      expect(diffBalanceUpdate.bond_id?.smart_rollup).toEqual(
+        'sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x'
+      );
+      done();
+    });
+  });
+
+  describe('smartRollupCement', () => {
+    it('shoud have correct types to access smart_rollup_cement results', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupCementResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][0]
+        .contents[0] as OperationContentsAndResultSmartRollupCement;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_CEMENT);
+      expect(content.source).toEqual('tz1gCe1sFpppbGGVwCt5jLRqDS9FD1W4Qca4');
+      expect(content.fee).toEqual('922');
+      expect(content.counter).toEqual('41267');
+      expect(content.gas_limit).toEqual('6432');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1AE6U3GNzE8iKzj6sKS5wh1U32ogeULCoN');
+      expect(content.commitment).toEqual('src13w2EBEZmVg4jsDd5PfYNakBRZ6GqSGDgWLz7EHZGeeG1gm7HT5');
+
+      const soruResult = content.metadata.operation_result;
+
+      expect(soruResult.status).toEqual('applied');
+      expect(soruResult.consumed_milligas).toEqual('6331052');
+      expect(soruResult.inbox_level).toEqual(197111);
+      done();
+    });
+  });
+
+  describe('smartRollupRefute', () => {
+    it('should have correct types to access smart_rollup_refute results move with pvm_step', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupRefuteResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][0]
+        .contents[0] as OperationContentsAndResultSmartRollupRefute;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_REFUTE);
+      expect(content.source).toEqual('tz1ZpuBypK6G754crXDZyoMPaVPoBmBsPda2');
+      expect(content.fee).toEqual('2096');
+      expect(content.counter).toEqual('32553');
+      expect(content.gas_limit).toEqual('6299');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x');
+      expect(content.opponent).toEqual('tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC');
+
+      const refutation = content.refutation as SmartRollupRefutationMove;
+      const step = refutation.step as SmartRollupRefutationMoveStepProof;
+
+      expect(refutation.refutation_kind).toEqual('move');
+      expect(refutation.choice).toEqual('176000000003');
+      expect(step.pvm_step).toEqual(
+        '03000298e4e3d5c88da366e885edf675ffd7a5087c8e0a2fcd508e7951113fe4c1491810067c06a78b88cb7c3e60c56b47ba9e14c922dbdbd4811ac6fee80a309620630005820764757261626c6582066b65726e656cd07d20c53bdd5b536a6be9c4cdad16e69a9af40b93a6564655fffd88bba050519008726561646f6e6c7982066b65726e656cd0a645771d9d5228a31312b282119c596699ccb6b60b93d759c2072a493ddbb5740c7761736d5f76657273696f6e8101408208636f6e74656e7473810130c10200322e302e30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000066c656e677468c008000000000000000503746167c00800000004536f6d650003810370766d00050004000381166f7574626f785f76616c69646974795f706572696f64c00400013b0082136c6173745f746f705f6c6576656c5f63616c6cc00680c0abd38f05196d6178696d756d5f7265626f6f74735f7065725f696e707574c002e80781146f7574626f785f6d6573736167655f6c696d6974c002a401810c6d61785f6e625f7469636b73c00580dc9afd28820576616c7565810370766d8107627566666572738205696e7075740003810468656164c001008208636f6e74656e7473d06e2c0a5b371a53e76a9b7f221a5baa67170b3f9f43205fb06c0649123cec2358066c656e677468c00103066f75747075740004820132810a6c6173745f6c6576656cc0040000a33f0133810f76616c69646974795f706572696f64c00400013b0082013181086f7574626f786573d0ccbff4c181451166adb153f7a1631e9f036832f8e5c82acd8e8c12876eeeda870134810d6d6573736167655f6c696d6974c002a401047761736d00048205696e707574c0050000a33f0203746167c00b0000000770616464696e67820c63757272656e745f7469636bc00683c0abd38f050e7265626f6f745f636f756e746572c002e907'
+      );
+      done();
+    });
+
+    it('should have correct types to access smart_rollup_refute results start', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupRefuteResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][1]
+        .contents[0] as OperationContentsAndResultSmartRollupRefute;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_REFUTE);
+      expect(content.source).toEqual('tz1Qn5AXWB5vYPgzDXsunDbZ7tTUp9cFDaRp');
+      expect(content.fee).toEqual('943');
+      expect(content.counter).toEqual('25002');
+      expect(content.gas_limit).toEqual('6109');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1Ce7znpA1ea2YZca3v1CefxqXMhqYgDEXR');
+      expect(content.opponent).toEqual('tz1VN3J6DyH712W1y13Uu1N8fxkt8RvMyqzm');
+
+      const refutation = content.refutation as SmartRollupRefutationStart;
+
+      expect(refutation.refutation_kind).toEqual('start');
+      expect(refutation.player_commitment_hash).toEqual(
+        'src14Liog4xxPoZ55AgpBpeDweFSxHK6b3zbybhp7ChsWbM9g1Jsrd'
+      );
+      expect(refutation.opponent_commitment_hash).toEqual(
+        'src12q2zZyxuK5UeYPQYSutA6RPMv7sZDtJ7oAWxAytuJC3rjvWct6'
+      );
+      done();
+    });
+    it('should have correct types to access smart_rollup_refute results move with dissection', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupRefuteResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][2]
+        .contents[0] as OperationContentsAndResultSmartRollupRefute;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_REFUTE);
+      expect(content.source).toEqual('tz1QD39GBmSzccuDxWMevj2gudiTX1pZL5kC');
+      expect(content.fee).toEqual('1989');
+      expect(content.counter).toEqual('32546');
+      expect(content.gas_limit).toEqual('4333');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1LhGA2zC9VcYALSifpRBCgDiQfDSQ6bb4x');
+      expect(content.opponent).toEqual('tz1ZpuBypK6G754crXDZyoMPaVPoBmBsPda2');
+
+      const refutation = content.refutation as SmartRollupRefutationMove;
+      const step = refutation.step as SmartRollupRefutationMoveStepDissection[];
+
+      expect(refutation.refutation_kind).toEqual('move');
+      expect(refutation.choice).toEqual('0');
+      expect(step[0]).toEqual({
+        state: 'srs11y1ZCJfeWnHzoX3rAjcTXiphwg8NvqQhvishP3PU68jgSREuk6',
+        tick: '0',
+      });
+      expect(step[1]).toEqual({
+        state: 'srs12ti4nRqiqahBZedqjgnFx9ZK88KkSgpYD8ns5Q41UMEXGg9w3b',
+        tick: '22000000000',
+      });
+      done();
+    });
+  });
+
+  describe('smartRollupRecoverBond', () => {
+    it('should have correct types to access smart_rollup_recover_bond results', async (done) => {
+      httpBackend.createRequest.mockReturnValue(Promise.resolve(smartRollupRecoverBondResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][0]
+        .contents[0] as OperationContentsAndResultSmartRollupRecoverBond;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_RECOVER_BOND);
+      expect(content.source).toEqual('tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw');
+      expect(content.fee).toEqual('1000000');
+      expect(content.counter).toEqual('25156');
+      expect(content.gas_limit).toEqual('4016');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1EYxm4fQjr15TASs2Q7PgZ1LqS6unkZhHL');
+      expect(content.staker).toEqual('tz1bTS4QDBnpQPmMPNM3rn7jN1hevkWDHSKw');
+      done();
+    });
+  });
+
+  describe('smartRollupTimeout', () => {
+    it('should have correct types to access smart_rollup_timeout', async (done) => {
+      httpBackend.createRequest.mockResolvedValue(Promise.resolve(smartRollupTimeoutResponse));
+      const response = await client.getBlock();
+      const content = response.operations[0][0]
+        .contents[0] as OperationContentsAndResultSmartRollupTimeout;
+
+      expect(content.kind).toEqual(OpKind.SMART_ROLLUP_TIMEOUT);
+      expect(content.source).toEqual('tz1TecRhYLVV9bTKRKU9g1Hhpb1Ymw3ynzWS');
+      expect(content.fee).toEqual('753');
+      expect(content.counter).toEqual('23077');
+      expect(content.gas_limit).toEqual('4647');
+      expect(content.storage_limit).toEqual('0');
+      expect(content.rollup).toEqual('sr1QZkk1swognQW3dmiXvga3wVkEgBq7QFjE');
+
+      const stakers = content.stakers as SmartRollupTimeoutStakers;
+
+      expect(stakers.alice).toEqual('tz1TecRhYLVV9bTKRKU9g1Hhpb1Ymw3ynzWS');
+      expect(stakers.bob).toEqual('tz1iFnSQ6V2d8piVMPMjtDNdkYNMaUfKwsoy');
       done();
     });
   });


### PR DESCRIPTION
closes - #2409
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
