### PR TITLE
fixed prepare provider to not carry over counter amounts across methods

### DIFF
--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -843,6 +843,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
     const contents = this.constructOpContents(ops, headCounter, pkh);
 

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -257,6 +257,7 @@ export class PrepareProvider implements PreparationProvider {
       const hash = await this.getBlockHash();
       const protocol = await this.getProtocolHash();
 
+      this.#counters = {};
       const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
       const contents = this.constructOpContents(ops, headCounter, pkh);
@@ -303,6 +304,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -341,6 +343,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -379,6 +382,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -420,6 +424,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -462,6 +467,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -503,6 +509,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -544,6 +551,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -585,6 +593,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -617,6 +626,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     let currentVotingPeriod: VotingPeriodBlockResult;
@@ -663,6 +673,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     let currentVotingPeriod: VotingPeriodBlockResult;
@@ -709,6 +720,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -747,6 +759,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
@@ -788,6 +801,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
     const contents = this.constructOpContents(ops, headCounter, pkh, source);
 
@@ -801,46 +815,46 @@ export class PrepareProvider implements PreparationProvider {
     };
   }
 
-    /**
+  /**
    *
    * @description Method to prepare a smart_rollup_originate operation
    * @param operation RPCOperation object or RPCOperation array
    * @returns a PreparedOperation object
    */
-    async smartRollupOriginate(params: SmartRollupOriginateParams): Promise<PreparedOperation> {
-      const pkh = await this.signer.publicKeyHash();
+  async smartRollupOriginate(params: SmartRollupOriginateParams): Promise<PreparedOperation> {
+    const pkh = await this.signer.publicKeyHash();
 
-      const originationProof = await this.rpc.getOriginationProof({
-        kind: params.pvmKind,
-        kernel: params.kernel,
-      });
-      const completeParams = { ...params, originationProof };
-      const estimate = await this.estimate.smartRollupOriginate(completeParams);
-      const estimates = this.buildEstimates(estimate);
+    const originationProof = await this.rpc.getOriginationProof({
+      kind: params.pvmKind,
+      kernel: params.kernel,
+    });
+    const completeParams = { ...params, originationProof };
+    const estimate = await this.estimate.smartRollupOriginate(completeParams);
+    const estimates = this.buildEstimates(estimate);
 
-      const op = await createSmartRollupOriginateOperation({
-        ...completeParams,
-        ...estimates,
-      });
+    const op = await createSmartRollupOriginateOperation({
+      ...completeParams,
+      ...estimates,
+    });
 
-      const operation = await this.addRevealOperationIfNeeded(op, pkh);
-      const ops = this.convertIntoArray(operation);
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
 
-      const hash = await this.getBlockHash();
-      const protocol = await this.getProtocolHash();
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
 
-      const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
-      const contents = this.constructOpContents(ops, headCounter, pkh);
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+    const contents = this.constructOpContents(ops, headCounter, pkh);
 
-      return {
-        opOb: {
-          branch: hash,
-          contents,
-          protocol,
-        },
-        counter: headCounter,
-      };
-    }
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
 
   /**
    *
@@ -862,6 +876,7 @@ export class PrepareProvider implements PreparationProvider {
     const hash = await this.getBlockHash();
     const protocol = await this.getProtocolHash();
 
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh);
@@ -889,6 +904,8 @@ export class PrepareProvider implements PreparationProvider {
     const protocol = await this.getProtocolHash();
 
     const pkh = await this.signer.publicKeyHash();
+
+    this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const params = contractMethod.toTransferParams();


### PR DESCRIPTION
Updated implementation of prepare provider to not carry over op counter amounts

closes #2425 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
