### PR TITLE
docs: add documentation for json michelson contract calls

### DIFF
--- a/docs/contract_call_parameters.md
+++ b/docs/contract_call_parameters.md
@@ -42,7 +42,7 @@ There is nothing special to do to pass an option with Taquito, Taquito will assu
 | Michelson type                             | Michelson value         | Taquito `methods`         | Taquito `methodsObject` |
 | ------------------------------------------ | ----------------------- | ------------------------- | ----------------------- |
 | or int string                              | Left 5                  | 0, 5                      | {0: 5}                  |
-| or int string                              | Right "Tezos            | 1, "Tezos"                | {1: "Tezos"}            |
+| or int string                              | Right "Tezos"           | 1, "Tezos"                | {1: "Tezos"}            |
 | or (pair int nat) string                   | Left (Pair 6 7)         | 0, { 0: 6, 1: 7 }         | {0: { 0: 6, 1: 7 }}     |
 | or (or string (pair nat int) (or int nat)) | Left (Right (Pair 6 7)) | see below                 | see below               |
 
@@ -71,6 +71,54 @@ In a list, `pair` and `union` values are always represented as objects: a `pair`
 | pair (pair (int %one) (nat %two)) (pair (string %three) (mutez %four)) | Pair (Pair (6 %one) (7 %two)) (Pair ("Tezos" %three) (500000 %four)) | 6, 7, "Tezos", 50_0000 | { "one": 6, "two": 7, "three": "Tezos", "four": 50_000 } |
 
 The `methodsObject` method always takes a single object to represent the pair to be passed, while `methods` requires the pair fields to be spread. If annotations are present, they are used to identify the pair fielda in the corresponding properties of the JS object.
+
+## Bypassing the Michelson Encoder
+Users can bypass the `michelson-encoder` and `ContractAbstraction` by directly passing JSON Michelson in a `transfer` call. This eliminates the need to fetch and create a JS/TS contract abstraction using `tezos.wallet.at` or `tezos.contract.at` and also removes the requirement to create a local contract instance for interaction. As a result, the conversion of entrypoint parameters to the JSON Michelson format using the michelson-encoder is no longer necessary as used in the ContractAbstraction entrypoints as listed prior for `methods` and `methodsObject`.
+
+The `transfer` method can be used with both the `wallet` and `contract` providers. However, it is necessary to specify and set the provider accordingly, whether it is a `wallet` or `signer` provider.
+
+A brief example for `Pair int string` using a Wallet Provider would be:
+
+```ts
+let nested2SomeNone1 = await tezos.wallet.transfer({ 
+  to: 'KT1NhJvzVTfidU5oV1NM9W9uwA2RSxNZz5Ai', 
+  amount: 0, 
+  parameter: { 
+    entrypoint: 'default', 
+    value: {
+      prim: 'Pair',
+      args: [
+        {int: 6}, 
+        {string:"tez"}
+      ],
+    }
+  }
+}).send()
+```
+
+Another example of Michelson type `pair (pair int nat) (option nat)` using the Contract Provider.
+
+```ts
+const nested2SomeNone2 = await tezos.contract.transfer({ 
+  to: 'KT1NhJvzVTfidU5oV1NM9W9uwA2RSxNZz5Ai', 
+  amount: 0, 
+  parameter: { 
+    entrypoint: 'default', 
+    value: {
+      prim: 'Pair',
+      args: [{
+        prim: 'Pair',
+        args: [
+          {int: 6},
+          {int: 7}
+        ],
+        }, 
+        { prim: 'None' } // <- this || { "int": 10 }
+      ],
+    }
+  }
+})
+```
 
 ## Map and big_map
 

--- a/docs/contract_call_parameters.md
+++ b/docs/contract_call_parameters.md
@@ -72,6 +72,11 @@ In a list, `pair` and `union` values are always represented as objects: a `pair`
 
 The `methodsObject` method always takes a single object to represent the pair to be passed, while `methods` requires the pair fields to be spread. If annotations are present, they are used to identify the pair fielda in the corresponding properties of the JS object.
 
+
+## Map and big_map
+
+See the [documentation about creating and updating maps and big_maps](https://tezostaquito.io/docs/michelsonmap/)
+
 ## Bypassing the Michelson Encoder
 Users can bypass the `michelson-encoder` and `ContractAbstraction` by directly passing JSON Michelson in a `transfer` call. This eliminates the need to fetch and create a JS/TS contract abstraction using `tezos.wallet.at` or `tezos.contract.at` and also removes the requirement to create a local contract instance for interaction. As a result, the conversion of entrypoint parameters to the JSON Michelson format using the michelson-encoder is no longer necessary as used in the ContractAbstraction entrypoints as listed prior for `methods` and `methodsObject`.
 
@@ -87,8 +92,8 @@ The michelson-encoder has limitations when encoding complex data structures with
 A brief example for `Pair int string` using a Wallet Provider would be:
 
 ```ts
-let nested2SomeNone1 = await tezos.wallet.transfer({ 
-  to: 'KT1NhJvzVTfidU5oV1NM9W9uwA2RSxNZz5Ai', 
+let opWithWallet = await tezos.wallet.transfer({ 
+  to: 'KT1...', 
   amount: 0, 
   parameter: { 
     entrypoint: 'default', 
@@ -106,8 +111,8 @@ let nested2SomeNone1 = await tezos.wallet.transfer({
 Another example of Michelson type `pair (pair int nat) (option nat)` using the Contract Provider.
 
 ```ts
-const nested2SomeNone2 = await tezos.contract.transfer({ 
-  to: 'KT1NhJvzVTfidU5oV1NM9W9uwA2RSxNZz5Ai', 
+const opWithSigner = await tezos.contract.transfer({ 
+  to: 'KT1...', 
   amount: 0, 
   parameter: { 
     entrypoint: 'default', 
@@ -127,6 +132,3 @@ const nested2SomeNone2 = await tezos.contract.transfer({
 })
 ```
 
-## Map and big_map
-
-See the [documentation about creating and updating maps and big_maps](https://tezostaquito.io/docs/michelsonmap/)

--- a/docs/contract_call_parameters.md
+++ b/docs/contract_call_parameters.md
@@ -77,6 +77,13 @@ Users can bypass the `michelson-encoder` and `ContractAbstraction` by directly p
 
 The `transfer` method can be used with both the `wallet` and `contract` providers. However, it is necessary to specify and set the provider accordingly, whether it is a `wallet` or `signer` provider.
 
+:::info
+Please Note:
+By using JSON Michelson directly in `transfer` calls with `Taquito`, developers can bypass potential edge cases that are not currently supported by the `michelson-encoder`. This is particularly useful when dealing with heavily nested entrypoint parameters involving multiple nest optional values.
+
+The michelson-encoder has limitations when encoding complex data structures with deep nesting in entrypoint parameters. By directly passing JSON Michelson, developers can freely construct and manipulate intricate entrypoint parameters without relying on the michelson-encoder to handle complex nesting. This approach provides more flexibility in working with complex data structures.
+:::
+
 A brief example for `Pair int string` using a Wallet Provider would be:
 
 ```ts


### PR DESCRIPTION
closes #2443 

This approach to call an entrypoint can skip potential edge cases that have not been covered yet for the michelson-encoder

what the note section looks like
![image](https://github.com/ecadlabs/taquito/assets/72581075/1d6244c4-320f-4b81-a26c-ffc2dc4ad359)
 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
