### PR TITLE
updated types for sc_rollup_cement in N

### DIFF
--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -1615,6 +1615,7 @@ export interface OperationResultSmartRollupCement {
   status: OperationResultStatusEnum;
   consumed_milligas?: string;
   inbox_level?: number;
+  commitment_hash?: string;
   errors?: TezosGenericOperationError[];
 }
 


### PR DESCRIPTION
closes #2448 

- Updated the Operation Result type of `sc_rollup_cement` 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
