### PR TITLE
added reveal op if needed in contract call preparation

### DIFF
--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -444,6 +444,7 @@ export class PrepareProvider extends Provider implements PreparationProvider {
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, rest.source);
+    console.log(`contents: ${JSON.stringify(contents)}`);
 
     return {
       opOb: {
@@ -1043,17 +1044,17 @@ export class PrepareProvider extends Provider implements PreparationProvider {
       DEFAULT_PARAMS
     );
 
-    const ops = [
-      {
-        kind: OpKind.TRANSACTION,
-        fee: params.fee ?? estimateLimits.fee,
-        gas_limit: params.gasLimit ?? estimateLimits.gasLimit,
-        storage_limit: params.storageLimit ?? estimateLimits.storageLimit,
-        amount: String(params.amount),
-        destination: params.to,
-        parameters: params.parameter,
-      },
-    ] as RPCOperation[];
+    const op = await createTransferOperation({
+      fee: params.fee ?? estimateLimits.fee,
+      gasLimit: params.gasLimit ?? estimateLimits.gasLimit,
+      storageLimit: params.storageLimit ?? estimateLimits.storageLimit,
+      amount: params.amount,
+      to: params.to,
+      parameter: params.parameter,
+    });
+
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
 
     const contents = this.constructOpContents(ops, headCounter, pkh);
 

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -444,7 +444,6 @@ export class PrepareProvider extends Provider implements PreparationProvider {
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
     const contents = this.constructOpContents(ops, headCounter, pkh, rest.source);
-    console.log(`contents: ${JSON.stringify(contents)}`);
 
     return {
       opOb: {


### PR DESCRIPTION
closes #2500 

Fixed preparation of contract calls and add reveal operations when needed.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
