### PR TITLE
fixed contract call estimate prep to check for reveal

### DIFF
--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -1043,17 +1043,17 @@ export class PrepareProvider extends Provider implements PreparationProvider {
       DEFAULT_PARAMS
     );
 
-    const ops = [
-      {
-        kind: OpKind.TRANSACTION,
-        fee: params.fee ?? estimateLimits.fee,
-        gas_limit: params.gasLimit ?? estimateLimits.gasLimit,
-        storage_limit: params.storageLimit ?? estimateLimits.storageLimit,
-        amount: String(params.amount),
-        destination: params.to,
-        parameters: params.parameter,
-      },
-    ] as RPCOperation[];
+    const op = await createTransferOperation({
+      fee: params.fee ?? estimateLimits.fee,
+      gasLimit: params.gasLimit ?? estimateLimits.gasLimit,
+      storageLimit: params.storageLimit ?? estimateLimits.storageLimit,
+      amount: params.amount,
+      to: params.to,
+      parameter: params.parameter,
+    });
+
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
 
     const contents = this.constructOpContents(ops, headCounter, pkh);
 

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -1043,14 +1043,15 @@ export class PrepareProvider extends Provider implements PreparationProvider {
       DEFAULT_PARAMS
     );
 
-    const op = await createTransferOperation({
+    const op = {
+      kind: OpKind.TRANSACTION,
       fee: params.fee ?? estimateLimits.fee,
-      gasLimit: params.gasLimit ?? estimateLimits.gasLimit,
-      storageLimit: params.storageLimit ?? estimateLimits.storageLimit,
-      amount: params.amount,
-      to: params.to,
-      parameter: params.parameter,
-    });
+      gas_limit: params.gasLimit ?? estimateLimits.gasLimit,
+      storage_limit: params.storageLimit ?? estimateLimits.storageLimit,
+      amount: String(params.amount),
+      destination: params.to,
+      parameters: params.parameter,
+    } as RPCOperation;
 
     const operation = await this.addRevealOperationIfNeeded(op, pkh);
     const ops = this.convertIntoArray(operation);


### PR DESCRIPTION
closes #2500 

Fixes contract call estimation behaviour to check for revealed keys

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
