### PR TITLE
hex2buf now returns an error in case of an odd number of characters

### DIFF
--- a/packages/taquito-signer/test/taquito-signer.spec.ts
+++ b/packages/taquito-signer/test/taquito-signer.spec.ts
@@ -98,8 +98,8 @@ describe('inmemory-signer', () => {
       'edskS3DtVSbWbPD1yviMGebjYwWJtruMjDcfAZsH9uba22EzKeYhmQkkraFosFETmEMfFNVcDYQ5QbFerj9ozDKroXZ6mb5oxV'
     );
 
-    expect((await signer.sign('123', new Uint8Array([3]))).sig).toEqual(
-      'signvMhyzCmfN6JCYnqbtLCHdReCqwQM9viGJm1QPsiTrLGhrMi1eEmAsoXVjfNB1cJwnP9rj6i3cVCZeucqkPcsDuKmT9me'
+    expect((await signer.sign('1234', new Uint8Array([3]))).sig).toEqual(
+      'sigeeho3jK4MZKsyqcTc9mjhtz9w6enG3AFniufgUXCuXFW7VjShxLoNmxqkQSRYUwP1LHRMere5LrvxcqLgU9KmDGN356Yz'
     );
     done();
   });

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -197,7 +197,7 @@ export function encodeKeyHash(value: string) {
  * @throws {@link ValueConversionError}
  */
 export const hex2buf = (hex: string): Uint8Array => {
-  if ((hex.length & 1) !== 0) {
+  if ((hex.length % 2) !== 0) {
     // odd length
     throw new ValueConversionError(hex, 'Uint8Array');
   }

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -197,12 +197,20 @@ export function encodeKeyHash(value: string) {
  * @throws {@link ValueConversionError}
  */
 export const hex2buf = (hex: string): Uint8Array => {
-  const match = hex.match(/[\da-f]{2}/gi);
-  if (match) {
-    return new Uint8Array(match.map((h) => parseInt(h, 16)));
-  } else {
+  if ((hex.length & 1) !== 0) {
+    // odd length
     throw new ValueConversionError(hex, 'Uint8Array');
   }
+  const out = new Uint8Array(hex.length / 2);
+  let j = 0;
+  for (let i = 0; i < hex.length; i += 2) {
+    const v = parseInt(hex.slice(i, i + 2), 16);
+    if (Number.isNaN(v)) {
+      throw new ValueConversionError(hex, 'Uint8Array');
+    }
+    out[j++] = v;
+  }
+  return out;
 };
 
 /**

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -197,9 +197,11 @@ export function encodeKeyHash(value: string) {
  * @throws {@link ValueConversionError}
  */
 export const hex2buf = (hex: string): Uint8Array => {
-  if ((hex.length % 2) !== 0) {
-    // odd length
-    throw new ValueConversionError(hex, 'Uint8Array');
+  if (hex.length % 2 !== 0) {
+    throw new InvalidHexStringError(hex, `: Expecting even number of characters`);
+  }
+  if (!hex.match(/^([\da-f]{2})*$/gi)) {
+    throw new InvalidHexStringError(hex, `: Only characters 0-9, a-f and A-F are expected`);
   }
   const out = new Uint8Array(hex.length / 2);
   let j = 0;
@@ -360,7 +362,7 @@ export function bytes2Char(hex: string): string {
  * @param hex String value to convert to bytes
  */
 export function hex2Bytes(hex: string): Buffer {
-  if (!hex.match(/[\da-f]{2}/gi)) {
+  if (!hex.match(/^([\da-f]{2})*$/gi)) {
     throw new InvalidHexStringError(hex, `: Expecting even number of characters`);
   }
   return Buffer.from(hex, 'hex');

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -206,12 +206,11 @@ export const hex2buf = (hex: string): Uint8Array => {
   const out = new Uint8Array(hex.length / 2);
   let j = 0;
   for (let i = 0; i < hex.length; i += 2) {
-    const hi = parseInt(hex[i], 16);
-    const lo = parseInt(hex[i + 1], 16);
-    if (Number.isNaN(hi) || Number.isNaN(lo)) {
+    const v = parseInt(hex.slice(i, i + 2), 16);
+    if (Number.isNaN(v)) {
       throw new ValueConversionError(hex, 'Uint8Array');
     }
-    out[j++] = (hi << 4) | lo;
+    out[j++] = v;
   }
   return out;
 };

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -200,10 +200,14 @@ export const hex2buf = (hex: string): Uint8Array => {
   if (hex.length % 2 !== 0) {
     throw new InvalidHexStringError(hex, `: Expecting even number of characters`);
   }
-  if (!hex.match(/^([\da-f]{2})*$/gi)) {
-    throw new InvalidHexStringError(hex, `: Only characters 0-9, a-f and A-F are expected`);
+  const hexDigits = stripHexPrefix(hex);
+  if (!hexDigits.match(/^([\da-f]{2})*$/gi)) {
+    throw new InvalidHexStringError(
+      hex,
+      `: Only characters 0-9, a-f and A-F are expected. Optionally, it can be prefixed with '0x'`
+    );
   }
-  const out = new Uint8Array(hex.length / 2);
+  const out = new Uint8Array(hexDigits.length / 2);
   let j = 0;
   for (let i = 0; i < hex.length; i += 2) {
     const v = parseInt(hex.slice(i, i + 2), 16);
@@ -361,10 +365,14 @@ export function bytes2Char(hex: string): string {
  * @param hex String value to convert to bytes
  */
 export function hex2Bytes(hex: string): Buffer {
-  if (!hex.match(/^([\da-f]{2})*$/gi)) {
-    throw new InvalidHexStringError(hex, `: Expecting even number of characters`);
+  const hexDigits = stripHexPrefix(hex);
+  if (!hexDigits.match(/^(0x)?([\da-f]{2})*$/gi)) {
+    throw new InvalidHexStringError(
+      hex,
+      `: Expecting even number of characters: 0-9, a-z, A-Z, optionally prefixed with 0x`
+    );
   }
-  return Buffer.from(hex, 'hex');
+  return Buffer.from(hexDigits, 'hex');
 }
 
 /**

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -209,8 +209,8 @@ export const hex2buf = (hex: string): Uint8Array => {
   }
   const out = new Uint8Array(hexDigits.length / 2);
   let j = 0;
-  for (let i = 0; i < hex.length; i += 2) {
-    const v = parseInt(hex.slice(i, i + 2), 16);
+  for (let i = 0; i < hexDigits.length; i += 2) {
+    const v = parseInt(hexDigits.slice(i, i + 2), 16);
     if (Number.isNaN(v)) {
       throw new ValueConversionError(hex, 'Uint8Array');
     }

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -204,11 +204,12 @@ export const hex2buf = (hex: string): Uint8Array => {
   const out = new Uint8Array(hex.length / 2);
   let j = 0;
   for (let i = 0; i < hex.length; i += 2) {
-    const v = parseInt(hex.slice(i, i + 2), 16);
-    if (Number.isNaN(v)) {
+    const hi = parseInt(hex[i], 16);
+    const lo = parseInt(hex[i + 1], 16);
+    if (Number.isNaN(hi) || Number.isNaN(lo)) {
       throw new ValueConversionError(hex, 'Uint8Array');
     }
-    out[j++] = v;
+    out[j++] = (hi << 4) | lo;
   }
   return out;
 };

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -15,6 +15,7 @@ import {
   hex2Bytes,
   b58decodeL2Address,
   encodeL2Address,
+  hex2buf,
 } from '../src/taquito-utils';
 import BigNumber from 'bignumber.js';
 
@@ -257,6 +258,21 @@ describe('Hex conversions', () => {
 
   it('Should throw an exception because of invalid character', () => {
     expect(() => hex2Bytes('abcq')).toThrow();
+  });
+
+  it('Should be able to convert hex to buffer', () => {
+    const result: Uint8Array = hex2buf('412D74657374');
+
+    expect(result).toBeDefined();
+    expect(result).toEqual(Uint8Array.from([65, 45, 116, 101, 115, 116]));
+  });
+
+  it('Should throw an exception because of an odd number of characters (hex2buf)', () => {
+    expect(() => hex2buf('abcda')).toThrow();
+  });
+
+  it('Should throw an exception because of invalid character (hex2buf)', () => {
+    expect(() => hex2buf('abcq')).toThrow();
   });
 
   it('should be able to get phk from tz4 Public key', () => {

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -252,6 +252,13 @@ describe('Hex conversions', () => {
     expect(result).toEqual(Buffer.from('abcd', 'hex'));
   });
 
+  it('Should be able to convert hex with 0x prefix to bytes', () => {
+    const result: Buffer = hex2Bytes('0xabcd');
+
+    expect(result).toBeDefined();
+    expect(result).toEqual(Buffer.from('abcd', 'hex'));
+  });
+
   it('Should throw an exception because of an odd number of characters', () => {
     expect(() => hex2Bytes('abcda')).toThrow();
   });
@@ -262,6 +269,13 @@ describe('Hex conversions', () => {
 
   it('Should be able to convert hex to buffer', () => {
     const result: Uint8Array = hex2buf('412D74657374');
+
+    expect(result).toBeDefined();
+    expect(result).toEqual(Uint8Array.from([65, 45, 116, 101, 115, 116]));
+  });
+
+  it('Should be able to convert hex with 0x prefix to buffer', () => {
+    const result: Uint8Array = hex2buf('0x412D74657374');
 
     expect(result).toBeDefined();
     expect(result).toEqual(Uint8Array.from([65, 45, 116, 101, 115, 116]));

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -251,6 +251,14 @@ describe('Hex conversions', () => {
     expect(result).toEqual(Buffer.from('abcd', 'hex'));
   });
 
+  it('Should throw an exception because of an odd number of characters', () => {
+    expect(() => hex2Bytes('abcda')).toThrow();
+  });
+
+  it('Should throw an exception because of invalid character', () => {
+    expect(() => hex2Bytes('abcq')).toThrow();
+  });
+
   it('should be able to get phk from tz4 Public key', () => {
     const publicKey =
       'BLpk1w1wkESXN91Ry39ZMRAhaaHJsDaMZ8wBax5QsKPEKPWTjDBk6dgKMDkoejxxPWJf52cm2osh';


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
