### PR TITLE
fix: fixed idx calculation in pairs with mix of annotated and unanntated children

### DIFF
--- a/packages/taquito-michelson-encoder/src/tokens/pair.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/pair.ts
@@ -169,11 +169,11 @@ export class PairToken extends ComparableToken {
     const leftToken = this.createToken(args[0], this.idx);
     let keyCount = 1;
     let leftValue;
-    if (leftToken instanceof PairToken) {
-      keyCount = Object.keys(leftToken.ExtractSchema()).length;
-    }
     if (leftToken instanceof PairToken && !leftToken.hasAnnotations()) {
       leftValue = getLeftValue(leftToken);
+      if (leftToken instanceof PairToken) {
+        keyCount = Object.keys(leftToken.ExtractSchema()).length;
+      }
     } else {
       leftValue = { [leftToken.annot()]: getLeftValue(leftToken) };
     }

--- a/packages/taquito-michelson-encoder/test/tokens/constant.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/constant.spec.ts
@@ -79,7 +79,7 @@ describe('Global constant token', () => {
       } catch (e: any) {
         expect(e).toBeInstanceOf(GlobalConstantDecodingError);
         expect(e.message).toEqual(
-          `[2] Unable to decode a value represented by a global constants. Please provide an expanded script to the Michelson-Encoder or semantics for the decoding. The following global constant hash was encountered: expru5X5fvCer8tbRkSAtwyVCs9FUCq46JQG7QCAkhZSumjbZBUGzb.`
+          `[1] Unable to decode a value represented by a global constants. Please provide an expanded script to the Michelson-Encoder or semantics for the decoding. The following global constant hash was encountered: expru5X5fvCer8tbRkSAtwyVCs9FUCq46JQG7QCAkhZSumjbZBUGzb.`
         );
       }
     });

--- a/packages/taquito-michelson-encoder/test/tokens/pair.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/pair.spec.ts
@@ -1,5 +1,7 @@
+import { Schema } from '../../src/taquito-michelson-encoder';
 import { createToken } from '../../src/tokens/createToken';
 import { PairToken } from '../../src/tokens/pair';
+import BigNumber from 'bignumber.js';
 
 describe('Pair token', () => {
   const token = createToken(
@@ -162,7 +164,7 @@ describe('Complexe pair token', () => {
         optional: {
           __michelsonType: 'pair',
           schema: {
-            '3': {
+            '2': {
               __michelsonType: 'or',
               schema: {
                 int: {
@@ -175,7 +177,7 @@ describe('Complexe pair token', () => {
                 },
               },
             },
-            '4': {
+            '3': {
               __michelsonType: 'or',
               schema: {
                 int: {
@@ -310,5 +312,47 @@ describe('Complexe pair token', () => {
         },
       ],
     });
+  });
+});
+
+describe('PairToken mixed with and without annotations', () => {
+  const schema = {
+    prim: 'pair',
+    args: [
+      {
+        prim: 'pair',
+        args: [
+          {
+            prim: 'pair',
+            args: [{ prim: 'int' }, { prim: 'int' }],
+            annots: ['%A3'],
+          },
+          { prim: 'int' },
+        ],
+      },
+      { prim: 'bool' },
+    ],
+  };
+
+  const michelineJson = {
+    prim: 'Pair',
+    args: [
+      {
+        prim: 'Pair',
+        args: [{ prim: 'Pair', args: [{ int: '11' }, { int: '22' }] }, { int: '33' }],
+      },
+      { prim: 'True' },
+    ],
+  };
+
+  const javaScriptObject = new Schema(schema).Execute(michelineJson);
+
+  expect(javaScriptObject).toEqual({
+    1: new BigNumber(33),
+    2: true,
+    A3: {
+      0: new BigNumber(11),
+      1: new BigNumber(22),
+    },
   });
 });


### PR DESCRIPTION
closes #2540 

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
