### PR TITLE
Reduce jest maxWorkers to 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
         version: 1.32.2
-    - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=8
+    - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=2
       env:
         # Ternary operator workaround
         TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.event.pull_request.head.repo.fork && format('https://{0}.ecadinfra.com', matrix.testnet) || null }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
         version: 1.32.2
-    - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=2
+    - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=4
       env:
         # Ternary operator workaround
         TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.event.pull_request.head.repo.fork && format('https://{0}.ecadinfra.com', matrix.testnet) || null }}


### PR DESCRIPTION
Ref #1690  

Reducing Jest maxWorkers to 4 decreases the chance to hit the ConnectionTimeout errors when running integration tests
