### PR TITLE
chore: remove tests from build-docs: improves speed, avoid failure in…

### DIFF
--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,5 +1,5 @@
 {
-  "exclude": ["website", "integration-tests", "apps"],
+  "exclude": ["website", "integration-tests", "apps", "**/test/**", "**/*.spec.ts"],
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es6",


### PR DESCRIPTION
Before this change:

If test code has build errors, `npm run build` would succeed (because it correctly excludes tests from build), but `npm run build-docs` fail, because it does not exclude test files. While it's good to know that a test file has build error, it is not related to building docs.

Also, building test files when building docs slows down the build. In my test, about 60% of `npm run build-docs` time can be avoided if we exclude test files.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
