### PR TITLE
replace JSON.stringify with a safe stringify (#2690)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6309,6 +6309,12 @@
       "integrity": "sha512-fSRMt/jgdsBMPHoJ0GxivTdmo2HhBhubqLssKIsu9NgtvCZJ0haHjo24tfU/0nrkYZKbyTLw5GoTxWg8ExzIsw==",
       "dev": true
     },
+    "node_modules/@types/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-fSRMt/jgdsBMPHoJ0GxivTdmo2HhBhubqLssKIsu9NgtvCZJ0haHjo24tfU/0nrkYZKbyTLw5GoTxWg8ExzIsw==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -33567,6 +33573,12 @@
       "version": "7.0.13",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
       "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+      "dev": true
+    },
+    "@types/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-fSRMt/jgdsBMPHoJ0GxivTdmo2HhBhubqLssKIsu9NgtvCZJ0haHjo24tfU/0nrkYZKbyTLw5GoTxWg8ExzIsw==",
       "dev": true
     },
     "@types/json-stringify-safe": {


### PR DESCRIPTION
* fix: replace JSON.stringify with a safe stringify

* chore: rollback safe stringify in doc files

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
