### PR TITLE
Add more info to operation estimation errors in batches

### DIFF
--- a/packages/taquito/src/contract/lambda-view.ts
+++ b/packages/taquito/src/contract/lambda-view.ts
@@ -25,10 +25,7 @@ export default class LambdaView {
       await this.lambdaContract.methods.default(this.voidLambda).send();
     } catch (ex) {
       if (ex instanceof TezosOperationError) {
-        const lastError: any = ex.errors[ex.errors.length - 1];
-
-        const failedWith = lastError.with;
-        return failedWith;
+        return (ex.lastError as any).with;
       } else {
         throw ex;
       }

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -107,7 +107,11 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
 
     // Fail early in case of errors
     if (errors.length) {
-      throw new TezosOperationError(errors, 'Error occurred during estimation');
+      throw new TezosOperationError(
+        errors,
+        'Error occurred during estimation',
+        opResponse.contents
+      );
     }
 
     let numberOfOps = 1;

--- a/packages/taquito/src/operations/errors.ts
+++ b/packages/taquito/src/operations/errors.ts
@@ -1,6 +1,7 @@
 import { ParameterValidationError, RpcError, TaquitoError } from '@taquito/core';
 import {
   MichelsonV1ExpressionBase,
+  OperationContentsAndResult,
   OperationResult,
   OperationResultDelegation,
   OperationResultOrigination,
@@ -33,31 +34,36 @@ const isErrorWithMessage = (error: any): error is TezosOperationErrorWithMessage
  *  @description Generic tezos error that will be thrown when a mistake occurs when doing an operation; more details here https://tezos.gitlab.io/api/errors.html
  */
 export class TezosOperationError extends RpcError {
-  id: string;
-  kind: string;
+  public readonly lastError: TezosGenericOperationError;
 
   constructor(
     public readonly errors: TezosGenericOperationError[],
-    public readonly errorDetails?: string
+    public readonly errorDetails: string,
+    public readonly operationsWithResults: OperationContentsAndResult[]
   ) {
     super();
     this.name = 'TezosOperationError';
     // Last error is 'often' the one with more detail
-    const lastError = errors[errors.length - 1];
-    this.id = lastError.id;
-    this.kind = lastError.kind;
+    this.lastError = errors[errors.length - 1];
 
     this.message = `(${this.kind}) ${this.id}`;
 
-    if (isErrorWithMessage(lastError)) {
-      if (lastError.with.string) {
-        this.message = lastError.with.string;
-      } else if (lastError.with.int) {
-        this.message = lastError.with.int;
+    if (isErrorWithMessage(this.lastError)) {
+      if (this.lastError.with.string) {
+        this.message = this.lastError.with.string;
+      } else if (this.lastError.with.int) {
+        this.message = this.lastError.with.int;
       } else {
-        this.message = JSON.stringify(lastError.with);
+        this.message = JSON.stringify(this.lastError.with);
       }
     }
+  }
+
+  get id(): string {
+    return this.lastError.id;
+  }
+  get kind(): string {
+    return this.lastError.kind;
   }
 }
 

--- a/packages/taquito/src/provider.ts
+++ b/packages/taquito/src/provider.ts
@@ -187,7 +187,8 @@ export abstract class Provider {
     if (errors.length) {
       throw new TezosOperationError(
         errors,
-        'Error occurred during validation simulation of operation'
+        'Error occurred during validation simulation of operation',
+        opResponse
       );
     }
 


### PR DESCRIPTION
It allows to find the faulty operation
Otherwise, it's just random guessing why it failed

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
