### PR TITLE
removed sapling deps and live code examples

### DIFF
--- a/docs/sapling.md
+++ b/docs/sapling.md
@@ -76,7 +76,7 @@ Note that the balance is represented in mutez.
 
 The balance can be retrieved as follows:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -109,7 +109,7 @@ The `SaplingTransactionViewer` class exposes a method called `getIncomingAndOutg
 
 Example:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -150,7 +150,7 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -222,7 +222,7 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -280,7 +280,7 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';

--- a/docs/sapling_in_memory_viewing_key.md
+++ b/docs/sapling_in_memory_viewing_key.md
@@ -16,7 +16,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js live noInline
+```js
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -31,7 +31,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 ### Instantiation from an encrypted spending key:
 
-```js live noInline
+```js
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -49,7 +49,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js live noInline 
+```js
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@taquito/website",
-  "version": "17.5.2",
+  "version": "19.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@taquito/website",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "dependencies": {
         "@docusaurus/core": "2.4.3",
         "@docusaurus/plugin-google-gtag": "2.4.3",
@@ -28,7 +28,6 @@
         "@taquito/michelson-encoder": "file:../packages/taquito-michelson-encoder",
         "@taquito/remote-signer": "file:../packages/taquito-remote-signer",
         "@taquito/rpc": "file:../packages/taquito-rpc",
-        "@taquito/sapling": "file:../packages/taquito-sapling",
         "@taquito/signer": "file:../packages/taquito-signer",
         "@taquito/taquito": "file:../packages/taquito",
         "@taquito/tzip12": "file:../packages/taquito-tzip12",
@@ -70,17 +69,17 @@
     },
     "../packages/taquito": {
       "name": "@taquito/taquito",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^17.5.2",
-        "@taquito/http-utils": "^17.5.2",
-        "@taquito/local-forging": "^17.5.2",
-        "@taquito/michel-codec": "^17.5.2",
-        "@taquito/michelson-encoder": "^17.5.2",
-        "@taquito/rpc": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/http-utils": "^19.0.0",
+        "@taquito/local-forging": "^19.0.0",
+        "@taquito/michel-codec": "^19.0.0",
+        "@taquito/michelson-encoder": "^19.0.0",
+        "@taquito/rpc": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "bignumber.js": "^9.1.2",
         "rxjs": "^7.8.1"
       },
@@ -128,12 +127,12 @@
     },
     "../packages/taquito-beacon-wallet": {
       "name": "@taquito/beacon-wallet",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@airgap/beacon-dapp": "4.1.0",
-        "@taquito/core": "^17.5.2",
-        "@taquito/taquito": "^17.5.2"
+        "@taquito/core": "^19.0.0",
+        "@taquito/taquito": "^19.0.0"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.40",
@@ -170,7 +169,7 @@
     },
     "../packages/taquito-core": {
       "name": "@taquito/core",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "json-stringify-safe": "^5.0.1"
@@ -186,10 +185,10 @@
     },
     "../packages/taquito-http-utils": {
       "name": "@taquito/http-utils",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^17.5.2",
+        "@taquito/core": "^19.0.0",
         "node-fetch": "^2.7.0"
       },
       "devDependencies": {
@@ -227,14 +226,14 @@
     },
     "../packages/taquito-ledger-signer": {
       "name": "@taquito/ledger-signer",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@ledgerhq/hw-transport": "^6.28.8",
         "@stablelib/blake2b": "^1.0.1",
-        "@taquito/core": "^17.5.2",
-        "@taquito/taquito": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/taquito": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "buffer": "^6.0.3"
       },
       "devDependencies": {
@@ -271,10 +270,10 @@
     },
     "../packages/taquito-michel-codec": {
       "name": "@taquito/michel-codec",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "MIT",
       "dependencies": {
-        "@taquito/core": "^17.5.2"
+        "@taquito/core": "^19.0.0"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.40",
@@ -304,12 +303,12 @@
     },
     "../packages/taquito-michelson-encoder": {
       "name": "@taquito/michelson-encoder",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^17.5.2",
-        "@taquito/rpc": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/rpc": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "bignumber.js": "^9.1.2",
         "fast-json-stable-stringify": "^2.1.0"
       },
@@ -346,15 +345,15 @@
     },
     "../packages/taquito-remote-signer": {
       "name": "@taquito/remote-signer",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
-        "@taquito/core": "^17.5.2",
-        "@taquito/http-utils": "^17.5.2",
-        "@taquito/taquito": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/http-utils": "^19.0.0",
+        "@taquito/taquito": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "typedarray-to-buffer": "^4.0.0"
       },
       "devDependencies": {
@@ -391,12 +390,12 @@
     },
     "../packages/taquito-rpc": {
       "name": "@taquito/rpc",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^17.5.2",
-        "@taquito/http-utils": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/http-utils": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "bignumber.js": "^9.1.2"
       },
       "devDependencies": {
@@ -430,60 +429,9 @@
         "node": ">=18"
       }
     },
-    "../packages/taquito-sapling": {
-      "name": "@taquito/sapling",
-      "version": "17.5.2",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@airgap/sapling-wasm": "0.0.9",
-        "@stablelib/nacl": "^1.0.4",
-        "@stablelib/random": "^1.0.2",
-        "@taquito/core": "^17.5.2",
-        "@taquito/rpc": "^17.5.2",
-        "@taquito/taquito": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
-        "bignumber.js": "^9.1.2",
-        "bip39": "3.1.0",
-        "blakejs": "^1.2.1",
-        "node-fetch": "^2.7.0",
-        "pbkdf2": "^3.1.2",
-        "typedarray-to-buffer": "^4.0.0"
-      },
-      "devDependencies": {
-        "@rollup/plugin-json": "^6.0.1",
-        "@types/jest": "^29.5.5",
-        "@types/node": "^20",
-        "@types/pbkdf2": "^3.1.0",
-        "@types/typedarray-to-buffer": "^4.0.0",
-        "@typescript-eslint/eslint-plugin": "^6.8.0",
-        "@typescript-eslint/parser": "^6.8.0",
-        "colors": "^1.4.0",
-        "coveralls": "^3.1.1",
-        "cross-env": "^7.0.3",
-        "eslint": "^8.51.0",
-        "jest": "^29.7.0",
-        "jest-config": "^29.7.0",
-        "lint-staged": "^14.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "prettier": "^3.0.3",
-        "prompt": "^1.3.0",
-        "replace-in-file": "^7.0.1",
-        "rimraf": "^5.0.5",
-        "rollup": "^4.1.4",
-        "rollup-plugin-typescript2": "^0.36.0",
-        "shelljs": "^0.8.5",
-        "ts-jest": "^29.1.1",
-        "ts-node": "^10.9.1",
-        "typescript": "~5.2.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "../packages/taquito-signer": {
       "name": "@taquito/signer",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/blake2b": "^1.0.1",
@@ -492,9 +440,9 @@
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/pbkdf2": "^1.0.1",
         "@stablelib/sha512": "^1.0.1",
-        "@taquito/core": "^17.5.2",
-        "@taquito/taquito": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/taquito": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "@types/bn.js": "^5.1.2",
         "bip39": "3.1.0",
         "elliptic": "^6.5.4",
@@ -537,13 +485,13 @@
     },
     "../packages/taquito-tzip12": {
       "name": "@taquito/tzip12",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^17.5.2",
-        "@taquito/michelson-encoder": "^17.5.2",
-        "@taquito/taquito": "^17.5.2",
-        "@taquito/tzip16": "^17.5.2"
+        "@taquito/core": "^19.0.0",
+        "@taquito/michelson-encoder": "^19.0.0",
+        "@taquito/taquito": "^19.0.0",
+        "@taquito/tzip16": "^19.0.0"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.40",
@@ -579,15 +527,15 @@
     },
     "../packages/taquito-tzip16": {
       "name": "@taquito/tzip16",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@taquito/core": "^17.5.2",
-        "@taquito/http-utils": "^17.5.2",
-        "@taquito/michelson-encoder": "^17.5.2",
-        "@taquito/rpc": "^17.5.2",
-        "@taquito/taquito": "^17.5.2",
-        "@taquito/utils": "^17.5.2",
+        "@taquito/core": "^19.0.0",
+        "@taquito/http-utils": "^19.0.0",
+        "@taquito/michelson-encoder": "^19.0.0",
+        "@taquito/rpc": "^19.0.0",
+        "@taquito/taquito": "^19.0.0",
+        "@taquito/utils": "^19.0.0",
         "bignumber.js": "^9.1.2",
         "crypto-js": "^4.2.0"
       },
@@ -626,12 +574,12 @@
     },
     "../packages/taquito-utils": {
       "name": "@taquito/utils",
-      "version": "17.5.2",
+      "version": "19.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
-        "@taquito/core": "^17.5.2",
+        "@taquito/core": "^19.0.0",
         "@types/bs58check": "^2.1.0",
         "bignumber.js": "^9.1.2",
         "blakejs": "^1.2.1",
@@ -6640,10 +6588,6 @@
     },
     "node_modules/@taquito/rpc": {
       "resolved": "../packages/taquito-rpc",
-      "link": true
-    },
-    "node_modules/@taquito/sapling": {
-      "resolved": "../packages/taquito-sapling",
       "link": true
     },
     "node_modules/@taquito/signer": {

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,6 @@
     "@taquito/michelson-encoder": "file:../packages/taquito-michelson-encoder",
     "@taquito/remote-signer": "file:../packages/taquito-remote-signer",
     "@taquito/rpc": "file:../packages/taquito-rpc",
-    "@taquito/sapling": "file:../packages/taquito-sapling",
     "@taquito/signer": "file:../packages/taquito-signer",
     "@taquito/taquito": "file:../packages/taquito",
     "@taquito/tzip12": "file:../packages/taquito-tzip12",
@@ -88,5 +87,5 @@
       "last 1 safari version"
     ]
   },
-  "version": "19.0.0-beta-RC.0"
+  "version": "19.0.0"
 }

--- a/website/src/theme/CodeBlock/index.js
+++ b/website/src/theme/CodeBlock/index.js
@@ -82,7 +82,6 @@ export default ({
       const { Schema, ParameterSchema } = await import("@taquito/michelson-encoder");
       const { Parser, packDataBytes } = await import('@taquito/michel-codec');
       const { RpcClient } = await import('@taquito/rpc');
-      const { SaplingToolkit, InMemorySpendingKey, InMemoryViewingKey } = await import('@taquito/sapling');
       const TransportWebHID = (await import("@ledgerhq/hw-transport-webhid")).default;
 
       let wallet;
@@ -127,10 +126,7 @@ export default ({
         Parser,
         packDataBytes,
         RpcReadAdapter,
-        SaplingToolkit,
         RpcClient,
-        InMemorySpendingKey,
-        InMemoryViewingKey,
         Ed25519,
         ECDSA,
         Path,
@@ -181,7 +177,6 @@ export default ({
           Parser: dependencies?.Parser,
           packDataBytes: dependencies?.packDataBytes,
           RpcReadAdapter: dependencies?.RpcReadAdapter,
-          SaplingToolkit: dependencies?.SaplingToolkit,
           RpcClient: dependencies?.RpcClient,
           InMemorySpendingKey: dependencies?.InMemorySpendingKey,
           InMemoryViewingKey: dependencies?.InMemoryViewingKey,

--- a/website/versioned_docs/version-17.2.0/sapling.md
+++ b/website/versioned_docs/version-17.2.0/sapling.md
@@ -76,7 +76,7 @@ Note that the balance is represented in mutez.
 
 The balance can be retrieved as follows:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -109,7 +109,7 @@ The `SaplingTransactionViewer` class exposes a method called `getIncomingAndOutg
 
 Example:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -150,7 +150,7 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -222,7 +222,7 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -280,7 +280,7 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';

--- a/website/versioned_docs/version-17.2.0/sapling_in_memory_viewing_key.md
+++ b/website/versioned_docs/version-17.2.0/sapling_in_memory_viewing_key.md
@@ -16,7 +16,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -31,7 +31,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 ### Instantiation from an encrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -49,7 +49,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js live noInline 
+```js  
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/website/versioned_docs/version-17.3.0/sapling.md
+++ b/website/versioned_docs/version-17.3.0/sapling.md
@@ -76,7 +76,7 @@ Note that the balance is represented in mutez.
 
 The balance can be retrieved as follows:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -109,7 +109,7 @@ The `SaplingTransactionViewer` class exposes a method called `getIncomingAndOutg
 
 Example:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -150,7 +150,7 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -222,7 +222,7 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -280,7 +280,7 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';

--- a/website/versioned_docs/version-17.3.0/sapling_in_memory_viewing_key.md
+++ b/website/versioned_docs/version-17.3.0/sapling_in_memory_viewing_key.md
@@ -16,7 +16,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -31,7 +31,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 ### Instantiation from an encrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -49,7 +49,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js live noInline 
+```js  
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/website/versioned_docs/version-17.4.0/sapling.md
+++ b/website/versioned_docs/version-17.4.0/sapling.md
@@ -76,7 +76,7 @@ Note that the balance is represented in mutez.
 
 The balance can be retrieved as follows:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -109,7 +109,7 @@ The `SaplingTransactionViewer` class exposes a method called `getIncomingAndOutg
 
 Example:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -150,7 +150,7 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -222,7 +222,7 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -280,7 +280,7 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';

--- a/website/versioned_docs/version-17.4.0/sapling_in_memory_viewing_key.md
+++ b/website/versioned_docs/version-17.4.0/sapling_in_memory_viewing_key.md
@@ -16,7 +16,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -31,7 +31,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 ### Instantiation from an encrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -49,7 +49,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js live noInline 
+```js  
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/website/versioned_docs/version-17.5.0/sapling.md
+++ b/website/versioned_docs/version-17.5.0/sapling.md
@@ -76,7 +76,7 @@ Note that the balance is represented in mutez.
 
 The balance can be retrieved as follows:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -109,7 +109,7 @@ The `SaplingTransactionViewer` class exposes a method called `getIncomingAndOutg
 
 Example:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -150,7 +150,7 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -222,7 +222,7 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -280,7 +280,7 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';

--- a/website/versioned_docs/version-17.5.0/sapling_in_memory_viewing_key.md
+++ b/website/versioned_docs/version-17.5.0/sapling_in_memory_viewing_key.md
@@ -16,7 +16,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -31,7 +31,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 ### Instantiation from an encrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -49,7 +49,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js live noInline 
+```js  
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 const inMemoryViewingKey = new InMemoryViewingKey(

--- a/website/versioned_docs/version-19.0.0/sapling.md
+++ b/website/versioned_docs/version-19.0.0/sapling.md
@@ -76,7 +76,7 @@ Note that the balance is represented in mutez.
 
 The balance can be retrieved as follows:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -109,7 +109,7 @@ The `SaplingTransactionViewer` class exposes a method called `getIncomingAndOutg
 
 Example:
 
-```js live noInline
+```js 
 import { RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
@@ -150,7 +150,7 @@ The `prepareShieldedTransaction` method returns the crafted Sapling transaction 
 
 Here is an example of how to prepare and inject a shielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -222,7 +222,7 @@ A user should not use their own implicit account (tz1, tz2, tz3) to submit a Sap
 
 Here is an example of how to prepare and inject a Sapling transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';
@@ -280,7 +280,7 @@ The `prepareUnshieldedTransaction` method returns the crafted Sapling transactio
 
 Here is an example of how to prepare and inject an unshielded transaction using Taquito:
 
-```js live noInline
+```js 
 // import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 // import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 // import { RpcClient } from '@taquito/rpc';

--- a/website/versioned_docs/version-19.0.0/sapling_in_memory_viewing_key.md
+++ b/website/versioned_docs/version-19.0.0/sapling_in_memory_viewing_key.md
@@ -16,7 +16,7 @@ const inMemoryViewingKey = new InMemoryViewingKey(
 
 ### Instantiation from an unencrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -31,7 +31,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 ### Instantiation from an encrypted spending key:
 
-```js live noInline
+```js 
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 InMemoryViewingKey.fromSpendingKey(
@@ -49,7 +49,7 @@ InMemoryViewingKey.fromSpendingKey(
 
 The `InMemoryViewingKey` class has a method named `getAddress`, allowing to derive addresses (zet) from the viewing key. An index can be specified as a parameter, or the default value `0` will be used.
 
-```js live noInline 
+```js  
 import { InMemoryViewingKey } from '@taquito/sapling';
 
 const inMemoryViewingKey = new InMemoryViewingKey(


### PR DESCRIPTION
Live code examples for Sapling were importing a file from its dependencies that has a 69MB file. This prevents the website from being deployed to Cloudflare due to the file size limit. It also potentially reduces performance of the website. 

This PR disables live code examples for Sapling. The static code examples will still be kept.

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [x] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
