### PR TITLE
made improvements to several methods in taquito-utils

### DIFF
--- a/apps/taquito-test-dapp/src/tests.ts
+++ b/apps/taquito-test-dapp/src/tests.ts
@@ -7,7 +7,7 @@ import {
 } from "@taquito/taquito";
 import type { ContractProvider } from "@taquito/taquito";
 import type { BeaconWallet } from "@taquito/beacon-wallet";
-import { byteStringToHexString, verifySignature } from "@taquito/utils";
+import { stringToBytes, verifySignature } from "@taquito/utils";
 import { SigningType, type RequestSignPayloadInput } from "@airgap/beacon-sdk";
 import { get } from "svelte/store";
 import type { TestSettings, TestResult } from "./types";
@@ -23,10 +23,10 @@ const preparePayloadToSign = (
   formattedInput: string;
 } => {
   const formattedInput = `Tezos Signed Message: taquito-test-dapp.netlify.app/ ${new Date().toISOString()} ${input}`;
-  const bytes = byteStringToHexString(formattedInput);
+  const bytes = stringToBytes(formattedInput);
   const payload: RequestSignPayloadInput = {
     signingType: SigningType.MICHELINE,
-    payload: "05" + "0100" + byteStringToHexString(bytes.length.toString()) + bytes,
+    payload: "05" + "0100" + stringToBytes(bytes.length.toString()) + bytes,
     sourceAddress: userAddress
   };
   return {
@@ -319,7 +319,7 @@ const signFailingNoop = async (
   input: string,
   tezos: TezosToolkit,
 ): Promise<TestResult> => {
-  const bytes = byteStringToHexString(input);
+  const bytes = stringToBytes(input);
   try {
     const signedPayload = await tezos.wallet.signFailingNoop({
       arbitrary: bytes,

--- a/apps/taquito-test-dapp/src/tests.ts
+++ b/apps/taquito-test-dapp/src/tests.ts
@@ -7,7 +7,7 @@ import {
 } from "@taquito/taquito";
 import type { ContractProvider } from "@taquito/taquito";
 import type { BeaconWallet } from "@taquito/beacon-wallet";
-import { char2Bytes, verifySignature } from "@taquito/utils";
+import { byteStringToHexString, verifySignature } from "@taquito/utils";
 import { SigningType, type RequestSignPayloadInput } from "@airgap/beacon-sdk";
 import { get } from "svelte/store";
 import type { TestSettings, TestResult } from "./types";
@@ -23,10 +23,10 @@ const preparePayloadToSign = (
   formattedInput: string;
 } => {
   const formattedInput = `Tezos Signed Message: taquito-test-dapp.netlify.app/ ${new Date().toISOString()} ${input}`;
-  const bytes = char2Bytes(formattedInput);
+  const bytes = byteStringToHexString(formattedInput);
   const payload: RequestSignPayloadInput = {
     signingType: SigningType.MICHELINE,
-    payload: "05" + "0100" + char2Bytes(bytes.length.toString()) + bytes,
+    payload: "05" + "0100" + byteStringToHexString(bytes.length.toString()) + bytes,
     sourceAddress: userAddress
   };
   return {
@@ -319,7 +319,7 @@ const signFailingNoop = async (
   input: string,
   tezos: TezosToolkit,
 ): Promise<TestResult> => {
-  const bytes = char2Bytes(input);
+  const bytes = byteStringToHexString(input);
   try {
     const signedPayload = await tezos.wallet.signFailingNoop({
       arbitrary: bytes,

--- a/docs/contract-test-collection.md
+++ b/docs/contract-test-collection.md
@@ -956,7 +956,7 @@ ledger.set(
 );
 
 const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-const bytesUrl = char2Bytes(url);
+const bytesUrl = byteStringToHexString(url);
 const metadata = new MichelsonMap();
 metadata.set('', bytesUrl);
 
@@ -964,15 +964,15 @@ const operators = new MichelsonMap();
 
 const tokens = new MichelsonMap();
 const metadataMap0 = new MichelsonMap();
-metadataMap0.set('', char2Bytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-metadataMap0.set('name', char2Bytes('Name from URI is prioritized!'));
+metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
 const metadataMap1 = new MichelsonMap();
-metadataMap1.set('name', char2Bytes('AliceToken'));
-metadataMap1.set('symbol', char2Bytes('ALC'));
+metadataMap1.set('name', byteStringToHexString('AliceToken'));
+metadataMap1.set('symbol', byteStringToHexString('ALC'));
 metadataMap1.set('decimals', '30');
-metadataMap1.set('extra', char2Bytes('Add more data'));
+metadataMap1.set('extra', byteStringToHexString('Add more data'));
 const metadataMap2 = new MichelsonMap();
-metadataMap2.set('name', char2Bytes('Invalid token metadata'));
+metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
 tokens.set('0', {
   metadata_map: metadataMap0,
   total_supply: '20000',
@@ -1059,8 +1059,8 @@ const metadataJSON = {
 };
 
 const metadataBigMap = new MichelsonMap();
-metadataBigMap.set('', char2Bytes('tezos-storage:here'));
-metadataBigMap.set('here', char2Bytes(JSON.stringify(metadataJSON)));
+metadataBigMap.set('', byteStringToHexString('tezos-storage:here'));
+metadataBigMap.set('here', byteStringToHexString(JSON.stringify(metadataJSON)));
 
 const tacoShopStorageMap = new MichelsonMap();
 
@@ -1115,7 +1115,7 @@ storage (pair (big_map %metadata string bytes)
 
 ```js
 const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-const bytesUrl = char2Bytes(url);
+const bytesUrl = byteStringToHexString(url);
 
 const metadataBigMap = new MichelsonMap();
 metadataBigMap.set('', bytesUrl);
@@ -1177,7 +1177,7 @@ const urlPercentEncoded = encodeURIComponent(
 );
 const metadataSha256 = '0x7e99ecf3a4490e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
 const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-const bytesUrl = char2Bytes(url);
+const bytesUrl = byteStringToHexString(url);
 
 const metadataBigMap = new MichelsonMap();
 metadataBigMap.set('', bytesUrl);
@@ -1235,7 +1235,7 @@ storage (pair (big_map %metadata string bytes)
 
 ```js
 const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-const bytesUrl = char2Bytes(uri);
+const bytesUrl = byteStringToHexString(uri);
 
 const metadataBigMap = new MichelsonMap();
 metadataBigMap.set('', bytesUrl);
@@ -1291,8 +1291,8 @@ storage (pair nat (big_map %metadata string bytes));
 
 ```js
 const metadataBigMAp = new MichelsonMap();
-metadataBigMAp.set('', char2Bytes('tezos-storage:here'));
-metadataBigMAp.set('here', char2Bytes(JSON.stringify(metadataViewsExample1)));
+metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
+metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample1)));
 
 const op = await tezos.contract.originate({
   code: contractCode,
@@ -1340,8 +1340,8 @@ storage (pair nat (big_map %metadata string bytes));
 
 ```js
 const metadataBigMAp = new MichelsonMap();
-metadataBigMAp.set('', char2Bytes('tezos-storage:here'));
-metadataBigMAp.set('here', char2Bytes(JSON.stringify(metadataViewsExample2)));
+metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
+metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample2)));
 
 const op = await tezos.contract.originate({
   code: contractCode,

--- a/docs/contract-test-collection.md
+++ b/docs/contract-test-collection.md
@@ -956,7 +956,7 @@ ledger.set(
 );
 
 const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-const bytesUrl = byteStringToHexString(url);
+const bytesUrl = stringToBytes(url);
 const metadata = new MichelsonMap();
 metadata.set('', bytesUrl);
 
@@ -964,15 +964,15 @@ const operators = new MichelsonMap();
 
 const tokens = new MichelsonMap();
 const metadataMap0 = new MichelsonMap();
-metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
+metadataMap0.set('', stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+metadataMap0.set('name', stringToBytes('Name from URI is prioritized!'));
 const metadataMap1 = new MichelsonMap();
-metadataMap1.set('name', byteStringToHexString('AliceToken'));
-metadataMap1.set('symbol', byteStringToHexString('ALC'));
+metadataMap1.set('name', stringToBytes('AliceToken'));
+metadataMap1.set('symbol', stringToBytes('ALC'));
 metadataMap1.set('decimals', '30');
-metadataMap1.set('extra', byteStringToHexString('Add more data'));
+metadataMap1.set('extra', stringToBytes('Add more data'));
 const metadataMap2 = new MichelsonMap();
-metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
+metadataMap2.set('name', stringToBytes('Invalid token metadata'));
 tokens.set('0', {
   metadata_map: metadataMap0,
   total_supply: '20000',
@@ -1059,8 +1059,8 @@ const metadataJSON = {
 };
 
 const metadataBigMap = new MichelsonMap();
-metadataBigMap.set('', byteStringToHexString('tezos-storage:here'));
-metadataBigMap.set('here', byteStringToHexString(JSON.stringify(metadataJSON)));
+metadataBigMap.set('', stringToBytes('tezos-storage:here'));
+metadataBigMap.set('here', stringToBytes(JSON.stringify(metadataJSON)));
 
 const tacoShopStorageMap = new MichelsonMap();
 
@@ -1115,7 +1115,7 @@ storage (pair (big_map %metadata string bytes)
 
 ```js
 const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-const bytesUrl = byteStringToHexString(url);
+const bytesUrl = stringToBytes(url);
 
 const metadataBigMap = new MichelsonMap();
 metadataBigMap.set('', bytesUrl);
@@ -1177,7 +1177,7 @@ const urlPercentEncoded = encodeURIComponent(
 );
 const metadataSha256 = '0x7e99ecf3a4490e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
 const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-const bytesUrl = byteStringToHexString(url);
+const bytesUrl = stringToBytes(url);
 
 const metadataBigMap = new MichelsonMap();
 metadataBigMap.set('', bytesUrl);
@@ -1235,7 +1235,7 @@ storage (pair (big_map %metadata string bytes)
 
 ```js
 const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-const bytesUrl = byteStringToHexString(uri);
+const bytesUrl = stringToBytes(uri);
 
 const metadataBigMap = new MichelsonMap();
 metadataBigMap.set('', bytesUrl);
@@ -1291,8 +1291,8 @@ storage (pair nat (big_map %metadata string bytes));
 
 ```js
 const metadataBigMAp = new MichelsonMap();
-metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
-metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample1)));
+metadataBigMAp.set('', stringToBytes('tezos-storage:here'));
+metadataBigMAp.set('here', stringToBytes(JSON.stringify(metadataViewsExample1)));
 
 const op = await tezos.contract.originate({
   code: contractCode,
@@ -1340,8 +1340,8 @@ storage (pair nat (big_map %metadata string bytes));
 
 ```js
 const metadataBigMAp = new MichelsonMap();
-metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
-metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample2)));
+metadataBigMAp.set('', stringToBytes('tezos-storage:here'));
+metadataBigMAp.set('here', stringToBytes(JSON.stringify(metadataViewsExample2)));
 
 const op = await tezos.contract.originate({
   code: contractCode,

--- a/docs/metadata-tzip16.md
+++ b/docs/metadata-tzip16.md
@@ -356,7 +356,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, bytes2Char } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -375,7 +375,7 @@ Tezos.contract
   })
   .then((result) => {
     println(`Result of the view someJson: ${result}`);
-    println(`Transform result to char: ${bytes2Char(result)}`);
+    println(`Transform result to char: ${hexStringToByteString(result)}`);
   })
   .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
@@ -385,7 +385,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, bytes2Char } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -404,7 +404,7 @@ Tezos.wallet
   })
   .then((result) => {
     println(`Result of the view someJson: ${result}`);
-    println(`Transform result to char: ${bytes2Char(result)}`);
+    println(`Transform result to char: ${hexStringToByteString(result)}`);
   })
   .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```

--- a/docs/metadata-tzip16.md
+++ b/docs/metadata-tzip16.md
@@ -356,7 +356,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, bytesToString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -375,7 +375,7 @@ Tezos.contract
   })
   .then((result) => {
     println(`Result of the view someJson: ${result}`);
-    println(`Transform result to char: ${hexStringToByteString(result)}`);
+    println(`Transform result to char: ${bytesToString(result)}`);
   })
   .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
@@ -385,7 +385,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, bytesToString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -404,7 +404,7 @@ Tezos.wallet
   })
   .then((result) => {
     println(`Result of the view someJson: ${result}`);
-    println(`Transform result to char: ${hexStringToByteString(result)}`);
+    println(`Transform result to char: ${bytesToString(result)}`);
   })
   .catch((error) => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -48,12 +48,12 @@ const formattedInput: string = [
 ].join(' ');
 ```
 
-After formatting the string properly, you can convert it into bytes, for example, with the `char2Bytes` function of the `@taquito/utils` package:
+After formatting the string properly, you can convert it into bytes, for example, with the `byteStringToHexString` function of the `@taquito/utils` package:
 
 ```js
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 
-const bytes = char2Bytes(formattedInput);
+const bytes = byteStringToHexString(formattedInput);
 const bytesLength = (bytes.length / 2).toString(16);
 const addPadding = `00000000${bytesLength}`;
 const paddedBytesLength = addPadding.slice(addPadding.length - 8);
@@ -90,7 +90,7 @@ The wallet will return an object with a `signature` property that holds our sign
 Here is the full code to sign data with a wallet:
 
 ```ts
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import { RequestSignPayloadInput, SigningType } from '@airgap/beacon-sdk';
 
 // The data to format
@@ -107,7 +107,7 @@ const formattedInput: string = [
 ].join(' ');
 
 // The bytes to sign
-const bytes = char2Bytes(formattedInput);
+const bytes = byteStringToHexString(formattedInput);
 const bytesLength = (bytes.length / 2).toString(16);
 const addPadding = `00000000${bytesLength}`;
 const paddedBytesLength = addPadding.slice(addPadding.length - 8);

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -48,12 +48,12 @@ const formattedInput: string = [
 ].join(' ');
 ```
 
-After formatting the string properly, you can convert it into bytes, for example, with the `byteStringToHexString` function of the `@taquito/utils` package:
+After formatting the string properly, you can convert it into bytes, for example, with the `stringToBytes` function of the `@taquito/utils` package:
 
 ```js
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 
-const bytes = byteStringToHexString(formattedInput);
+const bytes = stringToBytes(formattedInput);
 const bytesLength = (bytes.length / 2).toString(16);
 const addPadding = `00000000${bytesLength}`;
 const paddedBytesLength = addPadding.slice(addPadding.length - 8);
@@ -90,7 +90,7 @@ The wallet will return an object with a `signature` property that holds our sign
 Here is the full code to sign data with a wallet:
 
 ```ts
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import { RequestSignPayloadInput, SigningType } from '@airgap/beacon-sdk';
 
 // The data to format
@@ -107,7 +107,7 @@ const formattedInput: string = [
 ].join(' ');
 
 // The bytes to sign
-const bytes = byteStringToHexString(formattedInput);
+const bytes = stringToBytes(formattedInput);
 const bytesLength = (bytes.length / 2).toString(16);
 const addPadding = `00000000${bytesLength}`;
 const paddedBytesLength = addPadding.slice(addPadding.length - 8);

--- a/docs/tezos_domains.md
+++ b/docs/tezos_domains.md
@@ -16,7 +16,7 @@ If you have an address and you want to find the domain tied to it, the storage o
 
 ```typescript
 import { TezosToolkit } from "@taquito/taquito";
-import { hexStringToByteString } from "@taquito/utils";
+import { bytesToString } from "@taquito/utils";
 
 const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
@@ -27,7 +27,7 @@ const fetchTezosDomainFromAddress = async (address: string): Promise<string> => 
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
     if (domain) {
-      return hexStringToByteString(domain.name);
+      return bytesToString(domain.name);
     } else {
       return address;
     }
@@ -37,7 +37,7 @@ const fetchTezosDomainFromAddress = async (address: string): Promise<string> => 
 
 2 things to remember when you are looking for a Tezos domain in the storage of the contract:
 - the `reverse_records` bigmap is nested inside the `store` property
-- the domain name is stored as bytes, so you can use the `hexStringToByteString` function from `@taquito/utils` to decode it as a string.
+- the domain name is stored as bytes, so you can use the `bytesToString` function from `@taquito/utils` to decode it as a string.
 
 If we call the `fetchTezosDomainFromAddress` function with `tz1aauXT4uM8ZB3ouu5JrAenEMQdqfvDUSNH`, it will return `taquito.tez`.
 
@@ -47,7 +47,7 @@ It is also possible to look up a domain name to find the address it references. 
 
 ```typescript
 import { TezosToolkit } from "@taquito/taquito";
-import { byteStringToHexString } from "@taquito/utils";
+import { stringToBytes } from "@taquito/utils";
 
 const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
@@ -56,7 +56,7 @@ const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> 
     const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
-    const domain = await storage.store.records.get(byteStringToHexString(domainName));
+    const domain = await storage.store.records.get(stringToBytes(domainName));
     if (domain) {
       return domain.address; // address that the domain points to 
       // return domain.owner; // address that owns the domainName
@@ -76,7 +76,7 @@ To find the expiry date, you can check the `expiry_map` bigmap under the `store`
 
 ```typescript
 import { TezosToolkit } from "@taquito/taquito";
-import { byteStringToHexString } from "@taquito/utils";
+import { stringToBytes } from "@taquito/utils";
 
 const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
@@ -85,7 +85,7 @@ const fetchExpiryDate = async (domainName: string): Promise<string> => {
     const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
-    const expiryDate = await storage.store.expiry_map.get(byteStringToHexString(domainName));
+    const expiryDate = await storage.store.expiry_map.get(stringToBytes(domainName));
     if (expiryDate) {
       return expiryDate;
     } else {

--- a/docs/tezos_domains.md
+++ b/docs/tezos_domains.md
@@ -16,7 +16,7 @@ If you have an address and you want to find the domain tied to it, the storage o
 
 ```typescript
 import { TezosToolkit } from "@taquito/taquito";
-import { bytes2Char } from "@taquito/utils";
+import { hexStringToByteString } from "@taquito/utils";
 
 const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
@@ -27,7 +27,7 @@ const fetchTezosDomainFromAddress = async (address: string): Promise<string> => 
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
     if (domain) {
-      return bytes2Char(domain.name);
+      return hexStringToByteString(domain.name);
     } else {
       return address;
     }
@@ -37,7 +37,7 @@ const fetchTezosDomainFromAddress = async (address: string): Promise<string> => 
 
 2 things to remember when you are looking for a Tezos domain in the storage of the contract:
 - the `reverse_records` bigmap is nested inside the `store` property
-- the domain name is stored as bytes, so you can use the `bytes2Char` function from `@taquito/utils` to decode it as a string.
+- the domain name is stored as bytes, so you can use the `hexStringToByteString` function from `@taquito/utils` to decode it as a string.
 
 If we call the `fetchTezosDomainFromAddress` function with `tz1aauXT4uM8ZB3ouu5JrAenEMQdqfvDUSNH`, it will return `taquito.tez`.
 
@@ -47,7 +47,7 @@ It is also possible to look up a domain name to find the address it references. 
 
 ```typescript
 import { TezosToolkit } from "@taquito/taquito";
-import { char2Bytes } from "@taquito/utils";
+import { byteStringToHexString } from "@taquito/utils";
 
 const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
@@ -56,7 +56,7 @@ const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> 
     const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
-    const domain = await storage.store.records.get(char2Bytes(domainName));
+    const domain = await storage.store.records.get(byteStringToHexString(domainName));
     if (domain) {
       return domain.address; // address that the domain points to 
       // return domain.owner; // address that owns the domainName
@@ -76,7 +76,7 @@ To find the expiry date, you can check the `expiry_map` bigmap under the `store`
 
 ```typescript
 import { TezosToolkit } from "@taquito/taquito";
-import { char2Bytes } from "@taquito/utils";
+import { byteStringToHexString } from "@taquito/utils";
 
 const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
@@ -85,7 +85,7 @@ const fetchExpiryDate = async (domainName: string): Promise<string> => {
     const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
-    const expiryDate = await storage.store.expiry_map.get(char2Bytes(domainName));
+    const expiryDate = await storage.store.expiry_map.get(byteStringToHexString(domainName));
     if (expiryDate) {
       return expiryDate;
     } else {

--- a/docs/tzip12.md
+++ b/docs/tzip12.md
@@ -144,7 +144,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, bytes2Char } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -161,10 +161,10 @@ Tezos.contract.at(contractAddress, tzip16)
   return views['token_metadata']().executeView(tokenId)
 }).then (result => {
   println('Result of the view token_metadata:');
-  println(`name: ${bytes2Char((Object.values(result)[1]).get('name'))}`);
-  println(`decimals: ${bytes2Char((Object.values(result)[1]).get('decimals'))}`);
-  println(`symbol: ${bytes2Char((Object.values(result)[1]).get('symbol'))}`);
-  println(`extra: ${bytes2Char((Object.values(result)[1]).get('extra'))}`);
+  println(`name: ${hexStringToByteString((Object.values(result)[1]).get('name'))}`);
+  println(`decimals: ${hexStringToByteString((Object.values(result)[1]).get('decimals'))}`);
+  println(`symbol: ${hexStringToByteString((Object.values(result)[1]).get('symbol'))}`);
+  println(`extra: ${hexStringToByteString((Object.values(result)[1]).get('extra'))}`);
 })
 .catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
@@ -173,7 +173,7 @@ Tezos.contract.at(contractAddress, tzip16)
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, bytes2Char } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -190,10 +190,10 @@ Tezos.wallet.at(contractAddress, tzip16)
   return views['token_metadata']().executeView(tokenId)
 }).then (result => {
   println('Result of the view token_metadata:');
-  println(`name: ${bytes2Char((Object.values(result)[1]).get('name'))}`);
-  println(`decimals: ${bytes2Char((Object.values(result)[1]).get('decimals'))}`);
-  println(`symbol: ${bytes2Char((Object.values(result)[1]).get('symbol'))}`);
-  println(`extra: ${bytes2Char((Object.values(result)[1]).get('extra'))}`);
+  println(`name: ${hexStringToByteString((Object.values(result)[1]).get('name'))}`);
+  println(`decimals: ${hexStringToByteString((Object.values(result)[1]).get('decimals'))}`);
+  println(`symbol: ${hexStringToByteString((Object.values(result)[1]).get('symbol'))}`);
+  println(`extra: ${hexStringToByteString((Object.values(result)[1]).get('extra'))}`);
 })
 .catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```    

--- a/docs/tzip12.md
+++ b/docs/tzip12.md
@@ -144,7 +144,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, bytesToString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -161,10 +161,10 @@ Tezos.contract.at(contractAddress, tzip16)
   return views['token_metadata']().executeView(tokenId)
 }).then (result => {
   println('Result of the view token_metadata:');
-  println(`name: ${hexStringToByteString((Object.values(result)[1]).get('name'))}`);
-  println(`decimals: ${hexStringToByteString((Object.values(result)[1]).get('decimals'))}`);
-  println(`symbol: ${hexStringToByteString((Object.values(result)[1]).get('symbol'))}`);
-  println(`extra: ${hexStringToByteString((Object.values(result)[1]).get('extra'))}`);
+  println(`name: ${bytesToString((Object.values(result)[1]).get('name'))}`);
+  println(`decimals: ${bytesToString((Object.values(result)[1]).get('decimals'))}`);
+  println(`symbol: ${bytesToString((Object.values(result)[1]).get('symbol'))}`);
+  println(`extra: ${bytesToString((Object.values(result)[1]).get('extra'))}`);
 })
 .catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```
@@ -173,7 +173,7 @@ Tezos.contract.at(contractAddress, tzip16)
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// import { Tzip16Module, tzip16, hexStringToByteString } from "@taquito/tzip16";
+// import { Tzip16Module, tzip16, bytesToString } from "@taquito/tzip16";
 // const Tezos = new TezosToolkit('rpc_url');
 
 Tezos.addExtension(new Tzip16Module());
@@ -190,10 +190,10 @@ Tezos.wallet.at(contractAddress, tzip16)
   return views['token_metadata']().executeView(tokenId)
 }).then (result => {
   println('Result of the view token_metadata:');
-  println(`name: ${hexStringToByteString((Object.values(result)[1]).get('name'))}`);
-  println(`decimals: ${hexStringToByteString((Object.values(result)[1]).get('decimals'))}`);
-  println(`symbol: ${hexStringToByteString((Object.values(result)[1]).get('symbol'))}`);
-  println(`extra: ${hexStringToByteString((Object.values(result)[1]).get('extra'))}`);
+  println(`name: ${bytesToString((Object.values(result)[1]).get('name'))}`);
+  println(`decimals: ${bytesToString((Object.values(result)[1]).get('decimals'))}`);
+  println(`symbol: ${bytesToString((Object.values(result)[1]).get('symbol'))}`);
+  println(`extra: ${bytesToString((Object.values(result)[1]).get('extra'))}`);
 })
 .catch(error => println(`Error: ${JSON.stringify(error, null, 2)}`));
 ```    

--- a/docs/version.md
+++ b/docs/version.md
@@ -314,13 +314,13 @@ const Tezos = new TezosToolkit(rpcUrl);
 
 Tezos.setWalletProvider(wallet)
 const signedW = await Tezos.wallet.signFailingNoop({
-arbitrary: stringToBytes("Hello World"),
+arbitrary: char2Bytes("Hello World"),
 basedOnBlock: 0,
 });
 
 Tezos.setSignerProvider(signer)
 const signedC = await Tezos.contract.signFailingNoop({
-arbitrary: stringToBytes("Hello World"),
+arbitrary: char2Bytes("Hello World"),
 basedOnBlock: 'genesis',
 });
 ```
@@ -2694,7 +2694,7 @@ If you have feature or issue requests, please create an issue on http://github.c
 # 8.0.6-beta.0 Updated beacon-sdk, bug fixed related to contract callback entry point
 
 * Updated beacon-sdk to version 2.2.2 #677
-* stringToBytes and bytesToString functions (initially in the taquito-tzip16 package) have been added to the taquito-utils package #589
+* char2Bytes and bytes2char functions (initially in the taquito-tzip16 package) have been added to the taquito-utils package #589
 * Allow specifying an entry point in a contract callback #652
 * Improved CI by adding retry for some of the integration tests
 

--- a/docs/version.md
+++ b/docs/version.md
@@ -314,13 +314,13 @@ const Tezos = new TezosToolkit(rpcUrl);
 
 Tezos.setWalletProvider(wallet)
 const signedW = await Tezos.wallet.signFailingNoop({
-arbitrary: char2Bytes("Hello World"),
+arbitrary: byteStringToHexString("Hello World"),
 basedOnBlock: 0,
 });
 
 Tezos.setSignerProvider(signer)
 const signedC = await Tezos.contract.signFailingNoop({
-arbitrary: char2Bytes("Hello World"),
+arbitrary: byteStringToHexString("Hello World"),
 basedOnBlock: 'genesis',
 });
 ```
@@ -2694,7 +2694,7 @@ If you have feature or issue requests, please create an issue on http://github.c
 # 8.0.6-beta.0 Updated beacon-sdk, bug fixed related to contract callback entry point
 
 * Updated beacon-sdk to version 2.2.2 #677
-* char2bytes and bytes2char functions (initially in the taquito-tzip16 package) have been added to the taquito-utils package #589
+* byteStringToHexString and hexStringToByteString functions (initially in the taquito-tzip16 package) have been added to the taquito-utils package #589
 * Allow specifying an entry point in a contract callback #652
 * Improved CI by adding retry for some of the integration tests
 

--- a/docs/version.md
+++ b/docs/version.md
@@ -314,13 +314,13 @@ const Tezos = new TezosToolkit(rpcUrl);
 
 Tezos.setWalletProvider(wallet)
 const signedW = await Tezos.wallet.signFailingNoop({
-arbitrary: byteStringToHexString("Hello World"),
+arbitrary: stringToBytes("Hello World"),
 basedOnBlock: 0,
 });
 
 Tezos.setSignerProvider(signer)
 const signedC = await Tezos.contract.signFailingNoop({
-arbitrary: byteStringToHexString("Hello World"),
+arbitrary: stringToBytes("Hello World"),
 basedOnBlock: 'genesis',
 });
 ```
@@ -2694,7 +2694,7 @@ If you have feature or issue requests, please create an issue on http://github.c
 # 8.0.6-beta.0 Updated beacon-sdk, bug fixed related to contract callback entry point
 
 * Updated beacon-sdk to version 2.2.2 #677
-* byteStringToHexString and hexStringToByteString functions (initially in the taquito-tzip16 package) have been added to the taquito-utils package #589
+* stringToBytes and bytesToString functions (initially in the taquito-tzip16 package) have been added to the taquito-utils package #589
 * Allow specifying an entry point in a contract callback #652
 * Improved CI by adding retry for some of the integration tests
 

--- a/example/deploy-docs-live-code-contracts.ts
+++ b/example/deploy-docs-live-code-contracts.ts
@@ -27,7 +27,7 @@ import {
 } from '../integration-tests/data/metadataViews';
 import { saplingLiveCodeContract } from './data/sapling_live_code_contract';
 import { contractMap8pairs } from './data/contractMap8pairs';
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import { fa2Contract } from '../integration-tests/data/fa2_contract';
 import BigNumber from 'bignumber.js';
 
@@ -583,8 +583,8 @@ async function originateTzip16Storage() {
     };
 
     const metadataBigMap = new MichelsonMap();
-    metadataBigMap.set('', char2Bytes('tezos-storage:here'));
-    metadataBigMap.set('here', char2Bytes(JSON.stringify(metadataJSON)));
+    metadataBigMap.set('', byteStringToHexString('tezos-storage:here'));
+    metadataBigMap.set('here', byteStringToHexString(JSON.stringify(metadataJSON)));
 
     const tacoShopStorageMap = new MichelsonMap();
 
@@ -608,7 +608,7 @@ async function originateTzip16Https() {
   tezos.setSignerProvider(signer);
   try {
     const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-    const bytesUrl = char2Bytes(url);
+    const bytesUrl = byteStringToHexString(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set('', bytesUrl);
@@ -640,7 +640,7 @@ async function originateTzip16SHA256() {
     );
     const metadataSha256 = '0x7e99ecf3a4490e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
     const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-    const bytesUrl = char2Bytes(url);
+    const bytesUrl = byteStringToHexString(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set('', bytesUrl);
@@ -668,7 +668,7 @@ async function originateTzip16IPFS() {
   tezos.setSignerProvider(signer);
   try {
     const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-    const bytesUrl = char2Bytes(uri);
+    const bytesUrl = byteStringToHexString(uri);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set('', bytesUrl);
@@ -695,8 +695,8 @@ async function originateTzip16OnChainJSON() {
   tezos.setSignerProvider(signer);
   try {
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set('', char2Bytes('tezos-storage:here'));
-    metadataBigMAp.set('here', char2Bytes(JSON.stringify(metadataViewsExample1)));
+    metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
+    metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample1)));
 
     const op = await tezos.contract.originate({
       code: contractCode,
@@ -718,8 +718,8 @@ async function originateTzip16OnChainMultiply() {
   tezos.setSignerProvider(signer);
   try {
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set('', char2Bytes('tezos-storage:here'));
-    metadataBigMAp.set('here', char2Bytes(JSON.stringify(metadataViewsExample2)));
+    metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
+    metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample2)));
 
     const op = await tezos.contract.originate({
       code: contractCode,

--- a/example/deploy-docs-live-code-contracts.ts
+++ b/example/deploy-docs-live-code-contracts.ts
@@ -27,7 +27,7 @@ import {
 } from '../integration-tests/data/metadataViews';
 import { saplingLiveCodeContract } from './data/sapling_live_code_contract';
 import { contractMap8pairs } from './data/contractMap8pairs';
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import { fa2Contract } from '../integration-tests/data/fa2_contract';
 import BigNumber from 'bignumber.js';
 
@@ -583,8 +583,8 @@ async function originateTzip16Storage() {
     };
 
     const metadataBigMap = new MichelsonMap();
-    metadataBigMap.set('', byteStringToHexString('tezos-storage:here'));
-    metadataBigMap.set('here', byteStringToHexString(JSON.stringify(metadataJSON)));
+    metadataBigMap.set('', stringToBytes('tezos-storage:here'));
+    metadataBigMap.set('here', stringToBytes(JSON.stringify(metadataJSON)));
 
     const tacoShopStorageMap = new MichelsonMap();
 
@@ -608,7 +608,7 @@ async function originateTzip16Https() {
   tezos.setSignerProvider(signer);
   try {
     const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-    const bytesUrl = byteStringToHexString(url);
+    const bytesUrl = stringToBytes(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set('', bytesUrl);
@@ -640,7 +640,7 @@ async function originateTzip16SHA256() {
     );
     const metadataSha256 = '0x7e99ecf3a4490e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
     const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-    const bytesUrl = byteStringToHexString(url);
+    const bytesUrl = stringToBytes(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set('', bytesUrl);
@@ -668,7 +668,7 @@ async function originateTzip16IPFS() {
   tezos.setSignerProvider(signer);
   try {
     const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-    const bytesUrl = byteStringToHexString(uri);
+    const bytesUrl = stringToBytes(uri);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set('', bytesUrl);
@@ -695,8 +695,8 @@ async function originateTzip16OnChainJSON() {
   tezos.setSignerProvider(signer);
   try {
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
-    metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample1)));
+    metadataBigMAp.set('', stringToBytes('tezos-storage:here'));
+    metadataBigMAp.set('here', stringToBytes(JSON.stringify(metadataViewsExample1)));
 
     const op = await tezos.contract.originate({
       code: contractCode,
@@ -718,8 +718,8 @@ async function originateTzip16OnChainMultiply() {
   tezos.setSignerProvider(signer);
   try {
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set('', byteStringToHexString('tezos-storage:here'));
-    metadataBigMAp.set('here', byteStringToHexString(JSON.stringify(metadataViewsExample2)));
+    metadataBigMAp.set('', stringToBytes('tezos-storage:here'));
+    metadataBigMAp.set('here', stringToBytes(JSON.stringify(metadataViewsExample2)));
 
     const op = await tezos.contract.originate({
       code: contractCode,

--- a/example/example-tzip-12-big-map-off-chain.ts
+++ b/example/example-tzip-12-big-map-off-chain.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { importKey, InMemorySigner } from '@taquito/signer';
 import { fa2ForTokenMetadataView } from '../integration-tests/data/fa2-for-token-metadata-view';
-import { b58cencode, char2Bytes, Prefix, prefix } from '@taquito/utils';
+import { b58cencode, byteStringToHexString, Prefix, prefix } from '@taquito/utils';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const nodeCrypto = require('crypto');
 
@@ -49,7 +49,7 @@ async function example() {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-			const bytesUrl = char2Bytes(url);
+			const bytesUrl = byteStringToHexString(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -57,15 +57,15 @@ async function example() {
 
 			const tokens = new MichelsonMap();
 			const metadataMap0 = new MichelsonMap();
-			metadataMap0.set('', char2Bytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-			metadataMap0.set('name', char2Bytes('Name from URI is prioritized!'));
+			metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+			metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
 			const metadataMap1 = new MichelsonMap();
-			metadataMap1.set('name', char2Bytes('AliceToken'));
-			metadataMap1.set('symbol', char2Bytes('ALC'));
+			metadataMap1.set('name', byteStringToHexString('AliceToken'));
+			metadataMap1.set('symbol', byteStringToHexString('ALC'));
 			metadataMap1.set('decimals', '30');
-			metadataMap1.set('extra', char2Bytes('Add more data'));
+			metadataMap1.set('extra', byteStringToHexString('Add more data'));
 			const metadataMap2 = new MichelsonMap();
-			metadataMap2.set('name', char2Bytes('Invalid token metadata'));
+			metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
 			tokens.set('0', {
 				metadata_map: metadataMap0,
 				total_supply: '20000'

--- a/example/example-tzip-12-big-map-off-chain.ts
+++ b/example/example-tzip-12-big-map-off-chain.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { importKey, InMemorySigner } from '@taquito/signer';
 import { fa2ForTokenMetadataView } from '../integration-tests/data/fa2-for-token-metadata-view';
-import { b58cencode, byteStringToHexString, Prefix, prefix } from '@taquito/utils';
+import { b58cencode, stringToBytes, Prefix, prefix } from '@taquito/utils';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const nodeCrypto = require('crypto');
 
@@ -49,7 +49,7 @@ async function example() {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-			const bytesUrl = byteStringToHexString(url);
+			const bytesUrl = stringToBytes(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -57,15 +57,15 @@ async function example() {
 
 			const tokens = new MichelsonMap();
 			const metadataMap0 = new MichelsonMap();
-			metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-			metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
+			metadataMap0.set('', stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+			metadataMap0.set('name', stringToBytes('Name from URI is prioritized!'));
 			const metadataMap1 = new MichelsonMap();
-			metadataMap1.set('name', byteStringToHexString('AliceToken'));
-			metadataMap1.set('symbol', byteStringToHexString('ALC'));
+			metadataMap1.set('name', stringToBytes('AliceToken'));
+			metadataMap1.set('symbol', stringToBytes('ALC'));
 			metadataMap1.set('decimals', '30');
-			metadataMap1.set('extra', byteStringToHexString('Add more data'));
+			metadataMap1.set('extra', stringToBytes('Add more data'));
 			const metadataMap2 = new MichelsonMap();
-			metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
+			metadataMap2.set('name', stringToBytes('Invalid token metadata'));
 			tokens.set('0', {
 				metadata_map: metadataMap0,
 				total_supply: '20000'

--- a/example/example-tzip-12-big-map-token-metadata.ts
+++ b/example/example-tzip-12-big-map-token-metadata.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { importKey, InMemorySigner } from '@taquito/signer';
-import { b58cencode, byteStringToHexString, Prefix, prefix } from '@taquito/utils';
+import { b58cencode, stringToBytes, Prefix, prefix } from '@taquito/utils';
 import { fa2TokenFactory } from '../integration-tests/data/fa2-token-factory';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -51,7 +51,7 @@ async function example() {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-token-factory.json';
-			const bytesUrl = byteStringToHexString(url);
+			const bytesUrl = stringToBytes(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -69,12 +69,12 @@ async function example() {
 
 			const token_metadata = new MichelsonMap();
 			const token1 = new MichelsonMap();
-			token1.set('name', byteStringToHexString('wToken'));
-			token1.set('symbol', byteStringToHexString('wTK'));
+			token1.set('name', stringToBytes('wToken'));
+			token1.set('symbol', stringToBytes('wTK'));
 			token1.set('decimals', '36');
 			const token2 = new MichelsonMap();
-			token2.set('name', byteStringToHexString('AliceToken'));
-			token2.set('symbol', byteStringToHexString('ALC'));
+			token2.set('name', stringToBytes('AliceToken'));
+			token2.set('symbol', stringToBytes('ALC'));
 			token2.set('decimals', '30');
 			token_metadata.set('1', {
 				token_id: '1',

--- a/example/example-tzip-12-big-map-token-metadata.ts
+++ b/example/example-tzip-12-big-map-token-metadata.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { importKey, InMemorySigner } from '@taquito/signer';
-import { b58cencode, char2Bytes, Prefix, prefix } from '@taquito/utils';
+import { b58cencode, byteStringToHexString, Prefix, prefix } from '@taquito/utils';
 import { fa2TokenFactory } from '../integration-tests/data/fa2-token-factory';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -51,7 +51,7 @@ async function example() {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-token-factory.json';
-			const bytesUrl = char2Bytes(url);
+			const bytesUrl = byteStringToHexString(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -69,12 +69,12 @@ async function example() {
 
 			const token_metadata = new MichelsonMap();
 			const token1 = new MichelsonMap();
-			token1.set('name', char2Bytes('wToken'));
-			token1.set('symbol', char2Bytes('wTK'));
+			token1.set('name', byteStringToHexString('wToken'));
+			token1.set('symbol', byteStringToHexString('wTK'));
 			token1.set('decimals', '36');
 			const token2 = new MichelsonMap();
-			token2.set('name', char2Bytes('AliceToken'));
-			token2.set('symbol', char2Bytes('ALC'));
+			token2.set('name', byteStringToHexString('AliceToken'));
+			token2.set('symbol', byteStringToHexString('ALC'));
 			token2.set('decimals', '30');
 			token_metadata.set('1', {
 				token_id: '1',

--- a/example/example-tzip-16-IPFS.ts
+++ b/example/example-tzip-16-IPFS.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 
 async function example() {
   const provider = 'https://ghostnet.ecadinfra.com';
@@ -13,7 +13,7 @@ async function example() {
     console.log('Deploying Tzip16IPFS contract...');
      // location of the contract metadata
      const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-     const bytesUrl = char2Bytes(uri);
+     const bytesUrl = byteStringToHexString(uri);
 
      const metadataBigMap = new MichelsonMap();
      metadataBigMap.set("", bytesUrl);

--- a/example/example-tzip-16-IPFS.ts
+++ b/example/example-tzip-16-IPFS.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 
 async function example() {
   const provider = 'https://ghostnet.ecadinfra.com';
@@ -13,7 +13,7 @@ async function example() {
     console.log('Deploying Tzip16IPFS contract...');
      // location of the contract metadata
      const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-     const bytesUrl = byteStringToHexString(uri);
+     const bytesUrl = stringToBytes(uri);
 
      const metadataBigMap = new MichelsonMap();
      metadataBigMap.set("", bytesUrl);

--- a/example/example-tzip-16-SHA256.ts
+++ b/example/example-tzip-16-SHA256.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
@@ -15,7 +15,7 @@ async function example() {
     const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
     const metadataSha256 = '0x7e99ecf3a4490e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
     const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-    const bytesUrl = byteStringToHexString(url);
+    const bytesUrl = stringToBytes(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set("", bytesUrl);

--- a/example/example-tzip-16-SHA256.ts
+++ b/example/example-tzip-16-SHA256.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
@@ -15,7 +15,7 @@ async function example() {
     const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
     const metadataSha256 = '0x7e99ecf3a4490e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
     const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-    const bytesUrl = char2Bytes(url);
+    const bytesUrl = byteStringToHexString(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set("", bytesUrl);

--- a/example/example-tzip-16-contract-origination-hostile-strings.ts
+++ b/example/example-tzip-16-contract-origination-hostile-strings.ts
@@ -1,5 +1,5 @@
 import { TezosToolkit } from '@taquito/taquito';
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 import { InMemorySigner } from '@taquito/signer';
@@ -33,8 +33,8 @@ async function example() {
     };
 
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set("", char2Bytes('tezos-storage:here'));
-    metadataBigMAp.set("here", char2Bytes(JSON.stringify(metadataJSON)))
+    metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
+    metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
 
     const tacoShopStorageMap = new MichelsonMap();
 

--- a/example/example-tzip-16-contract-origination-hostile-strings.ts
+++ b/example/example-tzip-16-contract-origination-hostile-strings.ts
@@ -1,5 +1,5 @@
 import { TezosToolkit } from '@taquito/taquito';
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 import { InMemorySigner } from '@taquito/signer';
@@ -33,8 +33,8 @@ async function example() {
     };
 
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
-    metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
+    metadataBigMAp.set("", stringToBytes('tezos-storage:here'));
+    metadataBigMAp.set("here", stringToBytes(JSON.stringify(metadataJSON)))
 
     const tacoShopStorageMap = new MichelsonMap();
 

--- a/example/example-tzip-16-https.ts
+++ b/example/example-tzip-16-https.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 
 async function example() {
   const provider = 'https://ghostnet.ecadinfra.com';
@@ -13,7 +13,7 @@ async function example() {
     console.log('Deploying Tzip16Https contract...');
     // location of the contract metadata
     const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-    const bytesUrl = char2Bytes(url);
+    const bytesUrl = byteStringToHexString(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set("", bytesUrl);

--- a/example/example-tzip-16-https.ts
+++ b/example/example-tzip-16-https.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 
 async function example() {
   const provider = 'https://ghostnet.ecadinfra.com';
@@ -13,7 +13,7 @@ async function example() {
     console.log('Deploying Tzip16Https contract...');
     // location of the contract metadata
     const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-    const bytesUrl = byteStringToHexString(url);
+    const bytesUrl = stringToBytes(url);
 
     const metadataBigMap = new MichelsonMap();
     metadataBigMap.set("", bytesUrl);

--- a/example/example-tzip-16-on-chain-one.ts
+++ b/example/example-tzip-16-on-chain-one.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { contractCode, metadataViewsExample1 } from '../integration-tests/data/metadataViews';
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
@@ -13,8 +13,8 @@ async function example() {
     console.log('Deploying Tzip16OffChainOne contract...');
 
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set("", char2Bytes('tezos-storage:here'));
-    metadataBigMAp.set("here", char2Bytes(JSON.stringify(metadataViewsExample1)))
+    metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
+    metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample1)))
 
     const op = await tezos.contract.originate({
       code: contractCode,

--- a/example/example-tzip-16-on-chain-one.ts
+++ b/example/example-tzip-16-on-chain-one.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { contractCode, metadataViewsExample1 } from '../integration-tests/data/metadataViews';
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
@@ -13,8 +13,8 @@ async function example() {
     console.log('Deploying Tzip16OffChainOne contract...');
 
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
-    metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample1)))
+    metadataBigMAp.set("", stringToBytes('tezos-storage:here'));
+    metadataBigMAp.set("here", stringToBytes(JSON.stringify(metadataViewsExample1)))
 
     const op = await tezos.contract.originate({
       code: contractCode,

--- a/example/example-tzip-16-on-chain-two.ts
+++ b/example/example-tzip-16-on-chain-two.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 import { contractCode, metadataViewsExample2 } from '../integration-tests/data/metadataViews';
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 
 async function example() {
   const provider = 'https://ghostnet.ecadinfra.com';
@@ -13,8 +13,8 @@ async function example() {
     console.log('Deploying Tzip16OffChainTwo contract...');
 
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set("", char2Bytes('tezos-storage:here'));
-    metadataBigMAp.set("here", char2Bytes(JSON.stringify(metadataViewsExample2)))
+    metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
+    metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample2)))
 
     const op = await tezos.contract.originate({
       code: contractCode,

--- a/example/example-tzip-16-on-chain-two.ts
+++ b/example/example-tzip-16-on-chain-two.ts
@@ -1,7 +1,7 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 import { contractCode, metadataViewsExample2 } from '../integration-tests/data/metadataViews';
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 
 async function example() {
   const provider = 'https://ghostnet.ecadinfra.com';
@@ -13,8 +13,8 @@ async function example() {
     console.log('Deploying Tzip16OffChainTwo contract...');
 
     const metadataBigMAp = new MichelsonMap();
-    metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
-    metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample2)))
+    metadataBigMAp.set("", stringToBytes('tezos-storage:here'));
+    metadataBigMAp.set("here", stringToBytes(JSON.stringify(metadataViewsExample2)))
 
     const op = await tezos.contract.originate({
       code: contractCode,

--- a/example/example-tzip-16-storage.ts
+++ b/example/example-tzip-16-storage.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
@@ -24,8 +24,8 @@ async function example() {
     };
 
     const metadataBigMap = new MichelsonMap();
-    metadataBigMap.set("", byteStringToHexString('tezos-storage:here'));
-    metadataBigMap.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
+    metadataBigMap.set("", stringToBytes('tezos-storage:here'));
+    metadataBigMap.set("here", stringToBytes(JSON.stringify(metadataJSON)))
 
     // Ligo Taco shop contract modified to include metadata in storage
     // https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A

--- a/example/example-tzip-16-storage.ts
+++ b/example/example-tzip-16-storage.ts
@@ -1,6 +1,6 @@
 import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-contract"
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
@@ -24,8 +24,8 @@ async function example() {
     };
 
     const metadataBigMap = new MichelsonMap();
-    metadataBigMap.set("", char2Bytes('tezos-storage:here'));
-    metadataBigMap.set("here", char2Bytes(JSON.stringify(metadataJSON)))
+    metadataBigMap.set("", byteStringToHexString('tezos-storage:here'));
+    metadataBigMap.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
 
     // Ligo Taco shop contract modified to include metadata in storage
     // https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A

--- a/integration-tests/contract-permits.spec.ts
+++ b/integration-tests/contract-permits.spec.ts
@@ -3,7 +3,7 @@ import { MichelsonMap, MichelCodecPacker, TezosToolkit } from '@taquito/taquito'
 import { permit_admin_42_expiry } from './data/permit_admin_42_expiry';
 import { permit_admin_42_set } from './data/permit_admin_42_set';
 import { permit_fa12_smartpy } from './data/permit_fa12_smartpy';
-import { buf2hex, char2Bytes, hex2buf } from '@taquito/utils';
+import { buf2hex, byteStringToHexString, hex2buf } from '@taquito/utils';
 import { tzip16, Tzip16Module } from '@taquito/tzip16';
 import { packDataBytes } from "@taquito/michel-codec"
 
@@ -181,7 +181,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
     test('Verify contract.originate for a permit fa1.2 contract with metadata views', async () => {
       const url = 'https://storage.googleapis.com/tzip-16/permit_metadata.json';
-      const bytesUrl = char2Bytes(url);
+      const bytesUrl = byteStringToHexString(url);
       const metadata = new MichelsonMap();
       metadata.set('', bytesUrl);
 
@@ -284,7 +284,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
         //Originate permit-fa1.2 contract with bootstrap1_address as administrator
         const url = 'https://storage.googleapis.com/tzip-16/permit_metadata.json';
-        const bytesUrl = char2Bytes(url);
+        const bytesUrl = byteStringToHexString(url);
         const metadata = new MichelsonMap();
         metadata.set('', bytesUrl);
 

--- a/integration-tests/contract-permits.spec.ts
+++ b/integration-tests/contract-permits.spec.ts
@@ -3,7 +3,7 @@ import { MichelsonMap, MichelCodecPacker, TezosToolkit } from '@taquito/taquito'
 import { permit_admin_42_expiry } from './data/permit_admin_42_expiry';
 import { permit_admin_42_set } from './data/permit_admin_42_set';
 import { permit_fa12_smartpy } from './data/permit_fa12_smartpy';
-import { buf2hex, byteStringToHexString, hex2buf } from '@taquito/utils';
+import { buf2hex, stringToBytes, hex2buf } from '@taquito/utils';
 import { tzip16, Tzip16Module } from '@taquito/tzip16';
 import { packDataBytes } from "@taquito/michel-codec"
 
@@ -181,7 +181,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
     test('Verify contract.originate for a permit fa1.2 contract with metadata views', async () => {
       const url = 'https://storage.googleapis.com/tzip-16/permit_metadata.json';
-      const bytesUrl = byteStringToHexString(url);
+      const bytesUrl = stringToBytes(url);
       const metadata = new MichelsonMap();
       metadata.set('', bytesUrl);
 
@@ -284,7 +284,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
         //Originate permit-fa1.2 contract with bootstrap1_address as administrator
         const url = 'https://storage.googleapis.com/tzip-16/permit_metadata.json';
-        const bytesUrl = byteStringToHexString(url);
+        const bytesUrl = stringToBytes(url);
         const metadata = new MichelsonMap();
         metadata.set('', bytesUrl);
 

--- a/integration-tests/originate-known-contracts.ts
+++ b/integration-tests/originate-known-contracts.ts
@@ -2,7 +2,7 @@ import { CONFIGS } from './config';
 import { MichelsonMap, OriginateParams, RpcForger, TezosToolkit } from '@taquito/taquito';
 import { singleSaplingStateContractJProtocol } from './data/single_sapling_state_contract_jakarta_michelson';
 import { fa2ForTokenMetadataView } from './data/fa2-for-token-metadata-view';
-import { byteStringToHexString } from '@taquito/utils';
+import { stringToBytes } from '@taquito/utils';
 import BigNumber from 'bignumber.js';
 import { codeViewsTopLevel } from './data/contract_views_top_level';
 import { knownBigMapContract } from './data/knownBigMapContract';
@@ -118,7 +118,7 @@ CONFIGS().forEach(({ lib, setup, protocol }) => {
     );
 
     const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-    const bytesUrl = byteStringToHexString(url);
+    const bytesUrl = stringToBytes(url);
     const metadata = new MichelsonMap();
     metadata.set('', bytesUrl);
 
@@ -126,15 +126,15 @@ CONFIGS().forEach(({ lib, setup, protocol }) => {
 
     const tokens = new MichelsonMap();
     const metadataMap0 = new MichelsonMap();
-    metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-    metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
+    metadataMap0.set('', stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+    metadataMap0.set('name', stringToBytes('Name from URI is prioritized!'));
     const metadataMap1 = new MichelsonMap();
-    metadataMap1.set('name', byteStringToHexString('AliceToken'));
-    metadataMap1.set('symbol', byteStringToHexString('ALC'));
+    metadataMap1.set('name', stringToBytes('AliceToken'));
+    metadataMap1.set('symbol', stringToBytes('ALC'));
     metadataMap1.set('decimals', '30');
-    metadataMap1.set('extra', byteStringToHexString('Add more data'));
+    metadataMap1.set('extra', stringToBytes('Add more data'));
     const metadataMap2 = new MichelsonMap();
-    metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
+    metadataMap2.set('name', stringToBytes('Invalid token metadata'));
     tokens.set('0', {
       metadata_map: metadataMap0,
       total_supply: '20000',

--- a/integration-tests/originate-known-contracts.ts
+++ b/integration-tests/originate-known-contracts.ts
@@ -2,7 +2,7 @@ import { CONFIGS } from './config';
 import { MichelsonMap, OriginateParams, RpcForger, TezosToolkit } from '@taquito/taquito';
 import { singleSaplingStateContractJProtocol } from './data/single_sapling_state_contract_jakarta_michelson';
 import { fa2ForTokenMetadataView } from './data/fa2-for-token-metadata-view';
-import { char2Bytes } from '@taquito/utils';
+import { byteStringToHexString } from '@taquito/utils';
 import BigNumber from 'bignumber.js';
 import { codeViewsTopLevel } from './data/contract_views_top_level';
 import { knownBigMapContract } from './data/knownBigMapContract';
@@ -118,7 +118,7 @@ CONFIGS().forEach(({ lib, setup, protocol }) => {
     );
 
     const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-    const bytesUrl = char2Bytes(url);
+    const bytesUrl = byteStringToHexString(url);
     const metadata = new MichelsonMap();
     metadata.set('', bytesUrl);
 
@@ -126,15 +126,15 @@ CONFIGS().forEach(({ lib, setup, protocol }) => {
 
     const tokens = new MichelsonMap();
     const metadataMap0 = new MichelsonMap();
-    metadataMap0.set('', char2Bytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-    metadataMap0.set('name', char2Bytes('Name from URI is prioritized!'));
+    metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+    metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
     const metadataMap1 = new MichelsonMap();
-    metadataMap1.set('name', char2Bytes('AliceToken'));
-    metadataMap1.set('symbol', char2Bytes('ALC'));
+    metadataMap1.set('name', byteStringToHexString('AliceToken'));
+    metadataMap1.set('symbol', byteStringToHexString('ALC'));
     metadataMap1.set('decimals', '30');
-    metadataMap1.set('extra', char2Bytes('Add more data'));
+    metadataMap1.set('extra', byteStringToHexString('Add more data'));
     const metadataMap2 = new MichelsonMap();
-    metadataMap2.set('name', char2Bytes('Invalid token metadata'));
+    metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
     tokens.set('0', {
       metadata_map: metadataMap0,
       total_supply: '20000',

--- a/integration-tests/tzip12-token-metadata.spec.ts
+++ b/integration-tests/tzip12-token-metadata.spec.ts
@@ -1,6 +1,6 @@
 import { CONFIGS } from './config';
 import { compose, MichelsonMap, ViewSimulationError } from '@taquito/taquito';
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { tzip12, Tzip12Module, TokenIdNotFound, InvalidTokenMetadata } from '@taquito/tzip12';
 import { fa2TokenFactory } from './data/fa2-token-factory';
 import { fa2ForTokenMetadataView } from './data/fa2-for-token-metadata-view';
@@ -38,7 +38,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-token-factory.json';
-			const bytesUrl = char2Bytes(url);
+			const bytesUrl = byteStringToHexString(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -56,12 +56,12 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
 			const token_metadata = new MichelsonMap();
 			const token1 = new MichelsonMap();
-			token1.set('name', char2Bytes('wToken'));
-			token1.set('symbol', char2Bytes('wTK'));
+			token1.set('name', byteStringToHexString('wToken'));
+			token1.set('symbol', byteStringToHexString('wTK'));
 			token1.set('decimals', '36');
 			const token2 = new MichelsonMap();
-			token2.set('name', char2Bytes('AliceToken'));
-			token2.set('symbol', char2Bytes('ALC'));
+			token2.set('name', byteStringToHexString('AliceToken'));
+			token2.set('symbol', byteStringToHexString('ALC'));
 			token2.set('decimals', '30');
 			token_metadata.set('1', {
 				token_id: '1',
@@ -183,7 +183,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-			const bytesUrl = char2Bytes(url);
+			const bytesUrl = byteStringToHexString(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -191,15 +191,15 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
 			const tokens = new MichelsonMap();
 			const metadataMap0 = new MichelsonMap();
-			metadataMap0.set('', char2Bytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-			metadataMap0.set('name', char2Bytes('Name from URI is prioritized!'));
+			metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+			metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
 			const metadataMap1 = new MichelsonMap();
-			metadataMap1.set('name', char2Bytes('AliceToken'));
-			metadataMap1.set('symbol', char2Bytes('ALC'));
+			metadataMap1.set('name', byteStringToHexString('AliceToken'));
+			metadataMap1.set('symbol', byteStringToHexString('ALC'));
 			metadataMap1.set('decimals', '30');
-			metadataMap1.set('extra', char2Bytes('Add more data'));
+			metadataMap1.set('extra', byteStringToHexString('Add more data'));
 			const metadataMap2 = new MichelsonMap();
-			metadataMap2.set('name', char2Bytes('Invalid token metadata'));
+			metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
 			tokens.set('0', {
 				metadata_map: metadataMap0,
 				total_supply: '20000'

--- a/integration-tests/tzip12-token-metadata.spec.ts
+++ b/integration-tests/tzip12-token-metadata.spec.ts
@@ -1,6 +1,6 @@
 import { CONFIGS } from './config';
 import { compose, MichelsonMap, ViewSimulationError } from '@taquito/taquito';
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { tzip12, Tzip12Module, TokenIdNotFound, InvalidTokenMetadata } from '@taquito/tzip12';
 import { fa2TokenFactory } from './data/fa2-token-factory';
 import { fa2ForTokenMetadataView } from './data/fa2-for-token-metadata-view';
@@ -38,7 +38,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-token-factory.json';
-			const bytesUrl = byteStringToHexString(url);
+			const bytesUrl = stringToBytes(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -56,12 +56,12 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
 			const token_metadata = new MichelsonMap();
 			const token1 = new MichelsonMap();
-			token1.set('name', byteStringToHexString('wToken'));
-			token1.set('symbol', byteStringToHexString('wTK'));
+			token1.set('name', stringToBytes('wToken'));
+			token1.set('symbol', stringToBytes('wTK'));
 			token1.set('decimals', '36');
 			const token2 = new MichelsonMap();
-			token2.set('name', byteStringToHexString('AliceToken'));
-			token2.set('symbol', byteStringToHexString('ALC'));
+			token2.set('name', stringToBytes('AliceToken'));
+			token2.set('symbol', stringToBytes('ALC'));
 			token2.set('decimals', '30');
 			token_metadata.set('1', {
 				token_id: '1',
@@ -183,7 +183,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			);
 
 			const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-			const bytesUrl = byteStringToHexString(url);
+			const bytesUrl = stringToBytes(url);
 			const metadata = new MichelsonMap();
 			metadata.set('', bytesUrl);
 
@@ -191,15 +191,15 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
 			const tokens = new MichelsonMap();
 			const metadataMap0 = new MichelsonMap();
-			metadataMap0.set('', byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-			metadataMap0.set('name', byteStringToHexString('Name from URI is prioritized!'));
+			metadataMap0.set('', stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+			metadataMap0.set('name', stringToBytes('Name from URI is prioritized!'));
 			const metadataMap1 = new MichelsonMap();
-			metadataMap1.set('name', byteStringToHexString('AliceToken'));
-			metadataMap1.set('symbol', byteStringToHexString('ALC'));
+			metadataMap1.set('name', stringToBytes('AliceToken'));
+			metadataMap1.set('symbol', stringToBytes('ALC'));
 			metadataMap1.set('decimals', '30');
-			metadataMap1.set('extra', byteStringToHexString('Add more data'));
+			metadataMap1.set('extra', stringToBytes('Add more data'));
 			const metadataMap2 = new MichelsonMap();
-			metadataMap2.set('name', byteStringToHexString('Invalid token metadata'));
+			metadataMap2.set('name', stringToBytes('Invalid token metadata'));
 			tokens.set('0', {
 				metadata_map: metadataMap0,
 				total_supply: '20000'

--- a/integration-tests/tzip16-metadata-view.spec.ts
+++ b/integration-tests/tzip16-metadata-view.spec.ts
@@ -1,6 +1,6 @@
 import { CONFIGS } from './config';
 import { MichelsonMap } from '@taquito/taquito';
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { contractCode, metadataViewsExample1, metadataViewsExample2 } from './data/metadataViews';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
@@ -15,8 +15,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 		test('Verify contract.originate for a contract with metadata having views that return bytes (example taken from TZComet) and then call the views', async () => {
 
 			const metadataBigMAp = new MichelsonMap();
-			metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
-			metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample1)))
+			metadataBigMAp.set("", stringToBytes('tezos-storage:here'));
+			metadataBigMAp.set("here", stringToBytes(JSON.stringify(metadataViewsExample1)))
 
 			const op = await Tezos.contract.originate({
 				code: contractCode,
@@ -59,8 +59,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 		test('Verify contract.originate for a contract with metadata having a couple of views (example taken from TZComet) and then call the views', async () => {
 
 			const metadataBigMAp = new MichelsonMap();
-			metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
-			metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample2)))
+			metadataBigMAp.set("", stringToBytes('tezos-storage:here'));
+			metadataBigMAp.set("here", stringToBytes(JSON.stringify(metadataViewsExample2)))
 
 			const op = await Tezos.contract.originate({
 				code: contractCode,

--- a/integration-tests/tzip16-metadata-view.spec.ts
+++ b/integration-tests/tzip16-metadata-view.spec.ts
@@ -1,6 +1,6 @@
 import { CONFIGS } from './config';
 import { MichelsonMap } from '@taquito/taquito';
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { contractCode, metadataViewsExample1, metadataViewsExample2 } from './data/metadataViews';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
@@ -15,8 +15,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 		test('Verify contract.originate for a contract with metadata having views that return bytes (example taken from TZComet) and then call the views', async () => {
 
 			const metadataBigMAp = new MichelsonMap();
-			metadataBigMAp.set("", char2Bytes('tezos-storage:here'));
-			metadataBigMAp.set("here", char2Bytes(JSON.stringify(metadataViewsExample1)))
+			metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
+			metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample1)))
 
 			const op = await Tezos.contract.originate({
 				code: contractCode,
@@ -59,8 +59,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 		test('Verify contract.originate for a contract with metadata having a couple of views (example taken from TZComet) and then call the views', async () => {
 
 			const metadataBigMAp = new MichelsonMap();
-			metadataBigMAp.set("", char2Bytes('tezos-storage:here'));
-			metadataBigMAp.set("here", char2Bytes(JSON.stringify(metadataViewsExample2)))
+			metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
+			metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataViewsExample2)))
 
 			const op = await Tezos.contract.originate({
 				code: contractCode,

--- a/integration-tests/tzip16-originate-contract-having-metadata-on-IPFS-and-fetch-those.spec.ts
+++ b/integration-tests/tzip16-originate-contract-having-metadata-on-IPFS-and-fetch-those.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from './config';
 import { tacoContractTzip16 } from './data/modified-taco-contract';
 import { MichelsonMap } from '@taquito/taquito';
-import { byteStringToHexString, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
+import { stringToBytes, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-            const bytesUrl = byteStringToHexString(uri);
+            const bytesUrl = stringToBytes(uri);
 
             const metadataBigMap = new MichelsonMap();
             metadataBigMap.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-contract-having-metadata-on-IPFS-and-fetch-those.spec.ts
+++ b/integration-tests/tzip16-originate-contract-having-metadata-on-IPFS-and-fetch-those.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from './config';
 import { tacoContractTzip16 } from './data/modified-taco-contract';
 import { MichelsonMap } from '@taquito/taquito';
-import { char2Bytes, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
+import { byteStringToHexString, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-            const bytesUrl = char2Bytes(uri);
+            const bytesUrl = byteStringToHexString(uri);
 
             const metadataBigMap = new MichelsonMap();
             metadataBigMap.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from "./config";
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -20,7 +20,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/empty-metadata.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -61,7 +61,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMap = new MichelsonMap();
             metadataBigMap.set("", bytesUrl);
@@ -88,7 +88,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/emoji-in-metadata.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -163,7 +163,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/invalid.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from "./config";
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -20,7 +20,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/empty-metadata.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -61,7 +61,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMap = new MichelsonMap();
             metadataBigMap.set("", bytesUrl);
@@ -88,7 +88,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/emoji-in-metadata.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -163,7 +163,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/invalid.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-sha256-hash-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-sha256-hash-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 
@@ -23,7 +23,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
             const metadataSha256 = '0x18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d';
             const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMap = new MichelsonMap();
             metadataBigMap.set("", bytesUrl);
@@ -101,7 +101,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
             const metadataSha256 = '0x7e99ecf3a4491e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
             const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-sha256-hash-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-contracts-with-metadata-on-HTTPS-and-sha256-hash-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 
@@ -23,7 +23,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
             const metadataSha256 = '0x18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d';
             const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMap = new MichelsonMap();
             metadataBigMap.set("", bytesUrl);
@@ -101,7 +101,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
             const metadataSha256 = '0x7e99ecf3a4491e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b';
             const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-contracts-with-metadata-on-itself-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-contracts-with-metadata-on-itself-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 
@@ -28,8 +28,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       };
 
       const metadataBigMap = new MichelsonMap();
-      metadataBigMap.set("", byteStringToHexString('tezos-storage:here'));
-      metadataBigMap.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
+      metadataBigMap.set("", stringToBytes('tezos-storage:here'));
+      metadataBigMap.set("here", stringToBytes(JSON.stringify(metadataJSON)))
 
       // Ligo Taco shop contract modified to include metadata in storage
       // https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A
@@ -84,7 +84,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Verify contract.originate for a contract having metadata inside another contract same network', async () => {
 
       const metadataBigMap = new MichelsonMap();
-      metadataBigMap.set("", byteStringToHexString(`tezos-storage://${contractAddress}/here`));
+      metadataBigMap.set("", stringToBytes(`tezos-storage://${contractAddress}/here`));
 
       const tacoShopStorageMap = new MichelsonMap();
 

--- a/integration-tests/tzip16-originate-contracts-with-metadata-on-itself-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-contracts-with-metadata-on-itself-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 
@@ -28,8 +28,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       };
 
       const metadataBigMap = new MichelsonMap();
-      metadataBigMap.set("", char2Bytes('tezos-storage:here'));
-      metadataBigMap.set("here", char2Bytes(JSON.stringify(metadataJSON)))
+      metadataBigMap.set("", byteStringToHexString('tezos-storage:here'));
+      metadataBigMap.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
 
       // Ligo Taco shop contract modified to include metadata in storage
       // https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A
@@ -84,7 +84,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Verify contract.originate for a contract having metadata inside another contract same network', async () => {
 
       const metadataBigMap = new MichelsonMap();
-      metadataBigMap.set("", char2Bytes(`tezos-storage://${contractAddress}/here`));
+      metadataBigMap.set("", byteStringToHexString(`tezos-storage://${contractAddress}/here`));
 
       const tacoShopStorageMap = new MichelsonMap();
 

--- a/integration-tests/tzip16-originate-fa2-contract-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-fa2-contract-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { MichelsonMap } from "@taquito/taquito";
 import { fa2ContractTzip16 } from "./data/fa2_contract_with_metadata";
 
@@ -22,7 +22,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
          // location of the contract metadata
          const url = 'https://storage.googleapis.com/tzip-16/fa2-metadata.json';
-         const bytesUrl = byteStringToHexString(url);
+         const bytesUrl = stringToBytes(url);
 
          const metadataBigMAp = new MichelsonMap();
          metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-fa2-contract-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-fa2-contract-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { MichelsonMap } from "@taquito/taquito";
 import { fa2ContractTzip16 } from "./data/fa2_contract_with_metadata";
 
@@ -22,7 +22,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
          // location of the contract metadata
          const url = 'https://storage.googleapis.com/tzip-16/fa2-metadata.json';
-         const bytesUrl = char2Bytes(url);
+         const bytesUrl = byteStringToHexString(url);
 
          const metadataBigMAp = new MichelsonMap();
          metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-fa2-wallet-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-fa2-wallet-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { MichelsonMap } from "@taquito/taquito";
 import { fa2ContractTzip16 } from "./data/fa2_contract_with_metadata";
 
@@ -23,7 +23,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
          // location of the contract metadata
          const url = 'https://storage.googleapis.com/tzip-16/fa2-metadata.json';
-         const bytesUrl = char2Bytes(url);
+         const bytesUrl = byteStringToHexString(url);
 
          const metadataBigMAp = new MichelsonMap();
          metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-fa2-wallet-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-fa2-wallet-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { MichelsonMap } from "@taquito/taquito";
 import { fa2ContractTzip16 } from "./data/fa2_contract_with_metadata";
 
@@ -23,7 +23,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
          // location of the contract metadata
          const url = 'https://storage.googleapis.com/tzip-16/fa2-metadata.json';
-         const bytesUrl = byteStringToHexString(url);
+         const bytesUrl = stringToBytes(url);
 
          const metadataBigMAp = new MichelsonMap();
          metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-wallet-having-metadata-on-IPFS-and-fetch-those.spec.ts
+++ b/integration-tests/tzip16-originate-wallet-having-metadata-on-IPFS-and-fetch-those.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from './config';
 import { tacoContractTzip16 } from './data/modified-taco-contract';
 import { MichelsonMap } from '@taquito/taquito';
-import { char2Bytes, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
+import { byteStringToHexString, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-            const bytesUrl = char2Bytes(uri);
+            const bytesUrl = byteStringToHexString(uri);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-wallet-having-metadata-on-IPFS-and-fetch-those.spec.ts
+++ b/integration-tests/tzip16-originate-wallet-having-metadata-on-IPFS-and-fetch-those.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from './config';
 import { tacoContractTzip16 } from './data/modified-taco-contract';
 import { MichelsonMap } from '@taquito/taquito';
-import { byteStringToHexString, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
+import { stringToBytes, tzip16, Tzip16Module, IpfsHttpHandler, Handler, MetadataProvider } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -25,7 +25,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const uri = 'ipfs://QmXnASUptTDnfhmcoznFqz3S1Mxu7X1zqo2YwbTN3nW52V';
-            const bytesUrl = byteStringToHexString(uri);
+            const bytesUrl = stringToBytes(uri);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-wallets-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-wallets-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from "./config";
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -20,7 +20,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/empty-metadata.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -60,7 +60,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -86,7 +86,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/emoji-in-metadata.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -161,7 +161,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/invalid.json';
-            const bytesUrl = byteStringToHexString(url);
+            const bytesUrl = stringToBytes(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-wallets-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-wallets-with-metadata-on-HTTPS-and-fetch-metadata.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS } from "./config";
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;
@@ -20,7 +20,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/empty-metadata.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -60,7 +60,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/taco-shop-metadata.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -86,7 +86,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/emoji-in-metadata.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);
@@ -161,7 +161,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
             // location of the contract metadata
             const url = 'https://storage.googleapis.com/tzip-16/invalid.json';
-            const bytesUrl = char2Bytes(url);
+            const bytesUrl = byteStringToHexString(url);
 
             const metadataBigMAp = new MichelsonMap();
             metadataBigMAp.set("", bytesUrl);

--- a/integration-tests/tzip16-originate-wallets-with-metadata-on-itself-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-wallets-with-metadata-on-itself-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, char2Bytes } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 
@@ -28,8 +28,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       };
 
       const metadataBigMAp = new MichelsonMap();
-      metadataBigMAp.set("", char2Bytes('tezos-storage:here'));
-      metadataBigMAp.set("here", char2Bytes(JSON.stringify(metadataJSON)))
+      metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
+      metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
 
       // Ligo Taco shop contract modified to include metadata in storage
       // https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A
@@ -83,7 +83,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Verify wallet.originate for a contract having metadata inside another contract same network', async () => {
 
       const metadataBigMAp = new MichelsonMap();
-      metadataBigMAp.set("", char2Bytes(`tezos-storage://${contractAddress}/here`));
+      metadataBigMAp.set("", byteStringToHexString(`tezos-storage://${contractAddress}/here`));
 
       const tacoShopStorageMap = new MichelsonMap();
 

--- a/integration-tests/tzip16-originate-wallets-with-metadata-on-itself-and-fetch-metadata.spec.ts
+++ b/integration-tests/tzip16-originate-wallets-with-metadata-on-itself-and-fetch-metadata.spec.ts
@@ -1,5 +1,5 @@
 import { CONFIGS } from "./config";
-import { tzip16, Tzip16Module, byteStringToHexString } from '@taquito/tzip16';
+import { tzip16, Tzip16Module, stringToBytes } from '@taquito/tzip16';
 import { tacoContractTzip16 } from "./data/modified-taco-contract"
 import { MichelsonMap } from "@taquito/taquito";
 
@@ -28,8 +28,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       };
 
       const metadataBigMAp = new MichelsonMap();
-      metadataBigMAp.set("", byteStringToHexString('tezos-storage:here'));
-      metadataBigMAp.set("here", byteStringToHexString(JSON.stringify(metadataJSON)))
+      metadataBigMAp.set("", stringToBytes('tezos-storage:here'));
+      metadataBigMAp.set("here", stringToBytes(JSON.stringify(metadataJSON)))
 
       // Ligo Taco shop contract modified to include metadata in storage
       // https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A
@@ -83,7 +83,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it('Verify wallet.originate for a contract having metadata inside another contract same network', async () => {
 
       const metadataBigMAp = new MichelsonMap();
-      metadataBigMAp.set("", byteStringToHexString(`tezos-storage://${contractAddress}/here`));
+      metadataBigMAp.set("", stringToBytes(`tezos-storage://${contractAddress}/here`));
 
       const tacoShopStorageMap = new MichelsonMap();
 

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/address.ts
@@ -5,7 +5,7 @@ import {
   TokenValidationError,
   SemanticEncoding,
 } from '../token';
-import { b58decode, encodePubKey, validateAddress, ValidationResult } from '@taquito/utils';
+import { b58decode, encodeAddress, validateAddress, ValidationResult } from '@taquito/utils';
 import { BaseTokenSchema } from '../../schema/types';
 
 /**
@@ -14,7 +14,11 @@ import { BaseTokenSchema } from '../../schema/types';
  */
 export class AddressValidationError extends TokenValidationError {
   name = 'AddressValidationError';
-  constructor(public value: any, public token: AddressToken, message: string) {
+  constructor(
+    public value: any,
+    public token: AddressToken,
+    message: string
+  ) {
     super(value, token, message);
   }
 }
@@ -90,7 +94,7 @@ export class AddressToken extends ComparableToken {
       );
     }
 
-    return encodePubKey(val.bytes);
+    return encodeAddress(val.bytes);
   }
 
   /**
@@ -123,7 +127,7 @@ export class AddressToken extends ComparableToken {
       );
     }
 
-    return encodePubKey(bytes);
+    return encodeAddress(bytes);
   }
   compare(address1: string, address2: string) {
     const isImplicit = (address: string) => {

--- a/packages/taquito-michelson-encoder/src/tokens/contract.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/contract.ts
@@ -1,5 +1,5 @@
 import { TokenSchema } from './../schema/types';
-import { encodePubKey, validateAddress, ValidationResult } from '@taquito/utils';
+import { encodeAddress, validateAddress, ValidationResult } from '@taquito/utils';
 import { ContractTokenSchema } from '../schema/types';
 import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './token';
 
@@ -9,7 +9,11 @@ import { SemanticEncoding, Token, TokenFactory, TokenValidationError } from './t
  */
 export class ContractValidationError extends TokenValidationError {
   name = 'ContractValidationError';
-  constructor(public value: any, public token: ContractToken, message: string) {
+  constructor(
+    public value: any,
+    public token: ContractToken,
+    message: string
+  ) {
     super(value, token, message);
   }
 }
@@ -58,7 +62,7 @@ export class ContractToken extends Token {
       );
     }
 
-    return encodePubKey(val.bytes);
+    return encodeAddress(val.bytes);
   }
 
   /**

--- a/packages/taquito-sapling/src/sapling-forger/sapling-forger.ts
+++ b/packages/taquito-sapling/src/sapling-forger/sapling-forger.ts
@@ -4,7 +4,7 @@ import {
   SaplingTransactionOutput,
   SaplingTransactionPlaintext,
 } from '../types';
-import { char2Bytes, toHexBuf } from '@taquito/utils';
+import { byteStringToHexString, toHexBuf } from '@taquito/utils';
 import BigNumber from 'bignumber.js';
 
 export class SaplingForger {
@@ -106,7 +106,7 @@ export class SaplingForger {
 
   forgeTransactionPlaintext(txPlainText: SaplingTransactionPlaintext) {
     const encodedMemo = Buffer.from(
-      char2Bytes(txPlainText.memo).padEnd(txPlainText.memoSize, '0'),
+      byteStringToHexString(txPlainText.memo).padEnd(txPlainText.memoSize, '0'),
       'hex'
     );
     return Buffer.concat([

--- a/packages/taquito-sapling/src/sapling-forger/sapling-forger.ts
+++ b/packages/taquito-sapling/src/sapling-forger/sapling-forger.ts
@@ -4,7 +4,7 @@ import {
   SaplingTransactionOutput,
   SaplingTransactionPlaintext,
 } from '../types';
-import { byteStringToHexString, toHexBuf } from '@taquito/utils';
+import { stringToBytes, toHexBuf } from '@taquito/utils';
 import BigNumber from 'bignumber.js';
 
 export class SaplingForger {
@@ -106,7 +106,7 @@ export class SaplingForger {
 
   forgeTransactionPlaintext(txPlainText: SaplingTransactionPlaintext) {
     const encodedMemo = Buffer.from(
-      byteStringToHexString(txPlainText.memo).padEnd(txPlainText.memoSize, '0'),
+      stringToBytes(txPlainText.memo).padEnd(txPlainText.memoSize, '0'),
       'hex'
     );
     return Buffer.concat([

--- a/packages/taquito-sapling/src/sapling-tx-viewer/helpers.ts
+++ b/packages/taquito-sapling/src/sapling-tx-viewer/helpers.ts
@@ -1,10 +1,10 @@
-import { b58cencode, hexStringToByteString, Prefix, prefix } from '@taquito/utils';
+import { b58cencode, bytesToString, Prefix, prefix } from '@taquito/utils';
 import BigNumber from 'bignumber.js';
 import { Input } from '../types';
 
 export function memoHexToUtf8(memo: string) {
   const memoNoPadding = removeZeroPaddedBytesRight(memo);
-  return memoNoPadding === '' ? memoNoPadding : hexStringToByteString(memoNoPadding);
+  return memoNoPadding === '' ? memoNoPadding : bytesToString(memoNoPadding);
 }
 
 function removeZeroPaddedBytesRight(memo: string) {

--- a/packages/taquito-sapling/src/sapling-tx-viewer/helpers.ts
+++ b/packages/taquito-sapling/src/sapling-tx-viewer/helpers.ts
@@ -1,10 +1,10 @@
-import { b58cencode, bytes2Char, Prefix, prefix } from '@taquito/utils';
+import { b58cencode, hexStringToByteString, Prefix, prefix } from '@taquito/utils';
 import BigNumber from 'bignumber.js';
 import { Input } from '../types';
 
 export function memoHexToUtf8(memo: string) {
   const memoNoPadding = removeZeroPaddedBytesRight(memo);
-  return memoNoPadding === '' ? memoNoPadding : bytes2Char(memoNoPadding);
+  return memoNoPadding === '' ? memoNoPadding : hexStringToByteString(memoNoPadding);
 }
 
 function removeZeroPaddedBytesRight(memo: string) {

--- a/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
+++ b/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
@@ -4,7 +4,7 @@ import {
   Tzip16ContractAbstraction,
   MetadataContext,
   View,
-  bytes2Char,
+  hexStringToByteString,
   BigMapId,
 } from '@taquito/tzip16';
 import { InvalidTokenMetadata, TokenIdNotFound, TokenMetadataNotFound } from './errors';
@@ -130,14 +130,16 @@ export class Tzip12ContractAbstraction {
       try {
         const metadataFromUri = await this.context.metadataProvider.provideMetadata(
           this.contractAbstraction,
-          bytes2Char(uri),
+          hexStringToByteString(uri),
           this.context
         );
         return metadataFromUri.metadata;
       } catch (e: any) {
         if (e.name === 'InvalidUriError') {
           console.warn(
-            `The URI ${bytes2Char(uri)} is present in the token metadata, but is invalid.`
+            `The URI ${hexStringToByteString(
+              uri
+            )} is present in the token metadata, but is invalid.`
           );
         } else {
           throw e;
@@ -158,12 +160,14 @@ export class Tzip12ContractAbstraction {
       if (keyTokenMetadata === 'decimals') {
         Object.assign(tokenMetadataDecoded, {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          [keyTokenMetadata]: Number(bytes2Char(metadataTokenMap.get(keyTokenMetadata)!)),
+          [keyTokenMetadata]: Number(
+            hexStringToByteString(metadataTokenMap.get(keyTokenMetadata)!)
+          ),
         });
       } else if (!(keyTokenMetadata === '')) {
         Object.assign(tokenMetadataDecoded, {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          [keyTokenMetadata]: bytes2Char(metadataTokenMap.get(keyTokenMetadata)!),
+          [keyTokenMetadata]: hexStringToByteString(metadataTokenMap.get(keyTokenMetadata)!),
         });
       }
     }

--- a/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
+++ b/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
@@ -4,7 +4,7 @@ import {
   Tzip16ContractAbstraction,
   MetadataContext,
   View,
-  hexStringToByteString,
+  bytesToString,
   BigMapId,
 } from '@taquito/tzip16';
 import { InvalidTokenMetadata, TokenIdNotFound, TokenMetadataNotFound } from './errors';
@@ -130,16 +130,14 @@ export class Tzip12ContractAbstraction {
       try {
         const metadataFromUri = await this.context.metadataProvider.provideMetadata(
           this.contractAbstraction,
-          hexStringToByteString(uri),
+          bytesToString(uri),
           this.context
         );
         return metadataFromUri.metadata;
       } catch (e: any) {
         if (e.name === 'InvalidUriError') {
           console.warn(
-            `The URI ${hexStringToByteString(
-              uri
-            )} is present in the token metadata, but is invalid.`
+            `The URI ${bytesToString(uri)} is present in the token metadata, but is invalid.`
           );
         } else {
           throw e;
@@ -160,14 +158,12 @@ export class Tzip12ContractAbstraction {
       if (keyTokenMetadata === 'decimals') {
         Object.assign(tokenMetadataDecoded, {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          [keyTokenMetadata]: Number(
-            hexStringToByteString(metadataTokenMap.get(keyTokenMetadata)!)
-          ),
+          [keyTokenMetadata]: Number(bytesToString(metadataTokenMap.get(keyTokenMetadata)!)),
         });
       } else if (!(keyTokenMetadata === '')) {
         Object.assign(tokenMetadataDecoded, {
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          [keyTokenMetadata]: hexStringToByteString(metadataTokenMap.get(keyTokenMetadata)!),
+          [keyTokenMetadata]: bytesToString(metadataTokenMap.get(keyTokenMetadata)!),
         });
       }
     }

--- a/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
@@ -1,5 +1,5 @@
 import { MichelsonMap, ViewSimulationError } from '@taquito/taquito';
-import { byteStringToHexString, InvalidUriError } from '@taquito/tzip16';
+import { stringToBytes, InvalidUriError } from '@taquito/tzip16';
 import { Tzip12ContractAbstraction } from '../src/tzip12-contract-abstraction';
 import { InvalidTokenMetadata, TokenIdNotFound, TokenMetadataNotFound } from '../src/errors';
 
@@ -130,9 +130,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
-    tokenMap.set('decimals', byteStringToHexString('3'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
+    tokenMap.set('decimals', stringToBytes('3'));
 
     // takes as parameter the nat token-id and returns the (pair nat (map string bytes)) value
     mockMichelsonStorageView.executeView.mockResolvedValue({
@@ -192,10 +192,7 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set(
-      '',
-      byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json')
-    );
+    tokenMap.set('', stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
 
     mockMichelsonStorageView.executeView.mockResolvedValue({
       token_id: '0',
@@ -214,12 +211,12 @@ describe('Tzip12 contract abstraction test', () => {
 
   it('Test 1 for fetchTokenMetadataFromUri(): Should warn that the URI is invalid and return undefined', async () => {
     const tokenMap = new MichelsonMap();
-    tokenMap.set('test', byteStringToHexString('test'));
-    tokenMap.set('', byteStringToHexString('InvalidUriError'));
-    tokenMap.set('testtest', byteStringToHexString('testtest'));
+    tokenMap.set('test', stringToBytes('test'));
+    tokenMap.set('', stringToBytes('InvalidUriError'));
+    tokenMap.set('testtest', stringToBytes('testtest'));
 
     mockMetadataProvider.provideMetadata.mockImplementation(() => {
-      throw new InvalidUriError(byteStringToHexString('InvalidUriError'));
+      throw new InvalidUriError(stringToBytes('InvalidUriError'));
     });
 
     const tokenMetadata = await tzip12Abs['fetchTokenMetadataFromUri'](
@@ -230,8 +227,8 @@ describe('Tzip12 contract abstraction test', () => {
 
   it('Test 2 for fetchTokenMetadataFromUri(): Should return undefined when no URI', async () => {
     const tokenMap = new MichelsonMap();
-    tokenMap.set('test', byteStringToHexString('test'));
-    tokenMap.set('testtest', byteStringToHexString('testtest'));
+    tokenMap.set('test', stringToBytes('test'));
+    tokenMap.set('testtest', stringToBytes('testtest'));
 
     const tokenMetadata = await tzip12Abs['fetchTokenMetadataFromUri'](
       tokenMap as MichelsonMap<string, string>
@@ -253,9 +250,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
-    tokenMap.set('decimals', byteStringToHexString('3'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
+    tokenMap.set('decimals', stringToBytes('3'));
 
     // takes as parameter the nat token-id and returns the (pair nat (map string bytes)) value
     mockMichelsonStorageView.executeView.mockResolvedValue({
@@ -295,9 +292,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
-    tokenMap.set('decimals', byteStringToHexString('3'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
+    tokenMap.set('decimals', stringToBytes('3'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,
@@ -346,9 +343,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
-    tokenMap.set('decimals', byteStringToHexString('3'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
+    tokenMap.set('decimals', stringToBytes('3'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,
@@ -374,10 +371,10 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('', byteStringToHexString('https://test'));
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
-    tokenMap.set('decimals', byteStringToHexString('3'));
+    tokenMap.set('', stringToBytes('https://test'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
+    tokenMap.set('decimals', stringToBytes('3'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,
@@ -412,10 +409,10 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('', byteStringToHexString('https://test'));
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
-    tokenMap.set('decimals', byteStringToHexString('3'));
+    tokenMap.set('', stringToBytes('https://test'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
+    tokenMap.set('decimals', stringToBytes('3'));
 
     // takes as parameter the nat token-id and returns the (pair nat (map string bytes)) value
     mockMichelsonStorageView.executeView.mockResolvedValue({
@@ -441,8 +438,8 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', byteStringToHexString('Taquito'));
-    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('name', stringToBytes('Taquito'));
+    tokenMap.set('symbol', stringToBytes('XTZ'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,

--- a/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
@@ -1,5 +1,5 @@
 import { MichelsonMap, ViewSimulationError } from '@taquito/taquito';
-import { char2Bytes, InvalidUriError } from '@taquito/tzip16';
+import { byteStringToHexString, InvalidUriError } from '@taquito/tzip16';
 import { Tzip12ContractAbstraction } from '../src/tzip12-contract-abstraction';
 import { InvalidTokenMetadata, TokenIdNotFound, TokenMetadataNotFound } from '../src/errors';
 
@@ -130,9 +130,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
-    tokenMap.set('decimals', char2Bytes('3'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('decimals', byteStringToHexString('3'));
 
     // takes as parameter the nat token-id and returns the (pair nat (map string bytes)) value
     mockMichelsonStorageView.executeView.mockResolvedValue({
@@ -192,7 +192,10 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('', char2Bytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
+    tokenMap.set(
+      '',
+      byteStringToHexString('https://storage.googleapis.com/tzip-16/token-metadata.json')
+    );
 
     mockMichelsonStorageView.executeView.mockResolvedValue({
       token_id: '0',
@@ -211,12 +214,12 @@ describe('Tzip12 contract abstraction test', () => {
 
   it('Test 1 for fetchTokenMetadataFromUri(): Should warn that the URI is invalid and return undefined', async () => {
     const tokenMap = new MichelsonMap();
-    tokenMap.set('test', char2Bytes('test'));
-    tokenMap.set('', char2Bytes('InvalidUriError'));
-    tokenMap.set('testtest', char2Bytes('testtest'));
+    tokenMap.set('test', byteStringToHexString('test'));
+    tokenMap.set('', byteStringToHexString('InvalidUriError'));
+    tokenMap.set('testtest', byteStringToHexString('testtest'));
 
     mockMetadataProvider.provideMetadata.mockImplementation(() => {
-      throw new InvalidUriError(char2Bytes('InvalidUriError'));
+      throw new InvalidUriError(byteStringToHexString('InvalidUriError'));
     });
 
     const tokenMetadata = await tzip12Abs['fetchTokenMetadataFromUri'](
@@ -227,8 +230,8 @@ describe('Tzip12 contract abstraction test', () => {
 
   it('Test 2 for fetchTokenMetadataFromUri(): Should return undefined when no URI', async () => {
     const tokenMap = new MichelsonMap();
-    tokenMap.set('test', char2Bytes('test'));
-    tokenMap.set('testtest', char2Bytes('testtest'));
+    tokenMap.set('test', byteStringToHexString('test'));
+    tokenMap.set('testtest', byteStringToHexString('testtest'));
 
     const tokenMetadata = await tzip12Abs['fetchTokenMetadataFromUri'](
       tokenMap as MichelsonMap<string, string>
@@ -250,9 +253,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
-    tokenMap.set('decimals', char2Bytes('3'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('decimals', byteStringToHexString('3'));
 
     // takes as parameter the nat token-id and returns the (pair nat (map string bytes)) value
     mockMichelsonStorageView.executeView.mockResolvedValue({
@@ -292,9 +295,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
-    tokenMap.set('decimals', char2Bytes('3'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('decimals', byteStringToHexString('3'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,
@@ -343,9 +346,9 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
-    tokenMap.set('decimals', char2Bytes('3'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('decimals', byteStringToHexString('3'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,
@@ -371,10 +374,10 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('', char2Bytes('https://test'));
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
-    tokenMap.set('decimals', char2Bytes('3'));
+    tokenMap.set('', byteStringToHexString('https://test'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('decimals', byteStringToHexString('3'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,
@@ -409,10 +412,10 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('', char2Bytes('https://test'));
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
-    tokenMap.set('decimals', char2Bytes('3'));
+    tokenMap.set('', byteStringToHexString('https://test'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
+    tokenMap.set('decimals', byteStringToHexString('3'));
 
     // takes as parameter the nat token-id and returns the (pair nat (map string bytes)) value
     mockMichelsonStorageView.executeView.mockResolvedValue({
@@ -438,8 +441,8 @@ describe('Tzip12 contract abstraction test', () => {
       prim: 'map',
       args: [{ prim: 'string' }, { prim: 'bytes' }],
     });
-    tokenMap.set('name', char2Bytes('Taquito'));
-    tokenMap.set('symbol', char2Bytes('XTZ'));
+    tokenMap.set('name', byteStringToHexString('Taquito'));
+    tokenMap.set('symbol', byteStringToHexString('XTZ'));
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue({
       token_id: '0',
       token_info: tokenMap,

--- a/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
+++ b/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
@@ -1,7 +1,7 @@
 import { Schema } from '@taquito/michelson-encoder';
 import { Context, ContractAbstraction, ContractProvider, Wallet } from '@taquito/taquito';
 import { Handler, Tzip16Uri } from '../metadata-provider';
-import { bytes2Char } from '@taquito/utils';
+import { hexStringToByteString } from '@taquito/utils';
 import {
   InvalidContractMetadataTypeError,
   BigMapContractMetadataNotFoundError,
@@ -58,7 +58,7 @@ export class TezosStorageHandler implements Handler {
     if (!/^[0-9a-fA-F]*$/.test(bytes)) {
       throw new InvalidContractMetadataTypeError();
     }
-    return bytes2Char(bytes);
+    return hexStringToByteString(bytes);
   }
 
   /**

--- a/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
+++ b/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
@@ -1,7 +1,7 @@
 import { Schema } from '@taquito/michelson-encoder';
 import { Context, ContractAbstraction, ContractProvider, Wallet } from '@taquito/taquito';
 import { Handler, Tzip16Uri } from '../metadata-provider';
-import { hexStringToByteString } from '@taquito/utils';
+import { bytesToString } from '@taquito/utils';
 import {
   InvalidContractMetadataTypeError,
   BigMapContractMetadataNotFoundError,
@@ -58,7 +58,7 @@ export class TezosStorageHandler implements Handler {
     if (!/^[0-9a-fA-F]*$/.test(bytes)) {
       throw new InvalidContractMetadataTypeError();
     }
-    return hexStringToByteString(bytes);
+    return bytesToString(bytes);
   }
 
   /**

--- a/packages/taquito-tzip16/src/metadataProviderRequirements.md
+++ b/packages/taquito-tzip16/src/metadataProviderRequirements.md
@@ -65,7 +65,7 @@ Reuse the smart contract abstraction to retrieve the data from the storage.
 If the data are stored in another contract. Use TezosToolkit.contract.at to fetch it.
 
 Consideration:
-Data is encoded in byte in this protocol. Use the function `hexStringToByteString` from `tzip16-utils.ts` to decode it to a string. Then use JSON.parse on the string to produce a javascript object useable by Taquito users.
+Data is encoded in byte in this protocol. Use the function `bytesToString` from `tzip16-utils.ts` to decode it to a string. Then use JSON.parse on the string to produce a javascript object useable by Taquito users.
 
 
 # Milestone 2

--- a/packages/taquito-tzip16/src/metadataProviderRequirements.md
+++ b/packages/taquito-tzip16/src/metadataProviderRequirements.md
@@ -65,7 +65,7 @@ Reuse the smart contract abstraction to retrieve the data from the storage.
 If the data are stored in another contract. Use TezosToolkit.contract.at to fetch it.
 
 Consideration:
-Data is encoded in byte in this protocol. Use the function `bytes2Char` from `tzip16-utils.ts` to decode it to a string. Then use JSON.parse on the string to produce a javascript object useable by Taquito users.
+Data is encoded in byte in this protocol. Use the function `hexStringToByteString` from `tzip16-utils.ts` to decode it to a string. Then use JSON.parse on the string to produce a javascript object useable by Taquito users.
 
 
 # Milestone 2

--- a/packages/taquito-tzip16/src/taquito-tzip16.ts
+++ b/packages/taquito-tzip16/src/taquito-tzip16.ts
@@ -18,8 +18,8 @@ export * from './viewKind/viewFactory';
 export { VERSION } from './version';
 
 /**
- * @deprecated `import { bytes2Char, char2Bytes } from "@taquito/tzip16"` is deprecated in favor of
- * `import { bytes2Char, char2Bytes } from "@taquito/utils"`
+ * @deprecated `import { hexStringToByteString, byteStringToHexString } from "@taquito/tzip16"` is deprecated in favor of
+ * `import { hexStringToByteString, byteStringToHexString } from "@taquito/utils"`
  *
  */
-export { bytes2Char, char2Bytes } from '@taquito/utils';
+export { hexStringToByteString, byteStringToHexString } from '@taquito/utils';

--- a/packages/taquito-tzip16/src/taquito-tzip16.ts
+++ b/packages/taquito-tzip16/src/taquito-tzip16.ts
@@ -18,8 +18,8 @@ export * from './viewKind/viewFactory';
 export { VERSION } from './version';
 
 /**
- * @deprecated `import { hexStringToByteString, byteStringToHexString } from "@taquito/tzip16"` is deprecated in favor of
- * `import { hexStringToByteString, byteStringToHexString } from "@taquito/utils"`
+ * @deprecated `import { bytesToString, stringToBytes } from "@taquito/tzip16"` is deprecated in favor of
+ * `import { bytesToString, stringToBytes } from "@taquito/utils"`
  *
  */
-export { hexStringToByteString, byteStringToHexString } from '@taquito/utils';
+export { bytesToString, stringToBytes } from '@taquito/utils';

--- a/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
+++ b/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
@@ -6,7 +6,7 @@ import {
   ContractProvider,
   Wallet,
 } from '@taquito/taquito';
-import { bytes2Char } from '@taquito/utils';
+import { hexStringToByteString } from '@taquito/utils';
 import { MetadataEnvelope, MetadataProviderInterface } from './metadata-provider';
 import {
   BigMapContractMetadataNotFoundError,
@@ -78,7 +78,7 @@ export class Tzip16ContractAbstraction {
       const uri = await this.getUriOrFail();
       this._metadataEnvelope = await this._metadataProvider.provideMetadata(
         this.constractAbstraction,
-        bytes2Char(uri),
+        hexStringToByteString(uri),
         this.context
       );
     }

--- a/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
+++ b/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
@@ -6,7 +6,7 @@ import {
   ContractProvider,
   Wallet,
 } from '@taquito/taquito';
-import { hexStringToByteString } from '@taquito/utils';
+import { bytesToString } from '@taquito/utils';
 import { MetadataEnvelope, MetadataProviderInterface } from './metadata-provider';
 import {
   BigMapContractMetadataNotFoundError,
@@ -78,7 +78,7 @@ export class Tzip16ContractAbstraction {
       const uri = await this.getUriOrFail();
       this._metadataEnvelope = await this._metadataProvider.provideMetadata(
         this.constractAbstraction,
-        hexStringToByteString(uri),
+        bytesToString(uri),
         this.context
       );
     }

--- a/packages/taquito-utils/README.md
+++ b/packages/taquito-utils/README.md
@@ -135,15 +135,15 @@ console.log(isValid);
 
 **Conversion between hexadecimal and ASCII strings**
 ```ts
-import { char2Bytes, bytes2Char } from '@taquito/utils';
+import { byteStringToHexString, hexStringToByteString } from '@taquito/utils';
 
 const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
 const hex = '68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f747a69702d31362f6661322d76696577732e6a736f6e';
 
-console.log(char2Bytes(url));
+console.log(byteStringToHexString(url));
 // output: 68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f747a69702d31362f6661322d76696577732e6a736f6e
 
-console.log(bytes2Char(hex));
+console.log(hexStringToByteString(hex));
 // output: https://storage.googleapis.com/tzip-16/fa2-views.json
 ```
 

--- a/packages/taquito-utils/README.md
+++ b/packages/taquito-utils/README.md
@@ -135,15 +135,15 @@ console.log(isValid);
 
 **Conversion between hexadecimal and ASCII strings**
 ```ts
-import { byteStringToHexString, hexStringToByteString } from '@taquito/utils';
+import { stringToBytes, bytesToString } from '@taquito/utils';
 
 const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
 const hex = '68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f747a69702d31362f6661322d76696577732e6a736f6e';
 
-console.log(byteStringToHexString(url));
+console.log(stringToBytes(url));
 // output: 68747470733a2f2f73746f726167652e676f6f676c65617069732e636f6d2f747a69702d31362f6661322d76696577732e6a736f6e
 
-console.log(hexStringToByteString(hex));
+console.log(bytesToString(hex));
 // output: https://storage.googleapis.com/tzip-16/fa2-views.json
 ```
 
@@ -194,12 +194,12 @@ console.log(encodeKey('0060842d4ba23a9940ef5dcf4404fdaa430cfaaccb5029fad06cb5ea8
 
 **Base58 encode an address using a predefined prefix**
 ```ts
-import { encodePubKey } from '@taquito/utils'; 
+import { encodeAddress } from '@taquito/utils'; 
 
-console.log(encodePubKey('0000e96b9f8b19af9c7ffa0c0480e1977b295850961f'));
+console.log(encodeAddress('0000e96b9f8b19af9c7ffa0c0480e1977b295850961f'));
 // output: tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM
 
-console.log(encodePubKey('01f9b689a478253793bd92357c5e08e5ebcd8db47600'));
+console.log(encodeAddress('01f9b689a478253793bd92357c5e08e5ebcd8db47600'));
 // output: KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y
 ```
 

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -137,9 +137,9 @@ export function encodePubKey(value: string) {
 
 /**
  *
- * @description Base58 encode an address using predefined prefix (tz1, tz2, tz3). KT1 is not supported. When byte string has a 0x prefix, it will be removed.
+ * @description Base58 encode an address using predefined prefix (tz1, tz2, tz3, or KT1 without annotation)
  *
- * @param value Address to base58 encode (tz1, tz2, tz3 or KT1)
+ * @param value Address to base58 encode (tz1, tz2, tz3 or KT1). Supports value with or without '0x' prefix
  */
 export function encodeAddress(value: string) {
   if (value.substring(0, 2) === '0x') {

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -331,8 +331,19 @@ export const getPkhfromPk = (publicKey: string): string => {
  * @description Convert a string to bytes
  *
  * @param str String to convert
+ * @deprecated use byteStringToHexString instead, same functionality with a more descriptive name
  */
 export function char2Bytes(str: string) {
+  return Buffer.from(str, 'utf8').toString('hex');
+}
+
+/**
+ *
+ * @description Convert a byte string to a hex string representation
+ *
+ * @param str String to convert
+ */
+export function byteStringToHexString(str: string) {
   return Buffer.from(str, 'utf8').toString('hex');
 }
 
@@ -341,8 +352,19 @@ export function char2Bytes(str: string) {
  * @description Convert bytes to a string
  *
  * @param str Bytes to convert
+ * @deprecated use hexStringToBytes instead, same functionality with a more descriptive name
  */
 export function bytes2Char(hex: string): string {
+  return Buffer.from(hex2buf(hex)).toString('utf8');
+}
+
+/**
+ *
+ * @description Convert hex string representation to bytes
+ *
+ * @param str hex string to convert
+ */
+export function hexStringToByteString(hex: string): string {
   return Buffer.from(hex2buf(hex)).toString('utf8');
 }
 
@@ -370,6 +392,9 @@ export function hex2Bytes(hex: string): Buffer {
  * @param val The value  that will be converted to a hexadecimal string value
  */
 export function toHexBuf(val: number | BigNumber, bitLength = 8) {
+  return Buffer.from(num2PaddedHex(val, bitLength), 'hex');
+}
+export function numToHexBuffer(val: number | BigNumber, bitLength = 8) {
   return Buffer.from(num2PaddedHex(val, bitLength), 'hex');
 }
 

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -120,8 +120,28 @@ export function b58decodeL2Address(payload: string) {
  * @description Base58 encode an address using predefined prefix
  *
  * @param value Address to base58 encode (tz1, tz2, tz3 or KT1)
+ * @deprecated use encodeAddress instead, same functionality with a more descriptive name
  */
 export function encodePubKey(value: string) {
+  if (value.substring(0, 2) === '00') {
+    const pref: { [key: string]: Uint8Array } = {
+      '0000': prefix.tz1,
+      '0001': prefix.tz2,
+      '0002': prefix.tz3,
+    };
+
+    return b58cencode(value.substring(4), pref[value.substring(0, 4)]);
+  }
+  return b58cencode(value.substring(2, 42), prefix.KT);
+}
+
+/**
+ *
+ * @description Base58 encode an address using predefined prefix (tz1, tz2, tz3). KT1 is not supported.
+ *
+ * @param value Address to base58 encode (tz1, tz2, tz3 or KT1)
+ */
+export function encodeAddress(value: string) {
   if (value.substring(0, 2) === '00') {
     const pref: { [key: string]: Uint8Array } = {
       '0000': prefix.tz1,
@@ -331,7 +351,7 @@ export const getPkhfromPk = (publicKey: string): string => {
  * @description Convert a string to bytes
  *
  * @param str String to convert
- * @deprecated use byteStringToHexString instead, same functionality with a more descriptive name
+ * @deprecated use stringToBytes instead, same functionality with a more descriptive name
  */
 export function char2Bytes(str: string) {
   return Buffer.from(str, 'utf8').toString('hex');
@@ -339,11 +359,11 @@ export function char2Bytes(str: string) {
 
 /**
  *
- * @description Convert a byte string to a hex string representation
+ * @description Convert a string to a byte string representation
  *
  * @param str String to convert
  */
-export function byteStringToHexString(str: string) {
+export function stringToBytes(str: string) {
   return Buffer.from(str, 'utf8').toString('hex');
 }
 
@@ -360,11 +380,11 @@ export function bytes2Char(hex: string): string {
 
 /**
  *
- * @description Convert hex string representation to bytes
+ * @description Convert byte string representation to string
  *
- * @param str hex string to convert
+ * @param str byte string to convert
  */
-export function hexStringToByteString(hex: string): string {
+export function bytesToString(hex: string): string {
   return Buffer.from(hex2buf(hex)).toString('utf8');
 }
 

--- a/packages/taquito-utils/src/taquito-utils.ts
+++ b/packages/taquito-utils/src/taquito-utils.ts
@@ -137,11 +137,15 @@ export function encodePubKey(value: string) {
 
 /**
  *
- * @description Base58 encode an address using predefined prefix (tz1, tz2, tz3). KT1 is not supported.
+ * @description Base58 encode an address using predefined prefix (tz1, tz2, tz3). KT1 is not supported. When byte string has a 0x prefix, it will be removed.
  *
  * @param value Address to base58 encode (tz1, tz2, tz3 or KT1)
  */
 export function encodeAddress(value: string) {
+  if (value.substring(0, 2) === '0x') {
+    value = value.slice(2);
+  }
+
   if (value.substring(0, 2) === '00') {
     const pref: { [key: string]: Uint8Array } = {
       '0000': prefix.tz1,

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -1,6 +1,6 @@
 import { format } from '../src/format';
 import BigNumber from 'bignumber.js';
-import { hexStringToByteString, byteStringToHexString } from '../src/taquito-utils';
+import { bytesToString, stringToBytes } from '../src/taquito-utils';
 
 describe('Format', () => {
   it('Should convert mutez to tz', () => {
@@ -33,7 +33,7 @@ describe('tezostaquito.io example signing formatting', () => {
       'something',
     ].join(' ');
 
-    const bytes = byteStringToHexString(formattedInput);
+    const bytes = stringToBytes(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16);
     const addPadding = `00000000${bytesLength}`;
     const paddedBytesLength = addPadding.slice(addPadding.length - 8);
@@ -42,8 +42,8 @@ describe('tezostaquito.io example signing formatting', () => {
     const check = regex.test(payloadBytes);
     expect(check).toEqual(true);
     expect(payloadBytes.length % 2).toEqual(0);
-    expect(hexStringToByteString(payloadBytes)).toEqual(
-      hexStringToByteString('05' + '01' + paddedBytesLength) + formattedInput
+    expect(bytesToString(payloadBytes)).toEqual(
+      bytesToString('05' + '01' + paddedBytesLength) + formattedInput
     );
   });
 });

--- a/packages/taquito-utils/test/format.spec.ts
+++ b/packages/taquito-utils/test/format.spec.ts
@@ -1,6 +1,6 @@
 import { format } from '../src/format';
 import BigNumber from 'bignumber.js';
-import { bytes2Char, char2Bytes } from '../src/taquito-utils';
+import { hexStringToByteString, byteStringToHexString } from '../src/taquito-utils';
 
 describe('Format', () => {
   it('Should convert mutez to tz', () => {
@@ -22,7 +22,6 @@ describe('Format', () => {
   it('Should convert tz to mutez', () => {
     expect(format('tz', 'mutez', 1)).toEqual(new BigNumber(1000000));
   });
-
 });
 
 describe('tezostaquito.io example signing formatting', () => {
@@ -34,7 +33,7 @@ describe('tezostaquito.io example signing formatting', () => {
       'something',
     ].join(' ');
 
-    const bytes = char2Bytes(formattedInput);
+    const bytes = byteStringToHexString(formattedInput);
     const bytesLength = (bytes.length / 2).toString(16);
     const addPadding = `00000000${bytesLength}`;
     const paddedBytesLength = addPadding.slice(addPadding.length - 8);
@@ -43,6 +42,8 @@ describe('tezostaquito.io example signing formatting', () => {
     const check = regex.test(payloadBytes);
     expect(check).toEqual(true);
     expect(payloadBytes.length % 2).toEqual(0);
-    expect(bytes2Char(payloadBytes)).toEqual(bytes2Char('05' + '01' + paddedBytesLength) + formattedInput);
+    expect(hexStringToByteString(payloadBytes)).toEqual(
+      hexStringToByteString('05' + '01' + paddedBytesLength) + formattedInput
+    );
   });
 });

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -1,12 +1,12 @@
 import {
   encodeExpr,
-  byteStringToHexString,
-  hexStringToByteString,
+  stringToBytes,
+  bytesToString,
   encodeOpHash,
   getPkhfromPk,
   encodeKeyHash,
   encodeKey,
-  encodePubKey,
+  encodeAddress,
   b58cdecode,
   prefix,
   Prefix,
@@ -27,27 +27,27 @@ describe('Encode expr', () => {
   });
 });
 
-describe('encodePubKey', () => {
+describe('encodeAddress', () => {
   it('Should encode address properly (tz1)', () => {
-    expect(encodePubKey('0000e96b9f8b19af9c7ffa0c0480e1977b295850961f')).toEqual(
+    expect(encodeAddress('0000e96b9f8b19af9c7ffa0c0480e1977b295850961f')).toEqual(
       'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM'
     );
   });
 
   it('Should encode address properly (tz2)', () => {
-    expect(encodePubKey('0001907d6a7e9f084df840d6e67ffa8db5464f87d4d1')).toEqual(
+    expect(encodeAddress('0001907d6a7e9f084df840d6e67ffa8db5464f87d4d1')).toEqual(
       'tz2MVED1t9Jery77Bwm1m5YhUx8Wp5KWWRQe'
     );
   });
 
   it('Should encode address properly (tz3)', () => {
-    expect(encodePubKey('00022165a26786121eff8203bed56ffaf85d6bb25e42')).toEqual(
+    expect(encodeAddress('00022165a26786121eff8203bed56ffaf85d6bb25e42')).toEqual(
       'tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1'
     );
   });
 
   it('Should encode address properly (KT1)', () => {
-    expect(encodePubKey('01f9b689a478253793bd92357c5e08e5ebcd8db47600')).toEqual(
+    expect(encodeAddress('01f9b689a478253793bd92357c5e08e5ebcd8db47600')).toEqual(
       'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y'
     );
   });
@@ -112,63 +112,59 @@ describe('sapling keys', () => {
 describe('String/Bytes conversions', () => {
   it('Should convert a string to bytes', () => {
     // I used the result from http://string-functions.com/string-hex.aspx for the test
-    expect(byteStringToHexString('Taquito is awesome!')).toEqual(
-      '5461717569746f20697320617765736f6d6521'
-    );
+    expect(stringToBytes('Taquito is awesome!')).toEqual('5461717569746f20697320617765736f6d6521');
   });
 
   it('Should convert bytes to string', () => {
-    expect(hexStringToByteString('5461717569746f20697320617765736f6d6521')).toEqual(
-      'Taquito is awesome!'
-    );
+    expect(bytesToString('5461717569746f20697320617765736f6d6521')).toEqual('Taquito is awesome!');
   });
 
   it('Test1: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'http:';
     const bytes = '687474703a';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 
   it('Test2: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'tezos-storage:contents';
     const bytes = '74657a6f732d73746f726167653a636f6e74656e7473';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 
   it('Test3: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'tezos-storage:here';
     const bytes = '74657a6f732d73746f726167653a68657265';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 
   it('Test4: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = `{"version":"tzcomet-example v0.0.42"}`;
     const bytes = '7b2276657273696f6e223a22747a636f6d65742d6578616d706c652076302e302e3432227d';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 
   it('Test5: Should convert a string of char (utf-8) with Emoji to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'Test 😀, 🤣 & 💰';
     const bytes = '5465737420f09f98802c20f09fa4a3202620f09f92b0';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 
   it('Test6: Should convert a string of char (utf-8) with naughty string to a string of bytes, and convert it back to the same string of char', () => {
     const charString = '¯_(ツ)_/¯';
     const bytes = 'c2af5f28e38384295f2fc2af';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 
   it('Test7: Should convert a string of char (utf-8) with naughty string to a string of bytes, and convert it back to the same string of char', () => {
@@ -176,8 +172,8 @@ describe('String/Bytes conversions', () => {
     const bytes =
       'f09d958bf09d9599f09d959620f09d95a2f09d95a6f09d959af09d9594f09d959c20f09d9593f09d95a3f09d95a0f09d95a8f09d959f20f09d9597f09d95a0f09d95a920f09d959bf09d95a6f09d959ef09d95a1f09d95a420f09d95a0f09d95a7f09d9596f09d95a320f09d95a5f09d9599f09d959620f09d959df09d9592f09d95abf09d95aa20f09d9595f09d95a0f09d9598';
 
-    expect(byteStringToHexString(charString)).toEqual(bytes);
-    expect(hexStringToByteString(bytes)).toEqual(charString);
+    expect(stringToBytes(charString)).toEqual(bytes);
+    expect(bytesToString(bytes)).toEqual(charString);
   });
 });
 

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -51,6 +51,24 @@ describe('encodeAddress', () => {
       'KT1XM8VUFBiM9AC5czWU15fEeE9nmuEYWt3Y'
     );
   });
+
+  it('should encode address properly when the bytes have a 0x prefix (tz3)', () => {
+    expect(encodeAddress('0x0000e96b9f8b19af9c7ffa0c0480e1977b295850961f')).toEqual(
+      'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM'
+    );
+  });
+
+  it('should encode address properly when the bytes have a 0x prefix (tz3)', () => {
+    expect(encodeAddress('0x0001907d6a7e9f084df840d6e67ffa8db5464f87d4d1')).toEqual(
+      'tz2MVED1t9Jery77Bwm1m5YhUx8Wp5KWWRQe'
+    );
+  });
+
+  it('should encode address properly when the bytes have a 0x prefix (tz3)', () => {
+    expect(encodeAddress('0x00022165a26786121eff8203bed56ffaf85d6bb25e42')).toEqual(
+      'tz3PNdfg3Fc8hH4m9iSs7bHgDgugsufJnBZ1'
+    );
+  });
 });
 
 describe('encodeKey', () => {

--- a/packages/taquito-utils/test/taquito-utils.spec.ts
+++ b/packages/taquito-utils/test/taquito-utils.spec.ts
@@ -1,7 +1,7 @@
 import {
   encodeExpr,
-  char2Bytes,
-  bytes2Char,
+  byteStringToHexString,
+  hexStringToByteString,
   encodeOpHash,
   getPkhfromPk,
   encodeKeyHash,
@@ -112,59 +112,63 @@ describe('sapling keys', () => {
 describe('String/Bytes conversions', () => {
   it('Should convert a string to bytes', () => {
     // I used the result from http://string-functions.com/string-hex.aspx for the test
-    expect(char2Bytes('Taquito is awesome!')).toEqual('5461717569746f20697320617765736f6d6521');
+    expect(byteStringToHexString('Taquito is awesome!')).toEqual(
+      '5461717569746f20697320617765736f6d6521'
+    );
   });
 
   it('Should convert bytes to string', () => {
-    expect(bytes2Char('5461717569746f20697320617765736f6d6521')).toEqual('Taquito is awesome!');
+    expect(hexStringToByteString('5461717569746f20697320617765736f6d6521')).toEqual(
+      'Taquito is awesome!'
+    );
   });
 
   it('Test1: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'http:';
     const bytes = '687474703a';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 
   it('Test2: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'tezos-storage:contents';
     const bytes = '74657a6f732d73746f726167653a636f6e74656e7473';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 
   it('Test3: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'tezos-storage:here';
     const bytes = '74657a6f732d73746f726167653a68657265';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 
   it('Test4: Should convert a string of char (utf-8) to a string of bytes, and convert it back to the same string of char', () => {
     const charString = `{"version":"tzcomet-example v0.0.42"}`;
     const bytes = '7b2276657273696f6e223a22747a636f6d65742d6578616d706c652076302e302e3432227d';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 
   it('Test5: Should convert a string of char (utf-8) with Emoji to a string of bytes, and convert it back to the same string of char', () => {
     const charString = 'Test 😀, 🤣 & 💰';
     const bytes = '5465737420f09f98802c20f09fa4a3202620f09f92b0';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 
   it('Test6: Should convert a string of char (utf-8) with naughty string to a string of bytes, and convert it back to the same string of char', () => {
     const charString = '¯_(ツ)_/¯';
     const bytes = 'c2af5f28e38384295f2fc2af';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 
   it('Test7: Should convert a string of char (utf-8) with naughty string to a string of bytes, and convert it back to the same string of char', () => {
@@ -172,8 +176,8 @@ describe('String/Bytes conversions', () => {
     const bytes =
       'f09d958bf09d9599f09d959620f09d95a2f09d95a6f09d959af09d9594f09d959c20f09d9593f09d95a3f09d95a0f09d95a8f09d959f20f09d9597f09d95a0f09d95a920f09d959bf09d95a6f09d959ef09d95a1f09d95a420f09d95a0f09d95a7f09d9596f09d95a320f09d95a5f09d9599f09d959620f09d959df09d9592f09d95abf09d95aa20f09d9595f09d95a0f09d9598';
 
-    expect(char2Bytes(charString)).toEqual(bytes);
-    expect(bytes2Char(bytes)).toEqual(charString);
+    expect(byteStringToHexString(charString)).toEqual(bytes);
+    expect(hexStringToByteString(bytes)).toEqual(charString);
   });
 });
 


### PR DESCRIPTION
closes:
- #2372 
- #2274 

changes: 
- updated `bytes2char()` into `hexStringToByteString()`
- updated `char2bytes()` into `byteStringToHexString()`
- marked `char2bytes()` and `bytes2char()` as deprecated
- change `encodePubKey` name into `encodeAddress`
- updated `encodeAddress` (previously encodePubKey) to strip `0x` prefix in parameters

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [x] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
