### PR TITLE
fix: the idx of a `pair` inside `or` inside `pair` is not calculated correctly

### DIFF
--- a/integration-tests/__tests__/contract/no-annotations-call-by-index-methodsObject.spec.ts
+++ b/integration-tests/__tests__/contract/no-annotations-call-by-index-methodsObject.spec.ts
@@ -53,8 +53,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       // Approve
       const operation2 = await contract.methodsObject[APPROVE]({
-        2: ACCOUNT2_ADDRESS,
-        3: "1"
+        0: ACCOUNT2_ADDRESS,
+        1: "1"
       }).send();
 
       await operation2.confirmation();

--- a/integration-tests/__tests__/contract/no-annotations-call-by-index-methodsObject.spec.ts
+++ b/integration-tests/__tests__/contract/no-annotations-call-by-index-methodsObject.spec.ts
@@ -23,6 +23,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
     const ACCOUNT2_ADDRESS = 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu'
     
+    // Runs the entire tests for a given fieldNumberingStrategy
     const testContract = (strategy: FieldNumberingStrategy, innerObjectStartingIndex: number) => {
       it(`Verify contract.originate for a contract with no annotations for methods using methodObjects with fieldNumberingStrategy: ${strategy}`, async () => {
         Tezos.setFieldNumberingStrategy(strategy);
@@ -69,6 +70,8 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
         expect(account1[ALLOWANCES].get(ACCOUNT2_ADDRESS).toString()).toEqual('1')
       });
     };
+    
+    // Run the tests for all fieldNumberingStrategies
     testContract('Legacy', 2);
     testContract('ResetFieldNumbersInNestedObjects', 0);
     testContract('Latest', 0);

--- a/integration-tests/__tests__/contract/no-annotations-call-by-index-methodsObject.spec.ts
+++ b/integration-tests/__tests__/contract/no-annotations-call-by-index-methodsObject.spec.ts
@@ -1,3 +1,4 @@
+import { FieldNumberingStrategy } from "@taquito/michelson-encoder";
 import { CONFIGS } from "../../config";
 import { noAnnotCode, noAnnotInit } from "../../data/token_without_annotation";
 
@@ -10,59 +11,67 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     beforeEach(async () => {
       await setup()
     })
-    it('Verify contract.originate for a contract with no annotations for methods using methodObjects', async () => {
-      // Constants to replace annotations
-      const ACCOUNTS = '0';
-      const BALANCE = '0';
-      const ALLOWANCES = '1';
-      const TRANSFER = '0';
-      const APPROVE = '2';
 
-      // Actual tests
+    // Constants to replace annotations
+    const ACCOUNTS = '0';
+    const BALANCE = '0';
+    const ALLOWANCES = '1';
+    const TRANSFER = '0';
+    const APPROVE = '2';
 
-      const ACCOUNT1_ADDRESS = await Tezos.signer.publicKeyHash()
-      const ACCOUNT2_ADDRESS = 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu'
+    // Actual tests
 
-      // Originate a contract with a known state
-      const op = await Tezos.contract.originate({
-        balance: "1",
-        code: noAnnotCode,
-        init: noAnnotInit(await Tezos.signer.publicKeyHash())
-      })
-      await op.confirmation()
-      const contract = await op.contract()
+    const ACCOUNT2_ADDRESS = 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu'
+    
+    const testContract = (strategy: FieldNumberingStrategy, innerObjectStartingIndex: number) => {
+      it(`Verify contract.originate for a contract with no annotations for methods using methodObjects with fieldNumberingStrategy: ${strategy}`, async () => {
+        Tezos.setFieldNumberingStrategy(strategy);
+        const ACCOUNT1_ADDRESS = await Tezos.signer.publicKeyHash()
+        // Originate a contract with a known state
+        const op = await Tezos.contract.originate({
+          balance: "1",
+          code: noAnnotCode,
+          init: noAnnotInit(await Tezos.signer.publicKeyHash())
+        })
+        await op.confirmation()
+        const contract = await op.contract()
 
-      // Make a transfer
+        // Make a transfer
 
-      const operation = await contract.methodsObject[TRANSFER]({
-        0: ACCOUNT1_ADDRESS,
-        1: ACCOUNT2_ADDRESS,
-        2: "1"
-      }).send();
+        const operation = await contract.methodsObject[TRANSFER]({
+          0: ACCOUNT1_ADDRESS,
+          1: ACCOUNT2_ADDRESS,
+          2: "1"
+        }).send();
 
-      await operation.confirmation();
-      expect(operation.status).toEqual('applied')
+        await operation.confirmation();
+        expect(operation.status).toEqual('applied')
 
-      // Verify that the transfer was done as expected
-      const storage = await contract.storage<any>()
-      let account1 = await storage[ACCOUNTS].get(ACCOUNT1_ADDRESS)
-      expect(account1[BALANCE].toString()).toEqual('16')
+        // Verify that the transfer was done as expected
+        const storage = await contract.storage<any>()
+        let account1 = await storage[ACCOUNTS].get(ACCOUNT1_ADDRESS)
+        expect(account1[BALANCE].toString()).toEqual('16')
 
-      const account2 = await storage[ACCOUNTS].get(ACCOUNT2_ADDRESS)
-      expect(account2[BALANCE].toString()).toEqual('1')
+        const account2 = await storage[ACCOUNTS].get(ACCOUNT2_ADDRESS)
+        expect(account2[BALANCE].toString()).toEqual('1')
 
-      // Approve
-      const operation2 = await contract.methodsObject[APPROVE]({
-        0: ACCOUNT2_ADDRESS,
-        1: "1"
-      }).send();
+        // Approve
+        const operation2 = await contract.methodsObject[APPROVE]({
+          [innerObjectStartingIndex]: ACCOUNT2_ADDRESS,
+          [innerObjectStartingIndex + 1]: "1"
+        }).send();
 
-      await operation2.confirmation();
-      expect(operation2.status).toEqual('applied')
+        await operation2.confirmation();
+        expect(operation2.status).toEqual('applied')
 
-      // Verify that the allowance was done as expected
-      account1 = await storage[ACCOUNTS].get(ACCOUNT1_ADDRESS)
-      expect(account1[ALLOWANCES].get(ACCOUNT2_ADDRESS).toString()).toEqual('1')
-    })
+        // Verify that the allowance was done as expected
+        account1 = await storage[ACCOUNTS].get(ACCOUNT1_ADDRESS)
+        expect(account1[ALLOWANCES].get(ACCOUNT2_ADDRESS).toString()).toEqual('1')
+      });
+    };
+    testContract('Legacy', 2);
+    testContract('ResetFieldNumbersInNestedObjects', 0);
+    testContract('Latest', 0);
+
   });
-})
+});

--- a/packages/taquito-michelson-encoder/src/taquito-michelson-encoder.ts
+++ b/packages/taquito-michelson-encoder/src/taquito-michelson-encoder.ts
@@ -16,4 +16,4 @@ export const UnitValue = Symbol();
 export const SaplingStateValue = {};
 export * from './michelson-map';
 export { VERSION } from './version';
-export { Token } from './tokens/token';
+export { FieldNumberingStrategy, Token } from './tokens/token';

--- a/packages/taquito-michelson-encoder/src/tokens/createToken.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/createToken.ts
@@ -9,7 +9,10 @@ import { TaquitoError } from '@taquito/core';
  */
 export class InvalidTokenError extends TaquitoError {
   name = 'Invalid token error';
-  constructor(public message: string, public data: any) {
+  constructor(
+    public message: string,
+    public data: any
+  ) {
     super(message);
   }
 }
@@ -19,9 +22,13 @@ export class InvalidTokenError extends TaquitoError {
  * @description Create a token from a value
  * @throws {@link InvalidTokenError} If the value passed is not supported by the Michelson Encoder
  */
-export function createToken(val: any, idx: number): Token {
+export function createToken(
+  val: any,
+  idx: number,
+  parentTokenType?: 'Or' | 'Pair' | 'Other' | undefined
+): Token {
   if (Array.isArray(val)) {
-    return new PairToken(val, idx, createToken);
+    return new PairToken(val, idx, createToken, parentTokenType);
   }
 
   const t = tokens.find((x) => x.prim === val.prim);
@@ -31,5 +38,5 @@ export function createToken(val: any, idx: number): Token {
       val
     );
   }
-  return new t(val, idx, createToken);
+  return new t(val, idx, createToken, parentTokenType);
 }

--- a/packages/taquito-michelson-encoder/src/tokens/or.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/or.ts
@@ -38,13 +38,17 @@ export class OrToken extends ComparableToken {
   public Encode(args: any[]): any {
     const label = args[args.length - 1];
 
-    const leftToken = this.createToken(this.val.args[0], this.getIdx(), 'Or');
+    const leftToken = this.createToken(this.val.args[0], this.getIdxForChildren(), 'Or');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
 
-    const rightToken = this.createToken(this.val.args[1], this.getIdx() + keyCount, 'Or');
+    const rightToken = this.createToken(
+      this.val.args[1],
+      this.getIdxForChildren() + keyCount,
+      'Or'
+    );
 
     if (String(leftToken.annot()) === String(label) && !(leftToken instanceof OrToken)) {
       args.pop();
@@ -71,13 +75,17 @@ export class OrToken extends ComparableToken {
   }
 
   public ExtractSignature(): any {
-    const leftToken = this.createToken(this.val.args[0], this.getIdx(), 'Or');
+    const leftToken = this.createToken(this.val.args[0], this.getIdxForChildren(), 'Or');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
 
-    const rightToken = this.createToken(this.val.args[1], this.getIdx() + keyCount, 'Or');
+    const rightToken = this.createToken(
+      this.val.args[1],
+      this.getIdxForChildren() + keyCount,
+      'Or'
+    );
 
     const newSig = [];
 
@@ -107,13 +115,17 @@ export class OrToken extends ComparableToken {
     this.validateJavascriptObject(args);
     const label = Object.keys(args)[0];
 
-    const leftToken = this.createToken(this.val.args[0], this.getIdx(), 'Or');
+    const leftToken = this.createToken(this.val.args[0], this.getIdxForChildren(), 'Or');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
 
-    const rightToken = this.createToken(this.val.args[1], this.getIdx() + keyCount, 'Or');
+    const rightToken = this.createToken(
+      this.val.args[1],
+      this.getIdxForChildren() + keyCount,
+      'Or'
+    );
 
     if (String(leftToken.annot()) === String(label) && !(leftToken instanceof OrToken)) {
       return { prim: 'Left', args: [leftToken.EncodeObject(args[label], semantic)] };
@@ -159,12 +171,16 @@ export class OrToken extends ComparableToken {
    * @throws {@link OrValidationError}
    */
   public Execute(val: any, semantics?: Semantic): any {
-    const leftToken = this.createToken(this.val.args[0], this.getIdx(), 'Or');
+    const leftToken = this.createToken(this.val.args[0], this.getIdxForChildren(), 'Or');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
-    const rightToken = this.createToken(this.val.args[1], this.getIdx() + keyCount, 'Or');
+    const rightToken = this.createToken(
+      this.val.args[1],
+      this.getIdxForChildren() + keyCount,
+      'Or'
+    );
 
     if (val.prim === 'Right') {
       if (rightToken instanceof OrToken) {
@@ -195,7 +211,7 @@ export class OrToken extends ComparableToken {
     getRightValue: (token: Token) => any,
     concat: (left: any, right: any) => any
   ) {
-    const leftToken = this.createToken(this.val.args[0], this.getIdx(), 'Or');
+    const leftToken = this.createToken(this.val.args[0], this.getIdxForChildren(), 'Or');
     let keyCount = 1;
     let leftValue;
     if (leftToken instanceof OrToken) {
@@ -205,7 +221,11 @@ export class OrToken extends ComparableToken {
       leftValue = { [leftToken.annot()]: getLeftValue(leftToken) };
     }
 
-    const rightToken = this.createToken(this.val.args[1], this.getIdx() + keyCount, 'Or');
+    const rightToken = this.createToken(
+      this.val.args[1],
+      this.getIdxForChildren() + keyCount,
+      'Or'
+    );
     let rightValue;
     if (rightToken instanceof OrToken) {
       rightValue = getRightValue(rightToken);
@@ -260,13 +280,17 @@ export class OrToken extends ComparableToken {
   }
 
   private findToken(label: any): Token | null {
-    const leftToken = this.createToken(this.val.args[0], this.getIdx(), 'Or');
+    const leftToken = this.createToken(this.val.args[0], this.getIdxForChildren(), 'Or');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
 
-    const rightToken = this.createToken(this.val.args[1], this.getIdx() + keyCount, 'Or');
+    const rightToken = this.createToken(
+      this.val.args[1],
+      this.getIdxForChildren() + keyCount,
+      'Or'
+    );
 
     if (
       String(leftToken.annot()) === String(label) &&
@@ -340,7 +364,10 @@ export class OrToken extends ComparableToken {
     return tokens;
   }
 
-  protected getIdx(): number {
+  protected getIdxForChildren(): number {
+    if (Token.fieldNumberingStrategy === 'Legacy') {
+      return this.idx;
+    }
     return this.parentTokenType === 'Or' ? this.idx : 0;
   }
 }

--- a/packages/taquito-michelson-encoder/src/tokens/pair.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/pair.ts
@@ -97,7 +97,7 @@ export class PairToken extends ComparableToken {
   private tokens(): [Token, Token] {
     let cnt = 0;
     return this.args().map((a) => {
-      const tok = this.createToken(a, this.getIdx() + cnt, 'Pair');
+      const tok = this.createToken(a, this.getIdxForChildren() + cnt, 'Pair');
       if (tok instanceof PairToken) {
         cnt += Object.keys(tok.ExtractSchema()).length;
       } else {
@@ -116,13 +116,13 @@ export class PairToken extends ComparableToken {
 
   public ExtractSignature(): any {
     const args = this.args();
-    const leftToken = this.createToken(args[0], this.getIdx(), 'Pair');
+    const leftToken = this.createToken(args[0], this.getIdxForChildren(), 'Pair');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
 
-    const rightToken = this.createToken(args[1], this.getIdx() + keyCount, 'Pair');
+    const rightToken = this.createToken(args[1], this.getIdxForChildren() + keyCount, 'Pair');
 
     const newSig = [];
 
@@ -175,7 +175,7 @@ export class PairToken extends ComparableToken {
   private traversal(getLeftValue: (token: Token) => any, getRightValue: (token: Token) => any) {
     const args = this.args();
 
-    const leftToken = this.createToken(args[0], this.getIdx(), 'Pair');
+    const leftToken = this.createToken(args[0], this.getIdxForChildren(), 'Pair');
     let keyCount = 1;
     let leftValue;
     if (leftToken instanceof PairToken && !leftToken.hasAnnotations()) {
@@ -187,7 +187,7 @@ export class PairToken extends ComparableToken {
       leftValue = { [leftToken.annot()]: getLeftValue(leftToken) };
     }
 
-    const rightToken = this.createToken(args[1], this.getIdx() + keyCount, 'Pair');
+    const rightToken = this.createToken(args[1], this.getIdxForChildren() + keyCount, 'Pair');
     let rightValue;
     if (rightToken instanceof PairToken && !rightToken.hasAnnotations()) {
       rightValue = getRightValue(rightToken);
@@ -282,7 +282,10 @@ export class PairToken extends ComparableToken {
     return tokens;
   }
 
-  protected getIdx(): number {
+  protected getIdxForChildren(): number {
+    if (Token.fieldNumberingStrategy === 'Legacy') {
+      return this.idx;
+    }
     return this.parentTokenType === 'Pair' ? this.idx : 0;
   }
 }

--- a/packages/taquito-michelson-encoder/src/tokens/pair.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/pair.ts
@@ -65,7 +65,12 @@ function collapse(val: Token['val'] | any[], prim: string = PairToken.prim): [an
 export class PairToken extends ComparableToken {
   static prim: 'pair' = 'pair' as const;
 
-  constructor(val: MichelsonV1Expression, idx: number, fac: TokenFactory) {
+  constructor(
+    val: MichelsonV1Expression,
+    idx: number,
+    fac: TokenFactory,
+    parentTokenType?: 'Or' | 'Pair' | 'Other' | undefined
+  ) {
     super(
       Array.isArray(val)
         ? {
@@ -73,13 +78,14 @@ export class PairToken extends ComparableToken {
             args: val,
           }
         : (val as MichelsonV1ExpressionExtended).prim
-        ? (val as MichelsonV1ExpressionExtended)
-        : ({
-            prim: PairToken.prim,
-            args: val,
-          } as MichelsonV1ExpressionExtended),
+          ? (val as MichelsonV1ExpressionExtended)
+          : ({
+              prim: PairToken.prim,
+              args: val,
+            } as MichelsonV1ExpressionExtended),
       idx,
-      fac
+      fac,
+      parentTokenType
     );
   }
 
@@ -91,7 +97,7 @@ export class PairToken extends ComparableToken {
   private tokens(): [Token, Token] {
     let cnt = 0;
     return this.args().map((a) => {
-      const tok = this.createToken(a, this.idx + cnt);
+      const tok = this.createToken(a, this.getIdx() + cnt, 'Pair');
       if (tok instanceof PairToken) {
         cnt += Object.keys(tok.ExtractSchema()).length;
       } else {
@@ -110,13 +116,13 @@ export class PairToken extends ComparableToken {
 
   public ExtractSignature(): any {
     const args = this.args();
-    const leftToken = this.createToken(args[0], this.idx);
+    const leftToken = this.createToken(args[0], this.getIdx(), 'Pair');
     let keyCount = 1;
     if (leftToken instanceof OrToken) {
       keyCount = Object.keys(leftToken.ExtractSchema()).length;
     }
 
-    const rightToken = this.createToken(args[1], this.idx + keyCount);
+    const rightToken = this.createToken(args[1], this.getIdx() + keyCount, 'Pair');
 
     const newSig = [];
 
@@ -169,7 +175,7 @@ export class PairToken extends ComparableToken {
   private traversal(getLeftValue: (token: Token) => any, getRightValue: (token: Token) => any) {
     const args = this.args();
 
-    const leftToken = this.createToken(args[0], this.idx);
+    const leftToken = this.createToken(args[0], this.getIdx(), 'Pair');
     let keyCount = 1;
     let leftValue;
     if (leftToken instanceof PairToken && !leftToken.hasAnnotations()) {
@@ -181,7 +187,7 @@ export class PairToken extends ComparableToken {
       leftValue = { [leftToken.annot()]: getLeftValue(leftToken) };
     }
 
-    const rightToken = this.createToken(args[1], this.idx + keyCount);
+    const rightToken = this.createToken(args[1], this.getIdx() + keyCount, 'Pair');
     let rightValue;
     if (rightToken instanceof PairToken && !rightToken.hasAnnotations()) {
       rightValue = getRightValue(rightToken);
@@ -274,5 +280,9 @@ export class PairToken extends ComparableToken {
     }
     this.tokens().map((t) => t.findAndReturnTokens(tokenToFind, tokens));
     return tokens;
+  }
+
+  protected getIdx(): number {
+    return this.parentTokenType === 'Pair' ? this.idx : 0;
   }
 }

--- a/packages/taquito-michelson-encoder/src/tokens/token.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/token.ts
@@ -9,7 +9,11 @@ import { TaquitoError } from '@taquito/core';
 export abstract class TokenValidationError extends TaquitoError {
   name = 'TokenValidationError';
 
-  constructor(public readonly value: any, public readonly token: Token, baseMessage: string) {
+  constructor(
+    public readonly value: any,
+    public readonly token: Token,
+    baseMessage: string
+  ) {
     super();
     const annot = this.token.annot();
     const annotText = annot ? `[${annot}] ` : '';
@@ -17,7 +21,11 @@ export abstract class TokenValidationError extends TaquitoError {
   }
 }
 
-export type TokenFactory = (val: any, idx: number) => Token;
+export type TokenFactory = (
+  val: any,
+  idx: number,
+  parentTokenType?: 'Or' | 'Pair' | 'Other'
+) => Token;
 
 export interface Semantic {
   [key: string]: (value: MichelsonV1Expression, schema: MichelsonV1Expression) => any;
@@ -31,7 +39,8 @@ export abstract class Token {
   constructor(
     protected val: MichelsonV1ExpressionExtended,
     protected idx: number,
-    protected fac: TokenFactory
+    protected fac: TokenFactory,
+    protected parentTokenType?: 'Or' | 'Pair' | 'Other'
   ) {}
 
   protected typeWithoutAnnotations() {

--- a/packages/taquito-michelson-encoder/src/tokens/token.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/token.ts
@@ -35,7 +35,31 @@ export interface SemanticEncoding {
   [key: string]: (value: any, type?: MichelsonV1Expression) => MichelsonV1Expression;
 }
 
+/**
+ * @description Possible strategies for mapping between javascript classes and Michelson values
+ * Legacy: The old behaviour: { annot1: 'some value', annot2: 'other Value', annot3: { 2: 'yet another value', 3: 'also some value' }}
+ * ResetFieldNumbersInNestedObjects: { annot1: 'some value', annot2: 'other Value', annot3: { 0: 'yet another value', 1: 'also some value' }}
+ * Latest: This will include new changes as we might implement in the future. This is the suggested value if it does not break your code
+ */
+export type FieldNumberingStrategy = 'Legacy' | 'ResetFieldNumbersInNestedObjects' | 'Latest';
+
 export abstract class Token {
+  private static _fieldNumberingStrategy: FieldNumberingStrategy = 'Latest';
+
+  /**
+   * @description Gets the strategy used for field numbering in Token execute/encode/decode to convert Michelson values to/from javascript objects, returns a value of type {@link FieldNumberingStrategy} that controls how field numbers are calculated
+   */
+  static get fieldNumberingStrategy() {
+    return Token._fieldNumberingStrategy;
+  }
+
+  /**
+   * @description Sets the strategy used for field numbering in Token execute/encode/decode to convert Michelson values to/from javascript objects, accepts a value of type {@link FieldNumberingStrategy} that controls how field numbers are calculated
+   */
+  static set fieldNumberingStrategy(value: FieldNumberingStrategy) {
+    Token._fieldNumberingStrategy = value;
+  }
+
   constructor(
     protected val: MichelsonV1ExpressionExtended,
     protected idx: number,

--- a/packages/taquito-michelson-encoder/test/sample1.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample1.spec.ts
@@ -4,6 +4,7 @@ import { ParameterSchema } from '../src/schema/parameter';
 import { Schema } from '../src/schema/storage';
 import { MichelsonMap } from '../src/michelson-map';
 import { expectMichelsonMap } from './utils';
+import { Token } from '../src/taquito-michelson-encoder';
 
 describe('Schema test', () => {
   it('Should extract schema properly', () => {
@@ -202,8 +203,41 @@ describe('Schema test', () => {
 
   it('Should build parameter schema properly', () => {
     const schema = new ParameterSchema(params);
-    const s = schema.ExtractSchema();
-    expect(s).toEqual({
+    const extractSchema_Legacy = {
+      allowance: {
+        '4': 'address',
+        '5': 'address',
+        NatNatContract: 'contract',
+      },
+      approve: {
+        '1': 'address',
+        '2': 'nat',
+      },
+      balanceOf: {
+        '3': 'address',
+        NatContract: 'contract',
+      },
+      createAccount: {
+        '5': 'address',
+        '6': 'nat',
+      },
+      createAccounts: {
+        list: {
+          '6': 'address',
+          '7': 'nat',
+        },
+      },
+      transfer: {
+        '0': 'address',
+        '1': 'nat',
+      },
+      transferFrom: {
+        '2': 'address',
+        '3': 'address',
+        '4': 'nat',
+      },
+    };
+    const extractSchema_ResetFields = {
       allowance: {
         '0': 'address',
         '1': 'address',
@@ -236,9 +270,136 @@ describe('Schema test', () => {
         '1': 'address',
         '2': 'nat',
       },
-    });
+    };
 
-    expect(schema.generateSchema()).toEqual({
+    const generateSchema_Legacy = {
+      __michelsonType: 'or',
+      schema: {
+        allowance: {
+          __michelsonType: 'pair',
+          schema: {
+            '4': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '5': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            NatNatContract: {
+              __michelsonType: 'contract',
+              schema: {
+                parameter: {
+                  __michelsonType: 'pair',
+                  schema: {
+                    '0': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '1': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        approve: {
+          __michelsonType: 'pair',
+          schema: {
+            '1': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '2': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
+        },
+        balanceOf: {
+          __michelsonType: 'pair',
+          schema: {
+            '3': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            NatContract: {
+              __michelsonType: 'contract',
+              schema: {
+                parameter: {
+                  __michelsonType: 'nat',
+                  schema: 'nat',
+                },
+              },
+            },
+          },
+        },
+        createAccount: {
+          __michelsonType: 'pair',
+          schema: {
+            '5': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '6': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
+        },
+        createAccounts: {
+          __michelsonType: 'list',
+          schema: {
+            __michelsonType: 'pair',
+            schema: {
+              '6': {
+                __michelsonType: 'address',
+                schema: 'address',
+              },
+              '7': {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+            },
+          },
+        },
+        transfer: {
+          __michelsonType: 'pair',
+          schema: {
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '1': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
+        },
+        transferFrom: {
+          __michelsonType: 'pair',
+          schema: {
+            '2': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '3': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '4': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
+        },
+      },
+    };
+
+    const generateSchema_ResetFields = {
       __michelsonType: 'or',
       schema: {
         allowance: {
@@ -363,7 +524,17 @@ describe('Schema test', () => {
           },
         },
       },
-    });
+    };
+
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_Legacy);
+    expect(schema.generateSchema()).toEqual(generateSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
   });
 
   it('Should extract signature properly', () => {
@@ -373,14 +544,29 @@ describe('Schema test', () => {
     expect(sig).toContainEqual(['approve', 'address', 'nat']);
     expect(sig).toContainEqual(['balanceOf', 'address', 'contract']);
     expect(sig).toContainEqual(['createAccount', 'address', 'nat']);
-    expect(sig).toContainEqual([
-      'createAccounts',
-      {
-        list: {
-          '0': 'address',
-          '1': 'nat',
-        },
+    const createAccount_Legacy = {
+      list: {
+        '6': 'address',
+        '7': 'nat',
       },
+    };
+    const createAccount_ResetFields = {
+      list: {
+        '0': 'address',
+        '1': 'nat',
+      },
+    };
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.ExtractSignatures()).toContainEqual(['createAccounts', createAccount_Legacy]);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.ExtractSignatures()).toContainEqual([
+      'createAccounts',
+      createAccount_ResetFields,
+    ]);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.ExtractSignatures()).toContainEqual([
+      'createAccounts',
+      createAccount_ResetFields,
     ]);
     expect(sig).toContainEqual(['transfer', 'address', 'nat']);
     expect(sig).toContainEqual(['transferFrom', 'address', 'address', 'nat']);
@@ -388,13 +574,24 @@ describe('Schema test', () => {
 
   it('Should parse parameter properly', () => {
     const schema = new ParameterSchema(params);
-    const s = schema.Execute(txParams);
-    expect(s).toEqual({
+    const execute_Legacy = {
+      approve: {
+        '1': 'tz1fPjyo55HwUAkd1xcL5vo6DGzJrkxAMpiD',
+        '2': new BigNumber('60'),
+      },
+    };
+    const execute_ResetFields = {
       approve: {
         '0': 'tz1fPjyo55HwUAkd1xcL5vo6DGzJrkxAMpiD',
         '1': new BigNumber('60'),
       },
-    });
+    };
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.Execute(txParams)).toEqual(execute_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.Execute(txParams)).toEqual(execute_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.Execute(txParams)).toEqual(execute_ResetFields);
   });
 
   it(`Should find the value that corresponds to the type ({ prim: 'string', annots: ['%name'] }) in top-level pairs of the storage`, () => {

--- a/packages/taquito-michelson-encoder/test/sample1.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample1.spec.ts
@@ -12,7 +12,7 @@ describe('Schema test', () => {
     expect(s).toEqual({
       accounts: {
         big_map: {
-          key: "address",
+          key: 'address',
           value: {
             allowances: {
               map: {
@@ -32,60 +32,60 @@ describe('Schema test', () => {
     });
 
     expect(schema.generateSchema()).toEqual({
-      __michelsonType: "pair",
+      __michelsonType: 'pair',
       schema: {
         accounts: {
-          __michelsonType: "big_map",
+          __michelsonType: 'big_map',
           schema: {
             key: {
-              __michelsonType: "address",
-              schema: "address"
+              __michelsonType: 'address',
+              schema: 'address',
             },
             value: {
-              __michelsonType: "pair",
+              __michelsonType: 'pair',
               schema: {
                 allowances: {
-                  __michelsonType: "map",
+                  __michelsonType: 'map',
                   schema: {
                     key: {
-                      __michelsonType: "address",
-                      schema: "address"
+                      __michelsonType: 'address',
+                      schema: 'address',
                     },
                     value: {
-                      __michelsonType: "nat",
-                      schema: "nat"
+                      __michelsonType: 'nat',
+                      schema: 'nat',
                     },
                   },
                 },
                 balance: {
-                  __michelsonType: "nat",
-                  schema: "nat"
-                }
-              }
+                  __michelsonType: 'nat',
+                  schema: 'nat',
+                },
+              },
             },
           },
         },
         name: {
-          __michelsonType: "string",
-          schema: "string"
+          __michelsonType: 'string',
+          schema: 'string',
         },
         owner: {
-          __michelsonType: "address",
-          schema: "address"
+          __michelsonType: 'address',
+          schema: 'address',
         },
         symbol: {
-          __michelsonType: "string",
-          schema: "string"
+          __michelsonType: 'string',
+          schema: 'string',
         },
         totalSupply: {
-          __michelsonType: "nat",
-          schema: "nat"
+          __michelsonType: 'nat',
+          schema: 'nat',
         },
         version: {
-          __michelsonType: "nat",
-          schema: "nat"
+          __michelsonType: 'nat',
+          schema: 'nat',
         },
-      }
+      },
     });
   });
 
@@ -205,26 +205,26 @@ describe('Schema test', () => {
     const s = schema.ExtractSchema();
     expect(s).toEqual({
       allowance: {
-        '4': 'address',
-        '5': 'address',
+        '0': 'address',
+        '1': 'address',
         NatNatContract: 'contract',
       },
       approve: {
-        '1': 'address',
-        '2': 'nat',
+        '0': 'address',
+        '1': 'nat',
       },
       balanceOf: {
-        '3': 'address',
+        '0': 'address',
         NatContract: 'contract',
       },
       createAccount: {
-        '5': 'address',
-        '6': 'nat',
+        '0': 'address',
+        '1': 'nat',
       },
       createAccounts: {
         list: {
-          "6": "address",
-          "7": "nat",
+          '0': 'address',
+          '1': 'nat',
         },
       },
       transfer: {
@@ -232,137 +232,137 @@ describe('Schema test', () => {
         '1': 'nat',
       },
       transferFrom: {
-        '2': 'address',
-        '3': 'address',
-        '4': 'nat',
+        '0': 'address',
+        '1': 'address',
+        '2': 'nat',
       },
     });
 
     expect(schema.generateSchema()).toEqual({
-      __michelsonType: "or",
+      __michelsonType: 'or',
       schema: {
         allowance: {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '4': {
-              __michelsonType: "address",
-              schema: "address"
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
             },
-            '5': {
-              __michelsonType: "address",
-              schema: "address"
+            '1': {
+              __michelsonType: 'address',
+              schema: 'address',
             },
             NatNatContract: {
-              __michelsonType: "contract",
+              __michelsonType: 'contract',
               schema: {
                 parameter: {
-                  __michelsonType: "pair",
+                  __michelsonType: 'pair',
                   schema: {
                     '0': {
-                      __michelsonType: "nat",
-                      schema: "nat"
+                      __michelsonType: 'nat',
+                      schema: 'nat',
                     },
                     '1': {
-                      __michelsonType: "nat",
-                      schema: "nat"
-                    }
-                  }
-                }
-              }
-            }
-          }
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
         approve: {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '1': {
-              __michelsonType: "address",
-              schema: "address"
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
             },
-            '2': {
-              __michelsonType: "nat",
-              schema: "nat"
-            }
-          }
+            '1': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
         },
         balanceOf: {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '3': {
-              __michelsonType: "address",
-              schema: "address"
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
             },
             NatContract: {
-              __michelsonType: "contract",
+              __michelsonType: 'contract',
               schema: {
                 parameter: {
-                  __michelsonType: "nat",
-                  schema: "nat"
-                }
-              }
+                  __michelsonType: 'nat',
+                  schema: 'nat',
+                },
+              },
             },
-          }
+          },
         },
         createAccount: {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '5': {
-              __michelsonType: "address",
-              schema: "address"
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
             },
-            '6': {
-              __michelsonType: "nat",
-              schema: "nat"
+            '1': {
+              __michelsonType: 'nat',
+              schema: 'nat',
             },
-          }
+          },
         },
         createAccounts: {
-          __michelsonType: "list",
+          __michelsonType: 'list',
           schema: {
-            __michelsonType: "pair",
+            __michelsonType: 'pair',
             schema: {
-              "6": {
-                __michelsonType: "address",
-                schema: "address"
+              '0': {
+                __michelsonType: 'address',
+                schema: 'address',
               },
-              "7": {
-                __michelsonType: "nat",
-                schema: "nat"
+              '1': {
+                __michelsonType: 'nat',
+                schema: 'nat',
               },
-            }
+            },
           },
         },
         transfer: {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
             '0': {
-              __michelsonType: "address",
-              schema: "address"
+              __michelsonType: 'address',
+              schema: 'address',
             },
             '1': {
-              __michelsonType: "nat",
-              schema: "nat"
+              __michelsonType: 'nat',
+              schema: 'nat',
             },
-          }
+          },
         },
         transferFrom: {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '1': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
             '2': {
-              __michelsonType: "address",
-              schema: "address"
+              __michelsonType: 'nat',
+              schema: 'nat',
             },
-            '3': {
-              __michelsonType: "address",
-              schema: "address"
-            },
-            '4': {
-              __michelsonType: "nat",
-              schema: "nat"
-            },
-          }
+          },
         },
-      }
+      },
     });
   });
 
@@ -373,12 +373,14 @@ describe('Schema test', () => {
     expect(sig).toContainEqual(['approve', 'address', 'nat']);
     expect(sig).toContainEqual(['balanceOf', 'address', 'contract']);
     expect(sig).toContainEqual(['createAccount', 'address', 'nat']);
-    expect(sig).toContainEqual(["createAccounts", {
-      list: {
-        "6": "address",
-        "7": "nat"
-      }
-    }
+    expect(sig).toContainEqual([
+      'createAccounts',
+      {
+        list: {
+          '0': 'address',
+          '1': 'nat',
+        },
+      },
     ]);
     expect(sig).toContainEqual(['transfer', 'address', 'nat']);
     expect(sig).toContainEqual(['transferFrom', 'address', 'address', 'nat']);
@@ -389,8 +391,8 @@ describe('Schema test', () => {
     const s = schema.Execute(txParams);
     expect(s).toEqual({
       approve: {
-        '1': 'tz1fPjyo55HwUAkd1xcL5vo6DGzJrkxAMpiD',
-        '2': new BigNumber('60'),
+        '0': 'tz1fPjyo55HwUAkd1xcL5vo6DGzJrkxAMpiD',
+        '1': new BigNumber('60'),
       },
     });
   });
@@ -398,8 +400,10 @@ describe('Schema test', () => {
   it(`Should find the value that corresponds to the type ({ prim: 'string', annots: ['%name'] }) in top-level pairs of the storage`, () => {
     const typeOfValueToFind = { prim: 'string', annots: ['%name'] };
     const storageSchema = new Schema(storage);
-    const valueFound = storageSchema.FindFirstInTopLevelPair(rpcContractResponse.script.storage, typeOfValueToFind);
+    const valueFound = storageSchema.FindFirstInTopLevelPair(
+      rpcContractResponse.script.storage,
+      typeOfValueToFind
+    );
     expect(valueFound).toEqual({ string: 'Token B' });
   });
-
 });

--- a/packages/taquito-michelson-encoder/test/sample11_dexter.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample11_dexter.spec.ts
@@ -15,9 +15,9 @@ describe('Exchange contract test', () => {
     expect(schema.ExtractSchema()).toEqual({
       '0': {
         big_map: {
-          key: "address",
-          value: "nat"
-        }
+          key: 'address',
+          value: 'nat',
+        },
       },
       '1': 'contract',
       '2': 'contract',
@@ -32,19 +32,19 @@ describe('Exchange contract test', () => {
               '2': 'timestamp',
             },
             '1': {
-              '1': 'nat',
-              '2': 'mutez',
-              '3': 'nat',
-              '4': 'timestamp',
-            },
-            '2': {
+              '0': 'nat',
+              '1': 'mutez',
               '2': 'nat',
               '3': 'timestamp',
             },
+            '2': {
+              '0': 'nat',
+              '1': 'timestamp',
+            },
             '3': {
-              '3': 'nat',
-              '4': 'mutez',
-              '5': 'timestamp',
+              '0': 'nat',
+              '1': 'mutez',
+              '2': 'timestamp',
             },
           },
         },
@@ -55,17 +55,17 @@ describe('Exchange contract test', () => {
       __michelsonType: 'pair',
       schema: {
         '0': {
-          __michelsonType: "big_map",
+          __michelsonType: 'big_map',
           schema: {
             key: {
-              __michelsonType: "address",
-              schema: "address"
+              __michelsonType: 'address',
+              schema: 'address',
             },
             value: {
-              __michelsonType: "nat",
-              schema: "nat"
-            }
-          }
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
         },
         '1': {
           __michelsonType: 'contract',
@@ -78,7 +78,7 @@ describe('Exchange contract test', () => {
                   schema: {
                     0: {
                       __michelsonType: 'address',
-                      schema: 'address'
+                      schema: 'address',
                     },
                     1: {
                       __michelsonType: 'contract',
@@ -91,154 +91,154 @@ describe('Exchange contract test', () => {
                               schema: {
                                 0: {
                                   __michelsonType: 'address',
-                                  schema: 'address'
+                                  schema: 'address',
                                 },
                                 1: {
                                   __michelsonType: 'address',
-                                  schema: 'address'
+                                  schema: 'address',
                                 },
                                 2: {
                                   __michelsonType: 'nat',
-                                  schema: 'nat'
+                                  schema: 'nat',
                                 },
-                              }
+                              },
                             },
                             1: {
                               __michelsonType: 'address',
-                              schema: 'address'
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
+                              schema: 'address',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
                 },
                 1: {
                   __michelsonType: 'nat',
-                  schema: 'nat'
-                }
-              }
-            }
-          }
+                  schema: 'nat',
+                },
+              },
+            },
+          },
         },
         '2': {
           __michelsonType: 'contract',
           schema: {
             parameter: {
-              __michelsonType: "or",
+              __michelsonType: 'or',
               schema: {
                 0: {
-                  __michelsonType: "pair",
+                  __michelsonType: 'pair',
                   schema: {
                     0: {
                       __michelsonType: 'address',
-                      schema: 'address'
+                      schema: 'address',
                     },
                     1: {
                       __michelsonType: 'address',
-                      schema: 'address'
+                      schema: 'address',
                     },
                     2: {
                       __michelsonType: 'nat',
-                      schema: 'nat'
+                      schema: 'nat',
                     },
-                  }
+                  },
                 },
                 1: {
                   __michelsonType: 'address',
-                  schema: 'address'
-                }
-              }
-            }
-          }
+                  schema: 'address',
+                },
+              },
+            },
+          },
         },
         '3': {
           __michelsonType: 'nat',
-          schema: 'nat'
+          schema: 'nat',
         },
         '4': {
-          __michelsonType: "map",
+          __michelsonType: 'map',
           schema: {
             key: {
               __michelsonType: 'address',
-              schema: 'address'
+              schema: 'address',
             },
             value: {
-              __michelsonType: "or",
+              __michelsonType: 'or',
               schema: {
                 '0': {
-                  __michelsonType: "pair",
+                  __michelsonType: 'pair',
                   schema: {
                     '0': {
                       __michelsonType: 'nat',
-                      schema: 'nat'
+                      schema: 'nat',
                     },
                     '1': {
                       __michelsonType: 'nat',
-                      schema: 'nat'
+                      schema: 'nat',
                     },
                     '2': {
                       __michelsonType: 'timestamp',
-                      schema: 'timestamp'
+                      schema: 'timestamp',
                     },
-                  }
+                  },
                 },
                 '1': {
                   __michelsonType: 'pair',
                   schema: {
-                    '1': {
+                    '0': {
                       __michelsonType: 'nat',
-                      schema: 'nat'
+                      schema: 'nat',
+                    },
+                    '1': {
+                      __michelsonType: 'mutez',
+                      schema: 'mutez',
                     },
                     '2': {
-                      __michelsonType: 'mutez',
-                      schema: 'mutez'
+                      __michelsonType: 'nat',
+                      schema: 'nat',
                     },
                     '3': {
-                      __michelsonType: 'nat',
-                      schema: 'nat'
-                    },
-                    '4': {
                       __michelsonType: 'timestamp',
-                      schema: 'timestamp'
+                      schema: 'timestamp',
                     },
-                  }
+                  },
                 },
                 '2': {
                   __michelsonType: 'pair',
                   schema: {
-                    '2': {
+                    '0': {
                       __michelsonType: 'nat',
-                      schema: 'nat'
+                      schema: 'nat',
                     },
-                    '3': {
+                    '1': {
                       __michelsonType: 'timestamp',
-                      schema: 'timestamp'
+                      schema: 'timestamp',
                     },
-                  }
+                  },
                 },
                 '3': {
                   __michelsonType: 'pair',
                   schema: {
-                    '3': {
+                    '0': {
                       __michelsonType: 'nat',
-                      schema: 'nat'
+                      schema: 'nat',
                     },
-                    '4': {
+                    '1': {
                       __michelsonType: 'mutez',
-                      schema: 'mutez'
+                      schema: 'mutez',
                     },
-                    '5': {
+                    '2': {
                       __michelsonType: 'timestamp',
-                      schema: 'timestamp'
+                      schema: 'timestamp',
                     },
-                  }
+                  },
                 },
-              }
+              },
             },
           },
         },
-      }
+      },
     });
   });
 
@@ -278,99 +278,99 @@ describe('Exchange contract test', () => {
         '2': 'timestamp',
       },
       '1': {
-        '1': 'nat',
-        '2': 'mutez',
-        '3': 'nat',
-        '4': 'timestamp',
-      },
-      '2': {
+        '0': 'nat',
+        '1': 'mutez',
         '2': 'nat',
         '3': 'timestamp',
       },
+      '2': {
+        '0': 'nat',
+        '1': 'timestamp',
+      },
       '3': {
-        '3': 'nat',
-        '4': 'mutez',
-        '5': 'timestamp',
+        '0': 'nat',
+        '1': 'mutez',
+        '2': 'timestamp',
       },
       '4': 'nat',
     });
 
     expect(schema.generateSchema()).toEqual({
-      __michelsonType: "or",
+      __michelsonType: 'or',
       schema: {
         '0': {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
             '0': {
               __michelsonType: 'nat',
-              schema: 'nat'
+              schema: 'nat',
             },
             '1': {
               __michelsonType: 'nat',
-              schema: 'nat'
+              schema: 'nat',
             },
             '2': {
               __michelsonType: 'timestamp',
-              schema: 'timestamp'
+              schema: 'timestamp',
             },
-          }
+          },
         },
         '1': {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '1': {
+            '0': {
               __michelsonType: 'nat',
-              schema: 'nat'
+              schema: 'nat',
+            },
+            '1': {
+              __michelsonType: 'mutez',
+              schema: 'mutez',
             },
             '2': {
-              __michelsonType: 'mutez',
-              schema: 'mutez'
+              __michelsonType: 'nat',
+              schema: 'nat',
             },
             '3': {
-              __michelsonType: 'nat',
-              schema: 'nat'
-            },
-            '4': {
               __michelsonType: 'timestamp',
-              schema: 'timestamp'
+              schema: 'timestamp',
             },
-          }
+          },
         },
         '2': {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '2': {
+            '0': {
               __michelsonType: 'nat',
-              schema: 'nat'
+              schema: 'nat',
             },
-            '3': {
+            '1': {
               __michelsonType: 'timestamp',
-              schema: 'timestamp'
+              schema: 'timestamp',
             },
-          }
+          },
         },
         '3': {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
-            '3': {
+            '0': {
               __michelsonType: 'nat',
-              schema: 'nat'
+              schema: 'nat',
             },
-            '4': {
+            '1': {
               __michelsonType: 'mutez',
-              schema: 'mutez'
+              schema: 'mutez',
             },
-            '5': {
+            '2': {
               __michelsonType: 'timestamp',
-              schema: 'timestamp'
+              schema: 'timestamp',
             },
-          }
+          },
         },
         '4': {
           __michelsonType: 'nat',
-          schema: 'nat'
+          schema: 'nat',
         },
-      }
+      },
     });
   });
 
@@ -525,7 +525,7 @@ describe('Exchange contract test', () => {
     expect(schema.ExtractSchema()).toEqual({
       '0': {
         big_map: {
-          key: "address",
+          key: 'address',
           value: {
             '0': 'nat',
             '1': {
@@ -543,52 +543,52 @@ describe('Exchange contract test', () => {
     });
 
     expect(schema.generateSchema()).toEqual({
-      __michelsonType: "pair",
+      __michelsonType: 'pair',
       schema: {
         '0': {
-          __michelsonType: "big_map",
+          __michelsonType: 'big_map',
           schema: {
             key: {
-              __michelsonType: "address",
-              schema: "address"
+              __michelsonType: 'address',
+              schema: 'address',
             },
             value: {
               __michelsonType: 'pair',
               schema: {
                 '0': {
-                  __michelsonType: "nat",
-                  schema: "nat"
+                  __michelsonType: 'nat',
+                  schema: 'nat',
                 },
                 '1': {
                   __michelsonType: 'map',
                   schema: {
                     key: {
-                      __michelsonType: "address",
-                      schema: "address"
+                      __michelsonType: 'address',
+                      schema: 'address',
                     },
                     value: {
-                      __michelsonType: "nat",
-                      schema: "nat"
+                      __michelsonType: 'nat',
+                      schema: 'nat',
                     },
                   },
                 },
-              }
+              },
             },
           },
         },
         '1': {
-          __michelsonType: "nat",
-          schema: "nat"
+          __michelsonType: 'nat',
+          schema: 'nat',
         },
         '2': {
-          __michelsonType: "string",
-          schema: "string"
+          __michelsonType: 'string',
+          schema: 'string',
         },
         '3': {
-          __michelsonType: "string",
-          schema: "string"
+          __michelsonType: 'string',
+          schema: 'string',
         },
-      }
+      },
     });
   });
 
@@ -614,30 +614,30 @@ describe('Exchange contract test', () => {
     });
 
     expect(schema.generateSchema()).toEqual({
-      __michelsonType: "or",
+      __michelsonType: 'or',
       schema: {
         '0': {
-          __michelsonType: "pair",
+          __michelsonType: 'pair',
           schema: {
             '0': {
               __michelsonType: 'address',
-              schema: "address"
+              schema: 'address',
             },
             '1': {
               __michelsonType: 'address',
-              schema: "address"
+              schema: 'address',
             },
             '2': {
               __michelsonType: 'nat',
-              schema: "nat"
+              schema: 'nat',
             },
-          }
+          },
         },
         '1': {
           __michelsonType: 'address',
-          schema: "address"
+          schema: 'address',
         },
-      }
+      },
     });
 
     expect(schema.ExtractSignatures()).toContainEqual(['1', 'address']);

--- a/packages/taquito-michelson-encoder/test/sample11_dexter.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample11_dexter.spec.ts
@@ -9,10 +9,49 @@ import BigNumber from 'bignumber.js';
 import { ParameterSchema } from '../src/schema/parameter';
 import { MichelsonMap } from '../src/michelson-map';
 import { expectMichelsonMap } from './utils';
+import { Token } from '../src/taquito-michelson-encoder';
 describe('Exchange contract test', () => {
   it('Test storage schema', () => {
     const schema = new Schema(storageDexter);
-    expect(schema.ExtractSchema()).toEqual({
+    const extractSchema_Legacy = {
+      '0': {
+        big_map: {
+          key: 'address',
+          value: 'nat',
+        },
+      },
+      '1': 'contract',
+      '2': 'contract',
+      '3': 'nat',
+      '4': {
+        map: {
+          key: 'address',
+          value: {
+            '0': {
+              '0': 'nat',
+              '1': 'nat',
+              '2': 'timestamp',
+            },
+            '1': {
+              '1': 'nat',
+              '2': 'mutez',
+              '3': 'nat',
+              '4': 'timestamp',
+            },
+            '2': {
+              '2': 'nat',
+              '3': 'timestamp',
+            },
+            '3': {
+              '3': 'nat',
+              '4': 'mutez',
+              '5': 'timestamp',
+            },
+          },
+        },
+      },
+    };
+    const extractSchema_ResetFields = {
       '0': {
         big_map: {
           key: 'address',
@@ -49,9 +88,205 @@ describe('Exchange contract test', () => {
           },
         },
       },
-    });
+    };
 
-    expect(schema.generateSchema()).toEqual({
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+
+    const generateSchema_Legacy = {
+      __michelsonType: 'pair',
+      schema: {
+        '0': {
+          __michelsonType: 'big_map',
+          schema: {
+            key: {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            value: {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+          },
+        },
+        '1': {
+          __michelsonType: 'contract',
+          schema: {
+            parameter: {
+              __michelsonType: 'or',
+              schema: {
+                0: {
+                  __michelsonType: 'pair',
+                  schema: {
+                    0: {
+                      __michelsonType: 'address',
+                      schema: 'address',
+                    },
+                    1: {
+                      __michelsonType: 'contract',
+                      schema: {
+                        parameter: {
+                          __michelsonType: 'or',
+                          schema: {
+                            0: {
+                              __michelsonType: 'pair',
+                              schema: {
+                                0: {
+                                  __michelsonType: 'address',
+                                  schema: 'address',
+                                },
+                                1: {
+                                  __michelsonType: 'address',
+                                  schema: 'address',
+                                },
+                                2: {
+                                  __michelsonType: 'nat',
+                                  schema: 'nat',
+                                },
+                              },
+                            },
+                            1: {
+                              __michelsonType: 'address',
+                              schema: 'address',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+                1: {
+                  __michelsonType: 'nat',
+                  schema: 'nat',
+                },
+              },
+            },
+          },
+        },
+        '2': {
+          __michelsonType: 'contract',
+          schema: {
+            parameter: {
+              __michelsonType: 'or',
+              schema: {
+                0: {
+                  __michelsonType: 'pair',
+                  schema: {
+                    0: {
+                      __michelsonType: 'address',
+                      schema: 'address',
+                    },
+                    1: {
+                      __michelsonType: 'address',
+                      schema: 'address',
+                    },
+                    2: {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                  },
+                },
+                1: {
+                  __michelsonType: 'address',
+                  schema: 'address',
+                },
+              },
+            },
+          },
+        },
+        '3': {
+          __michelsonType: 'nat',
+          schema: 'nat',
+        },
+        '4': {
+          __michelsonType: 'map',
+          schema: {
+            key: {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            value: {
+              __michelsonType: 'or',
+              schema: {
+                '0': {
+                  __michelsonType: 'pair',
+                  schema: {
+                    '0': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '1': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '2': {
+                      __michelsonType: 'timestamp',
+                      schema: 'timestamp',
+                    },
+                  },
+                },
+                '1': {
+                  __michelsonType: 'pair',
+                  schema: {
+                    '1': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '2': {
+                      __michelsonType: 'mutez',
+                      schema: 'mutez',
+                    },
+                    '3': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '4': {
+                      __michelsonType: 'timestamp',
+                      schema: 'timestamp',
+                    },
+                  },
+                },
+                '2': {
+                  __michelsonType: 'pair',
+                  schema: {
+                    '2': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '3': {
+                      __michelsonType: 'timestamp',
+                      schema: 'timestamp',
+                    },
+                  },
+                },
+                '3': {
+                  __michelsonType: 'pair',
+                  schema: {
+                    '3': {
+                      __michelsonType: 'nat',
+                      schema: 'nat',
+                    },
+                    '4': {
+                      __michelsonType: 'mutez',
+                      schema: 'mutez',
+                    },
+                    '5': {
+                      __michelsonType: 'timestamp',
+                      schema: 'timestamp',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+    const generateSchema_ResetFields = {
       __michelsonType: 'pair',
       schema: {
         '0': {
@@ -239,7 +474,14 @@ describe('Exchange contract test', () => {
           },
         },
       },
-    });
+    };
+
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.generateSchema()).toEqual(generateSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
   });
 
   it('Test storage parsing', () => {
@@ -271,7 +513,30 @@ describe('Exchange contract test', () => {
 
   it('Test parameter schema', () => {
     const schema = new ParameterSchema(params);
-    expect(schema.ExtractSchema()).toEqual({
+    const extractSchema_Legacy = {
+      '0': {
+        '0': 'nat',
+        '1': 'nat',
+        '2': 'timestamp',
+      },
+      '1': {
+        '1': 'nat',
+        '2': 'mutez',
+        '3': 'nat',
+        '4': 'timestamp',
+      },
+      '2': {
+        '2': 'nat',
+        '3': 'timestamp',
+      },
+      '3': {
+        '3': 'nat',
+        '4': 'mutez',
+        '5': 'timestamp',
+      },
+      '4': 'nat',
+    };
+    const extractSchema_ResetFields = {
       '0': {
         '0': 'nat',
         '1': 'nat',
@@ -293,9 +558,93 @@ describe('Exchange contract test', () => {
         '2': 'timestamp',
       },
       '4': 'nat',
-    });
+    };
 
-    expect(schema.generateSchema()).toEqual({
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+
+    const generateSchema_Legacy = {
+      __michelsonType: 'or',
+      schema: {
+        '0': {
+          __michelsonType: 'pair',
+          schema: {
+            '0': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+            '1': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+            '2': {
+              __michelsonType: 'timestamp',
+              schema: 'timestamp',
+            },
+          },
+        },
+        '1': {
+          __michelsonType: 'pair',
+          schema: {
+            '1': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+            '2': {
+              __michelsonType: 'mutez',
+              schema: 'mutez',
+            },
+            '3': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+            '4': {
+              __michelsonType: 'timestamp',
+              schema: 'timestamp',
+            },
+          },
+        },
+        '2': {
+          __michelsonType: 'pair',
+          schema: {
+            '2': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+            '3': {
+              __michelsonType: 'timestamp',
+              schema: 'timestamp',
+            },
+          },
+        },
+        '3': {
+          __michelsonType: 'pair',
+          schema: {
+            '3': {
+              __michelsonType: 'nat',
+              schema: 'nat',
+            },
+            '4': {
+              __michelsonType: 'mutez',
+              schema: 'mutez',
+            },
+            '5': {
+              __michelsonType: 'timestamp',
+              schema: 'timestamp',
+            },
+          },
+        },
+        '4': {
+          __michelsonType: 'nat',
+          schema: 'nat',
+        },
+      },
+    };
+    const generateSchema_ResetFields = {
       __michelsonType: 'or',
       schema: {
         '0': {
@@ -371,7 +720,14 @@ describe('Exchange contract test', () => {
           schema: 'nat',
         },
       },
-    });
+    };
+
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.generateSchema()).toEqual(generateSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
   });
 
   it('Encode parameter properly func 0', () => {

--- a/packages/taquito-michelson-encoder/test/sample9_lambda.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample9_lambda.spec.ts
@@ -2,17 +2,39 @@
 
 import { params as params9 } from '../data/sample9';
 import { ParameterSchema } from '../src/schema/parameter';
+import { Token } from '../src/taquito-michelson-encoder';
 
 describe('Schema test', () => {
   it('Should parse storage properly', () => {
     const schema = new ParameterSchema(params9);
-    const storage = schema.ExtractSchema();
 
     expect(schema.ExtractSignatures()).toContainEqual(['0', 'address', 'string', 'bytes']);
     expect(schema.ExtractSignatures()).toContainEqual(['1', 'mutez']);
     expect(schema.ExtractSignatures()).toContainEqual(['2', 'address', 'bool']);
 
-    expect(storage).toEqual({
+    const extractSchema_Legacy = {
+      '0': {
+        '0': 'address',
+        '1': 'string',
+        '2': { Some: 'bytes' },
+      },
+      '1': 'mutez',
+      '2': {
+        '2': 'address',
+        '3': 'bool',
+      },
+      '3': {
+        lambda: {
+          parameters: {
+            5: { Some: 'bytes' },
+            3: 'address',
+            4: 'string',
+          },
+          returns: 'operation',
+        },
+      },
+    };
+    const extractSchema_ResetFields = {
       '0': {
         '0': 'address',
         '1': 'string',
@@ -33,9 +55,87 @@ describe('Schema test', () => {
           returns: 'operation',
         },
       },
-    });
+    };
 
-    expect(schema.generateSchema()).toEqual({
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.ExtractSchema()).toEqual(extractSchema_ResetFields);
+
+    const generateSchema_Legacy = {
+      __michelsonType: 'or',
+      schema: {
+        '0': {
+          __michelsonType: 'pair',
+          schema: {
+            '0': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '1': {
+              __michelsonType: 'string',
+              schema: 'string',
+            },
+            '2': {
+              __michelsonType: 'option',
+              schema: {
+                __michelsonType: 'bytes',
+                schema: 'bytes',
+              },
+            },
+          },
+        },
+        '1': {
+          __michelsonType: 'mutez',
+          schema: 'mutez',
+        },
+        '2': {
+          __michelsonType: 'pair',
+          schema: {
+            '2': {
+              __michelsonType: 'address',
+              schema: 'address',
+            },
+            '3': {
+              __michelsonType: 'bool',
+              schema: 'bool',
+            },
+          },
+        },
+        '3': {
+          __michelsonType: 'lambda',
+          schema: {
+            parameters: {
+              __michelsonType: 'pair',
+              schema: {
+                3: {
+                  __michelsonType: 'address',
+                  schema: 'address',
+                },
+                4: {
+                  __michelsonType: 'string',
+                  schema: 'string',
+                },
+                5: {
+                  __michelsonType: 'option',
+                  schema: {
+                    __michelsonType: 'bytes',
+                    schema: 'bytes',
+                  },
+                },
+              },
+            },
+            returns: {
+              __michelsonType: 'operation',
+              schema: 'operation',
+            },
+          },
+        },
+      },
+    };
+    const generateSchema_ResetFields = {
       __michelsonType: 'or',
       schema: {
         '0': {
@@ -105,7 +205,14 @@ describe('Schema test', () => {
           },
         },
       },
-    });
+    };
+
+    Token.fieldNumberingStrategy = 'Legacy';
+    expect(schema.generateSchema()).toEqual(generateSchema_Legacy);
+    Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
+    Token.fieldNumberingStrategy = 'Latest';
+    expect(schema.generateSchema()).toEqual(generateSchema_ResetFields);
 
     expect({
       args: [

--- a/packages/taquito-michelson-encoder/test/sample9_lambda.spec.ts
+++ b/packages/taquito-michelson-encoder/test/sample9_lambda.spec.ts
@@ -20,15 +20,15 @@ describe('Schema test', () => {
       },
       '1': 'mutez',
       '2': {
-        '2': 'address',
-        '3': 'bool',
+        '0': 'address',
+        '1': 'bool',
       },
       '3': {
         lambda: {
           parameters: {
-            5: { Some: 'bytes' },
-            3: 'address',
-            4: 'string',
+            0: 'address',
+            1: 'string',
+            2: { Some: 'bytes' },
           },
           returns: 'operation',
         },
@@ -65,11 +65,11 @@ describe('Schema test', () => {
         '2': {
           __michelsonType: 'pair',
           schema: {
-            '2': {
+            '0': {
               __michelsonType: 'address',
               schema: 'address',
             },
-            '3': {
+            '1': {
               __michelsonType: 'bool',
               schema: 'bool',
             },
@@ -81,15 +81,15 @@ describe('Schema test', () => {
             parameters: {
               __michelsonType: 'pair',
               schema: {
-                3: {
+                0: {
                   __michelsonType: 'address',
                   schema: 'address',
                 },
-                4: {
+                1: {
                   __michelsonType: 'string',
                   schema: 'string',
                 },
-                5: {
+                2: {
                   __michelsonType: 'option',
                   schema: {
                     __michelsonType: 'bytes',

--- a/packages/taquito-michelson-encoder/test/tokens/map.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/map.spec.ts
@@ -192,7 +192,7 @@ describe('Map token', () => {
       map.set({ myBytes: 'cccc' }, 15); //LLR
       map.set({ myAddress: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu' }, 5); //LLL
       map.set({ myNat: 48 }, 16); //LRR
-      map.set({ myPair: { 4: 12, 5: 6 } }, 3); //RLL
+      map.set({ myPair: { 0: 12, 1: 6 } }, 3); //RLL
       map.set({ myInt: 4 }, 6); //LRL
       map.set({ myString: 'test' }, 3); //RLR
       map.set({ myBytes: 'aaaa' }, 5); //LLR
@@ -351,7 +351,7 @@ describe('Map token', () => {
       map.set({ 1: 'cccc' }, 15); //LLR
       map.set({ 0: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu' }, 5); //LLL
       map.set({ 3: 48 }, 16); //LRR
-      map.set({ 4: { 4: 12, 5: 6 } }, 3); //RLL
+      map.set({ 4: { 0: 12, 1: 6 } }, 3); //RLL
       map.set({ 2: 4 }, 6); //LRL
       map.set({ 5: 'test' }, 3); //RLR
       map.set({ 1: 'aaaa' }, 5); //LLR
@@ -642,13 +642,13 @@ describe('Map token', () => {
         schema: {
           key: {
             __michelsonType: 'string',
-            schema: 'string'
+            schema: 'string',
           },
           value: {
             __michelsonType: 'int',
-            schema: 'int'
-          }
-        }
+            schema: 'int',
+          },
+        },
       });
     });
   });
@@ -760,19 +760,19 @@ describe('Map token with pair', () => {
             schema: {
               0: {
                 __michelsonType: 'string',
-                schema: 'string'
+                schema: 'string',
               },
               1: {
                 __michelsonType: 'string',
-                schema: 'string'
-              }
-            }
+                schema: 'string',
+              },
+            },
           },
           value: {
             __michelsonType: 'int',
-            schema: 'int'
-          }
-        }
+            schema: 'int',
+          },
+        },
       });
     });
   });
@@ -890,19 +890,19 @@ describe('Map token with annotated pair', () => {
           schema: {
             test: {
               __michelsonType: 'string',
-              schema: 'string'
+              schema: 'string',
             },
             test2: {
               __michelsonType: 'string',
-              schema: 'string'
-            }
-          }
+              schema: 'string',
+            },
+          },
         },
         value: {
           __michelsonType: 'int',
-          schema: 'int'
-        }
-      }
+          schema: 'int',
+        },
+      },
     });
   });
 });
@@ -1176,47 +1176,47 @@ describe('Map token with complex pair', () => {
           schema: {
             0: {
               __michelsonType: 'int',
-              schema: 'int'
+              schema: 'int',
             },
             1: {
               __michelsonType: 'nat',
-              schema: 'nat'
+              schema: 'nat',
             },
             2: {
               __michelsonType: 'string',
-              schema: 'string'
+              schema: 'string',
             },
             3: {
               __michelsonType: 'bytes',
-              schema: 'bytes'
+              schema: 'bytes',
             },
             4: {
               __michelsonType: 'mutez',
-              schema: 'mutez'
+              schema: 'mutez',
             },
             5: {
               __michelsonType: 'bool',
-              schema: 'bool'
+              schema: 'bool',
             },
             6: {
               __michelsonType: 'key_hash',
-              schema: 'key_hash'
+              schema: 'key_hash',
             },
             7: {
               __michelsonType: 'timestamp',
-              schema: 'timestamp'
+              schema: 'timestamp',
             },
             8: {
               __michelsonType: 'address',
-              schema: 'address'
+              schema: 'address',
             },
-          }
+          },
         },
         value: {
           __michelsonType: 'int',
-          schema: 'int'
-        }
-      }
+          schema: 'int',
+        },
+      },
     });
   });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
@@ -10,6 +10,7 @@ import {
   tokenNoAnnots,
   tokenOrWithOption,
 } from '../data/or-tokens';
+import { Schema } from '../../src/taquito-michelson-encoder';
 
 describe('Or token', () => {
   describe('generateSchema, EncodeObject, Execute', () => {
@@ -980,6 +981,412 @@ describe('Or token', () => {
         key: { prim: 'Right', args: [{ string: 'test' }] },
         type: { prim: 'or', args: [{ prim: 'int' }, { prim: 'string' }] },
       });
+    });
+  });
+
+  describe('Nesting of Pair and Or', () => {
+    it('reproducing the reported bug in #2927', () => {
+      const schemaObj = {
+        prim: 'pair',
+        args: [
+          {
+            prim: 'set',
+            args: [
+              {
+                prim: 'address',
+              },
+            ],
+            annots: ['%owners'],
+          },
+          {
+            prim: 'set',
+            args: [
+              {
+                prim: 'address',
+              },
+            ],
+            annots: ['%inheritors'],
+          },
+          {
+            prim: 'or',
+            args: [
+              {
+                prim: 'unit',
+                annots: ['%aCTIVE'],
+              },
+              {
+                prim: 'or',
+                args: [
+                  {
+                    prim: 'pair',
+                    args: [
+                      {
+                        prim: 'address',
+                      },
+                      {
+                        prim: 'timestamp',
+                      },
+                    ],
+                    annots: ['%rECOVERING'],
+                  },
+                  {
+                    prim: 'unit',
+                    annots: ['%dEAD'],
+                  },
+                ],
+              },
+            ],
+            annots: ['%status'],
+          },
+          {
+            prim: 'mutez',
+            annots: ['%quick_recovery_stake'],
+          },
+          {
+            prim: 'nat',
+            annots: ['%quick_recovery_period'],
+          },
+        ],
+      };
+      const dataObj = {
+        prim: 'Pair',
+        args: [
+          [
+            {
+              string: 'tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6',
+            },
+          ],
+          [],
+          {
+            prim: 'Right',
+            args: [
+              {
+                prim: 'Left',
+                args: [
+                  {
+                    prim: 'Pair',
+                    args: [
+                      {
+                        string: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+                      },
+                      {
+                        string: '2024-04-19T13:53:22Z',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            int: '1000000',
+          },
+          {
+            int: '0',
+          },
+          {
+            int: '414522',
+          },
+          {
+            int: '414523',
+          },
+        ],
+      };
+      const expected = {
+        owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
+        inheritors: [],
+        status: {
+          rECOVERING: {
+            0: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+            1: '2024-04-19T13:53:22.000Z',
+          },
+        },
+        quick_recovery_stake: BigNumber(1000000),
+        quick_recovery_period: BigNumber(0),
+        direct_debit_mandates: '414522',
+        direct_debit_mandates_history: '414523',
+      };
+
+      const schema = new Schema(schemaObj);
+      const result = schema.Execute(dataObj);
+      expect(result).toEqual(expected);
+    });
+
+    it('a smaller reproduction', () => {
+      const schemaObj = {
+        prim: 'pair',
+        args: [
+          {
+            prim: 'set',
+            args: [
+              {
+                prim: 'address',
+              },
+            ],
+            annots: ['%owners'],
+          },
+          {
+            prim: 'set',
+            args: [
+              {
+                prim: 'address',
+              },
+            ],
+            annots: ['%inheritors'],
+          },
+          {
+            prim: 'or',
+            args: [
+              {
+                prim: 'unit',
+                annots: ['%aCTIVE'],
+              },
+              {
+                prim: 'or',
+                args: [
+                  {
+                    prim: 'pair',
+                    args: [
+                      {
+                        prim: 'address',
+                      },
+                      {
+                        prim: 'timestamp',
+                      },
+                    ],
+                    annots: ['%rECOVERING'],
+                  },
+                  {
+                    prim: 'unit',
+                    annots: ['%dEAD'],
+                  },
+                ],
+              },
+            ],
+            annots: ['%status'],
+          },
+          {
+            prim: 'mutez',
+            annots: ['%quick_recovery_stake'],
+          },
+          {
+            prim: 'nat',
+            annots: ['%quick_recovery_period'],
+          },
+          {
+            prim: 'big_map',
+            args: [
+              {
+                prim: 'pair',
+                args: [
+                  {
+                    prim: 'address',
+                  },
+                  {
+                    prim: 'or',
+                    args: [
+                      {
+                        prim: 'nat',
+                        annots: ['%sECOND'],
+                      },
+                      {
+                        prim: 'or',
+                        args: [
+                          {
+                            prim: 'nat',
+                            annots: ['%mINUTE'],
+                          },
+                          {
+                            prim: 'or',
+                            args: [
+                              {
+                                prim: 'nat',
+                                annots: ['%hOUR'],
+                              },
+                              {
+                                prim: 'or',
+                                args: [
+                                  {
+                                    prim: 'nat',
+                                    annots: ['%dAY'],
+                                  },
+                                  {
+                                    prim: 'or',
+                                    args: [
+                                      {
+                                        prim: 'nat',
+                                        annots: ['%wEEK'],
+                                      },
+                                      {
+                                        prim: 'or',
+                                        args: [
+                                          {
+                                            prim: 'nat',
+                                            annots: ['%mONTH'],
+                                          },
+                                          {
+                                            prim: 'nat',
+                                            annots: ['%yEAR'],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                prim: 'mutez',
+              },
+            ],
+            annots: ['%direct_debit_mandates'],
+          },
+          {
+            prim: 'big_map',
+            args: [
+              {
+                prim: 'pair',
+                args: [
+                  {
+                    prim: 'address',
+                  },
+                  {
+                    prim: 'or',
+                    args: [
+                      {
+                        prim: 'nat',
+                        annots: ['%sECOND'],
+                      },
+                      {
+                        prim: 'or',
+                        args: [
+                          {
+                            prim: 'nat',
+                            annots: ['%mINUTE'],
+                          },
+                          {
+                            prim: 'or',
+                            args: [
+                              {
+                                prim: 'nat',
+                                annots: ['%hOUR'],
+                              },
+                              {
+                                prim: 'or',
+                                args: [
+                                  {
+                                    prim: 'nat',
+                                    annots: ['%dAY'],
+                                  },
+                                  {
+                                    prim: 'or',
+                                    args: [
+                                      {
+                                        prim: 'nat',
+                                        annots: ['%wEEK'],
+                                      },
+                                      {
+                                        prim: 'or',
+                                        args: [
+                                          {
+                                            prim: 'nat',
+                                            annots: ['%mONTH'],
+                                          },
+                                          {
+                                            prim: 'nat',
+                                            annots: ['%yEAR'],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                prim: 'timestamp',
+              },
+            ],
+            annots: ['%direct_debit_mandates_history'],
+          },
+        ],
+      };
+      const dataObj = {
+        prim: 'Pair',
+        args: [
+          [
+            {
+              string: 'tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6',
+            },
+          ],
+          [],
+          {
+            prim: 'Right',
+            args: [
+              {
+                prim: 'Left',
+                args: [
+                  {
+                    prim: 'Pair',
+                    args: [
+                      {
+                        string: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+                      },
+                      {
+                        string: '2024-04-19T13:53:22Z',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            int: '1000000',
+          },
+          {
+            int: '0',
+          },
+          {
+            int: '414522',
+          },
+          {
+            int: '414523',
+          },
+        ],
+      };
+      const expected = {
+        owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
+        inheritors: [],
+        status: {
+          rECOVERING: {
+            0: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+            1: '2024-04-19T13:53:22.000Z',
+          },
+        },
+        quick_recovery_stake: BigNumber(1000000),
+        quick_recovery_period: BigNumber(0),
+        direct_debit_mandates: '414522',
+        direct_debit_mandates_history: '414523',
+      };
+
+      const schema = new Schema(schemaObj);
+      const result = schema.Execute(dataObj);
+      expect(result).toEqual(expected);
     });
   });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
@@ -10,7 +10,7 @@ import {
   tokenNoAnnots,
   tokenOrWithOption,
 } from '../data/or-tokens';
-import { Schema } from '../../src/taquito-michelson-encoder';
+import { Schema, Token } from '../../src/taquito-michelson-encoder';
 
 describe('Or token', () => {
   describe('generateSchema, EncodeObject, Execute', () => {
@@ -152,11 +152,8 @@ describe('Or token', () => {
           },
         ],
       });
-      expect(
-        tokenComplexNoAnnots.EncodeObject({
-          1: { 0: 3, 1: 4, 2: 31, 3: '2019-09-06T15:08:29.000Z' },
-        })
-      ).toEqual({
+
+      let encode_Expected: object = {
         prim: 'Left',
         args: [
           {
@@ -175,8 +172,17 @@ describe('Or token', () => {
             ],
           },
         ],
-      });
-      expect(tokenComplexNoAnnots.EncodeObject({ 2: { 0: 3, 1: 'test' } })).toEqual({
+      };
+      let object_Legacy: object = { 1: { 1: 3, 2: 4, 3: 31, 4: '2019-09-06T15:08:29.000Z' } };
+      let object_ResetFields: object = { 1: { 0: 3, 1: 4, 2: 31, 3: '2019-09-06T15:08:29.000Z' } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplexNoAnnots.EncodeObject(object_Legacy)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplexNoAnnots.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplexNoAnnots.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+
+      encode_Expected = {
         prim: 'Right',
         args: [
           {
@@ -184,12 +190,17 @@ describe('Or token', () => {
             args: [{ prim: 'Pair', args: [{ int: '3' }, { string: 'test' }] }],
           },
         ],
-      });
-      expect(
-        tokenComplexNoAnnots.EncodeObject({
-          3: { 0: 4, 1: 3, 2: '2019-09-06T15:08:29.000Z' },
-        })
-      ).toEqual({
+      };
+      object_Legacy = { 2: { 2: 3, 3: 'test' } };
+      object_ResetFields = { 2: { 0: 3, 1: 'test' } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplexNoAnnots.EncodeObject(object_Legacy)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplexNoAnnots.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplexNoAnnots.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+
+      encode_Expected = {
         prim: 'Right',
         args: [
           {
@@ -213,7 +224,15 @@ describe('Or token', () => {
             ],
           },
         ],
-      });
+      };
+      object_Legacy = { 3: { 3: 4, 4: 3, 5: '2019-09-06T15:08:29.000Z' } };
+      object_ResetFields = { 3: { 0: 4, 1: 3, 2: '2019-09-06T15:08:29.000Z' } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplexNoAnnots.EncodeObject(object_Legacy)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplexNoAnnots.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplexNoAnnots.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
       expect(tokenComplexNoAnnots.EncodeObject({ 4: 4 })).toEqual({
         prim: 'Right',
         args: [{ prim: 'Right', args: [{ prim: 'Right', args: [{ int: '4' }] }] }],
@@ -243,11 +262,8 @@ describe('Or token', () => {
           },
         ],
       });
-      expect(
-        tokenComplex.EncodeObject({
-          option1: { 0: 3, 1: 4, 2: 31, 3: '2019-09-06T15:08:29.000Z' },
-        })
-      ).toEqual({
+
+      encode_Expected = {
         prim: 'Left',
         args: [
           {
@@ -266,8 +282,17 @@ describe('Or token', () => {
             ],
           },
         ],
-      });
-      expect(tokenComplex.EncodeObject({ option2: { 0: 3, 1: 'test' } })).toEqual({
+      };
+      object_Legacy = { option1: { 1: 3, 2: 4, 3: 31, 4: '2019-09-06T15:08:29.000Z' } };
+      object_ResetFields = { option1: { 0: 3, 1: 4, 2: 31, 3: '2019-09-06T15:08:29.000Z' } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplex.EncodeObject(object_Legacy)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplex.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplex.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+
+      encode_Expected = {
         prim: 'Right',
         args: [
           {
@@ -275,12 +300,17 @@ describe('Or token', () => {
             args: [{ prim: 'Pair', args: [{ int: '3' }, { string: 'test' }] }],
           },
         ],
-      });
-      expect(
-        tokenComplex.EncodeObject({
-          option3: { 0: 4, 1: 3, 2: '2019-09-06T15:08:29.000Z' },
-        })
-      ).toEqual({
+      };
+      object_Legacy = { option2: { 2: 3, 3: 'test' } };
+      object_ResetFields = { option2: { 0: 3, 1: 'test' } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplex.EncodeObject(object_Legacy)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplex.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplex.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+
+      encode_Expected = {
         prim: 'Right',
         args: [
           {
@@ -304,7 +334,16 @@ describe('Or token', () => {
             ],
           },
         ],
-      });
+      };
+      object_Legacy = { option3: { 3: 4, 4: 3, 5: '2019-09-06T15:08:29.000Z' } };
+      object_ResetFields = { option3: { 0: 4, 1: 3, 2: '2019-09-06T15:08:29.000Z' } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplex.EncodeObject(object_Legacy)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplex.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplex.EncodeObject(object_ResetFields)).toEqual(encode_Expected);
+
       expect(tokenComplex.EncodeObject({ option4: 4 })).toEqual({
         prim: 'Right',
         args: [{ prim: 'Right', args: [{ prim: 'Right', args: [{ int: '4' }] }] }],
@@ -575,15 +614,105 @@ describe('Or token', () => {
         },
       });
 
-      expect(tokenComplexNoAnnots.ExtractSchema()).toEqual({
+      let extractSchema_Legacy: object = {
+        0: { 0: 'nat', 1: 'nat', 2: 'timestamp' },
+        1: { 1: 'nat', 2: 'mutez', 3: 'nat', 4: 'timestamp' },
+        2: { 2: 'nat', 3: 'timestamp' },
+        3: { 3: 'nat', 4: 'mutez', 5: 'timestamp' },
+        4: 'nat',
+      };
+      let extractSchema_ResetFields: object = {
         0: { 0: 'nat', 1: 'nat', 2: 'timestamp' },
         1: { 0: 'nat', 1: 'mutez', 2: 'nat', 3: 'timestamp' },
         2: { 0: 'nat', 1: 'timestamp' },
         3: { 0: 'nat', 1: 'mutez', 2: 'timestamp' },
         4: 'nat',
-      });
+      };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplexNoAnnots.ExtractSchema()).toEqual(extractSchema_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplexNoAnnots.ExtractSchema()).toEqual(extractSchema_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplexNoAnnots.ExtractSchema()).toEqual(extractSchema_ResetFields);
 
-      expect(tokenComplexNoAnnots.generateSchema()).toEqual({
+      let generateSchema_Legacy: object = {
+        __michelsonType: 'or',
+        schema: {
+          0: {
+            __michelsonType: 'pair',
+            schema: {
+              0: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              1: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              2: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          1: {
+            __michelsonType: 'pair',
+            schema: {
+              1: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              2: {
+                __michelsonType: 'mutez',
+                schema: 'mutez',
+              },
+              3: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              4: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          2: {
+            __michelsonType: 'pair',
+            schema: {
+              2: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              3: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          3: {
+            __michelsonType: 'pair',
+            schema: {
+              3: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              4: {
+                __michelsonType: 'mutez',
+                schema: 'mutez',
+              },
+              5: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          4: {
+            __michelsonType: 'nat',
+            schema: 'nat',
+          },
+        },
+      };
+      let generateSchema_ResetFields: object = {
         __michelsonType: 'or',
         schema: {
           0: {
@@ -659,17 +788,113 @@ describe('Or token', () => {
             schema: 'nat',
           },
         },
-      });
+      };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplexNoAnnots.generateSchema()).toEqual(generateSchema_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplexNoAnnots.generateSchema()).toEqual(generateSchema_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplexNoAnnots.generateSchema()).toEqual(generateSchema_ResetFields);
 
-      expect(tokenComplex.ExtractSchema()).toEqual({
+      extractSchema_Legacy = {
+        option0: { 0: 'nat', 1: 'nat', 2: 'timestamp' },
+        option1: { 1: 'nat', 2: 'mutez', 3: 'nat', 4: 'timestamp' },
+        option2: { 2: 'nat', 3: 'timestamp' },
+        option3: { 3: 'nat', 4: 'mutez', 5: 'timestamp' },
+        option4: 'nat',
+      };
+      extractSchema_ResetFields = {
         option0: { 0: 'nat', 1: 'nat', 2: 'timestamp' },
         option1: { 0: 'nat', 1: 'mutez', 2: 'nat', 3: 'timestamp' },
         option2: { 0: 'nat', 1: 'timestamp' },
         option3: { 0: 'nat', 1: 'mutez', 2: 'timestamp' },
         option4: 'nat',
-      });
+      };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplex.ExtractSchema()).toEqual(extractSchema_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplex.ExtractSchema()).toEqual(extractSchema_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplex.ExtractSchema()).toEqual(extractSchema_ResetFields);
 
-      expect(tokenComplex.generateSchema()).toEqual({
+      generateSchema_Legacy = {
+        __michelsonType: 'or',
+        schema: {
+          option0: {
+            __michelsonType: 'pair',
+            schema: {
+              0: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              1: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              2: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          option1: {
+            __michelsonType: 'pair',
+            schema: {
+              1: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              2: {
+                __michelsonType: 'mutez',
+                schema: 'mutez',
+              },
+              3: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              4: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          option2: {
+            __michelsonType: 'pair',
+            schema: {
+              2: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              3: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          option3: {
+            __michelsonType: 'pair',
+            schema: {
+              3: {
+                __michelsonType: 'nat',
+                schema: 'nat',
+              },
+              4: {
+                __michelsonType: 'mutez',
+                schema: 'mutez',
+              },
+              5: {
+                __michelsonType: 'timestamp',
+                schema: 'timestamp',
+              },
+            },
+          },
+          option4: {
+            __michelsonType: 'nat',
+            schema: 'nat',
+          },
+        },
+      };
+      generateSchema_ResetFields = {
         __michelsonType: 'or',
         schema: {
           option0: {
@@ -745,7 +970,13 @@ describe('Or token', () => {
             schema: 'nat',
           },
         },
-      });
+      };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenComplex.generateSchema()).toEqual(generateSchema_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenComplex.generateSchema()).toEqual(generateSchema_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenComplex.generateSchema()).toEqual(generateSchema_ResetFields);
 
       expect(tokenOrWithOption.generateSchema()).toEqual({
         __michelsonType: 'or',
@@ -841,22 +1072,29 @@ describe('Or token', () => {
           ],
         })
       ).toEqual({ myNat: new BigNumber(6) }); // { 0: '6'  }
-      expect(
-        tokenNestedOr.Execute({
-          prim: 'Right',
-          args: [
-            {
-              prim: 'Left',
-              args: [
-                {
-                  prim: 'Left',
-                  args: [{ prim: 'Pair', args: [{ int: '3' }, { int: '4' }] }],
-                },
-              ],
-            },
-          ],
-        })
-      ).toEqual({ myPair: { 0: new BigNumber(3), 1: new BigNumber(4) } }); // { 4: { myPair: { 4: '3', 5: '4'} } }
+      let michelson: object = {
+        prim: 'Right',
+        args: [
+          {
+            prim: 'Left',
+            args: [
+              {
+                prim: 'Left',
+                args: [{ prim: 'Pair', args: [{ int: '3' }, { int: '4' }] }],
+              },
+            ],
+          },
+        ],
+      };
+      let execute_Legacy: object = { myPair: { 4: new BigNumber(3), 5: new BigNumber(4) } };
+      let execute_ResetFields: object = { myPair: { 0: new BigNumber(3), 1: new BigNumber(4) } };
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenNestedOr.Execute(michelson)).toEqual(execute_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenNestedOr.Execute(michelson)).toEqual(execute_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenNestedOr.Execute(michelson)).toEqual(execute_ResetFields);
+
       expect(
         tokenNestedOr.Execute({
           prim: 'Right',
@@ -924,22 +1162,31 @@ describe('Or token', () => {
           ],
         })
       ).toEqual({ 3: new BigNumber(6) }); // { 0: '6'  }
-      expect(
-        tokenNestedOrWithoutAnnot.Execute({
-          prim: 'Right',
-          args: [
-            {
-              prim: 'Left',
-              args: [
-                {
-                  prim: 'Left',
-                  args: [{ prim: 'Pair', args: [{ int: '3' }, { int: '4' }] }],
-                },
-              ],
-            },
-          ],
-        })
-      ).toEqual({ 4: { 0: new BigNumber(3), 1: new BigNumber(4) } }); // { 4: { myPair: { 4: '3', 5: '4'} } }
+
+      michelson = {
+        prim: 'Right',
+        args: [
+          {
+            prim: 'Left',
+            args: [
+              {
+                prim: 'Left',
+                args: [{ prim: 'Pair', args: [{ int: '3' }, { int: '4' }] }],
+              },
+            ],
+          },
+        ],
+      };
+      execute_Legacy = { 4: { 4: new BigNumber(3), 5: new BigNumber(4) } };
+      execute_ResetFields = { 4: { 0: new BigNumber(3), 1: new BigNumber(4) } };
+
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(tokenNestedOrWithoutAnnot.Execute(michelson)).toEqual(execute_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(tokenNestedOrWithoutAnnot.Execute(michelson)).toEqual(execute_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(tokenNestedOrWithoutAnnot.Execute(michelson)).toEqual(execute_ResetFields);
+
       expect(
         tokenNestedOrWithoutAnnot.Execute({
           prim: 'Right',
@@ -1242,7 +1489,21 @@ describe('Or token', () => {
           },
         ],
       };
-      const expected = {
+      const execute_Legacy = {
+        owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
+        inheritors: [],
+        status: {
+          rECOVERING: {
+            3: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+            4: '2024-04-19T13:53:22.000Z',
+          },
+        },
+        quick_recovery_stake: BigNumber(1000000),
+        quick_recovery_period: BigNumber(0),
+        direct_debit_mandates: '414522',
+        direct_debit_mandates_history: '414523',
+      };
+      const execte_ResetFields = {
         owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
         inheritors: [],
         status: {
@@ -1258,8 +1519,12 @@ describe('Or token', () => {
       };
 
       const schema = new Schema(schemaObj);
-      const result = schema.Execute(dataObj);
-      expect(result).toEqual(expected);
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(schema.Execute(dataObj)).toEqual(execute_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(schema.Execute(dataObj)).toEqual(execte_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(schema.Execute(dataObj)).toEqual(execte_ResetFields);
     });
 
     it('a smaller reproduction', () => {
@@ -1349,7 +1614,17 @@ describe('Or token', () => {
           },
         ],
       };
-      const expected = {
+      const execute_Legacy = {
+        owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
+        inheritors: [],
+        status: {
+          rECOVERING: {
+            3: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+            4: '2024-04-19T13:53:22.000Z',
+          },
+        },
+      };
+      const execute_ResetFields = {
         owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
         inheritors: [],
         status: {
@@ -1361,8 +1636,12 @@ describe('Or token', () => {
       };
 
       const schema = new Schema(schemaObj);
-      const result = schema.Execute(dataObj);
-      expect(result).toEqual(expected);
+      Token.fieldNumberingStrategy = 'Legacy';
+      expect(schema.Execute(dataObj)).toEqual(execute_Legacy);
+      Token.fieldNumberingStrategy = 'ResetFieldNumbersInNestedObjects';
+      expect(schema.Execute(dataObj)).toEqual(execute_ResetFields);
+      Token.fieldNumberingStrategy = 'Latest';
+      expect(schema.Execute(dataObj)).toEqual(execute_ResetFields);
     });
   });
 });

--- a/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
@@ -1046,133 +1046,6 @@ describe('Or token', () => {
             prim: 'nat',
             annots: ['%quick_recovery_period'],
           },
-        ],
-      };
-      const dataObj = {
-        prim: 'Pair',
-        args: [
-          [
-            {
-              string: 'tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6',
-            },
-          ],
-          [],
-          {
-            prim: 'Right',
-            args: [
-              {
-                prim: 'Left',
-                args: [
-                  {
-                    prim: 'Pair',
-                    args: [
-                      {
-                        string: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
-                      },
-                      {
-                        string: '2024-04-19T13:53:22Z',
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            int: '1000000',
-          },
-          {
-            int: '0',
-          },
-          {
-            int: '414522',
-          },
-          {
-            int: '414523',
-          },
-        ],
-      };
-      const expected = {
-        owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
-        inheritors: [],
-        status: {
-          rECOVERING: {
-            0: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
-            1: '2024-04-19T13:53:22.000Z',
-          },
-        },
-        quick_recovery_stake: BigNumber(1000000),
-        quick_recovery_period: BigNumber(0),
-        direct_debit_mandates: '414522',
-        direct_debit_mandates_history: '414523',
-      };
-
-      const schema = new Schema(schemaObj);
-      const result = schema.Execute(dataObj);
-      expect(result).toEqual(expected);
-    });
-
-    it('a smaller reproduction', () => {
-      const schemaObj = {
-        prim: 'pair',
-        args: [
-          {
-            prim: 'set',
-            args: [
-              {
-                prim: 'address',
-              },
-            ],
-            annots: ['%owners'],
-          },
-          {
-            prim: 'set',
-            args: [
-              {
-                prim: 'address',
-              },
-            ],
-            annots: ['%inheritors'],
-          },
-          {
-            prim: 'or',
-            args: [
-              {
-                prim: 'unit',
-                annots: ['%aCTIVE'],
-              },
-              {
-                prim: 'or',
-                args: [
-                  {
-                    prim: 'pair',
-                    args: [
-                      {
-                        prim: 'address',
-                      },
-                      {
-                        prim: 'timestamp',
-                      },
-                    ],
-                    annots: ['%rECOVERING'],
-                  },
-                  {
-                    prim: 'unit',
-                    annots: ['%dEAD'],
-                  },
-                ],
-              },
-            ],
-            annots: ['%status'],
-          },
-          {
-            prim: 'mutez',
-            annots: ['%quick_recovery_stake'],
-          },
-          {
-            prim: 'nat',
-            annots: ['%quick_recovery_period'],
-          },
           {
             prim: 'big_map',
             args: [
@@ -1382,6 +1255,109 @@ describe('Or token', () => {
         quick_recovery_period: BigNumber(0),
         direct_debit_mandates: '414522',
         direct_debit_mandates_history: '414523',
+      };
+
+      const schema = new Schema(schemaObj);
+      const result = schema.Execute(dataObj);
+      expect(result).toEqual(expected);
+    });
+
+    it('a smaller reproduction', () => {
+      const schemaObj = {
+        prim: 'pair',
+        args: [
+          {
+            prim: 'set',
+            args: [
+              {
+                prim: 'address',
+              },
+            ],
+            annots: ['%owners'],
+          },
+          {
+            prim: 'set',
+            args: [
+              {
+                prim: 'address',
+              },
+            ],
+            annots: ['%inheritors'],
+          },
+          {
+            prim: 'or',
+            args: [
+              {
+                prim: 'unit',
+                annots: ['%aCTIVE'],
+              },
+              {
+                prim: 'or',
+                args: [
+                  {
+                    prim: 'pair',
+                    args: [
+                      {
+                        prim: 'address',
+                      },
+                      {
+                        prim: 'timestamp',
+                      },
+                    ],
+                    annots: ['%rECOVERING'],
+                  },
+                  {
+                    prim: 'unit',
+                    annots: ['%dEAD'],
+                  },
+                ],
+              },
+            ],
+            annots: ['%status'],
+          },
+        ],
+      };
+      const dataObj = {
+        prim: 'Pair',
+        args: [
+          [
+            {
+              string: 'tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6',
+            },
+          ],
+          [],
+          {
+            prim: 'Right',
+            args: [
+              {
+                prim: 'Left',
+                args: [
+                  {
+                    prim: 'Pair',
+                    args: [
+                      {
+                        string: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+                      },
+                      {
+                        string: '2024-04-19T13:53:22Z',
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const expected = {
+        owners: ['tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6'],
+        inheritors: [],
+        status: {
+          rECOVERING: {
+            0: 'tz1dcjLdDM6uYKYdQhK177cUbtvL8QwX4ebH',
+            1: '2024-04-19T13:53:22.000Z',
+          },
+        },
       };
 
       const schema = new Schema(schemaObj);

--- a/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
@@ -154,7 +154,7 @@ describe('Or token', () => {
       });
       expect(
         tokenComplexNoAnnots.EncodeObject({
-          1: { 1: 3, 2: 4, 3: 31, 4: '2019-09-06T15:08:29.000Z' },
+          1: { 0: 3, 1: 4, 2: 31, 3: '2019-09-06T15:08:29.000Z' },
         })
       ).toEqual({
         prim: 'Left',
@@ -176,7 +176,7 @@ describe('Or token', () => {
           },
         ],
       });
-      expect(tokenComplexNoAnnots.EncodeObject({ 2: { 2: 3, 3: 'test' } })).toEqual({
+      expect(tokenComplexNoAnnots.EncodeObject({ 2: { 0: 3, 1: 'test' } })).toEqual({
         prim: 'Right',
         args: [
           {
@@ -187,7 +187,7 @@ describe('Or token', () => {
       });
       expect(
         tokenComplexNoAnnots.EncodeObject({
-          3: { 3: 4, 4: 3, 5: '2019-09-06T15:08:29.000Z' },
+          3: { 0: 4, 1: 3, 2: '2019-09-06T15:08:29.000Z' },
         })
       ).toEqual({
         prim: 'Right',
@@ -245,7 +245,7 @@ describe('Or token', () => {
       });
       expect(
         tokenComplex.EncodeObject({
-          option1: { 1: 3, 2: 4, 3: 31, 4: '2019-09-06T15:08:29.000Z' },
+          option1: { 0: 3, 1: 4, 2: 31, 3: '2019-09-06T15:08:29.000Z' },
         })
       ).toEqual({
         prim: 'Left',
@@ -267,7 +267,7 @@ describe('Or token', () => {
           },
         ],
       });
-      expect(tokenComplex.EncodeObject({ option2: { 2: 3, 3: 'test' } })).toEqual({
+      expect(tokenComplex.EncodeObject({ option2: { 0: 3, 1: 'test' } })).toEqual({
         prim: 'Right',
         args: [
           {
@@ -278,7 +278,7 @@ describe('Or token', () => {
       });
       expect(
         tokenComplex.EncodeObject({
-          option3: { 3: 4, 4: 3, 5: '2019-09-06T15:08:29.000Z' },
+          option3: { 0: 4, 1: 3, 2: '2019-09-06T15:08:29.000Z' },
         })
       ).toEqual({
         prim: 'Right',
@@ -577,9 +577,9 @@ describe('Or token', () => {
 
       expect(tokenComplexNoAnnots.ExtractSchema()).toEqual({
         0: { 0: 'nat', 1: 'nat', 2: 'timestamp' },
-        1: { 1: 'nat', 2: 'mutez', 3: 'nat', 4: 'timestamp' },
-        2: { 2: 'nat', 3: 'timestamp' },
-        3: { 3: 'nat', 4: 'mutez', 5: 'timestamp' },
+        1: { 0: 'nat', 1: 'mutez', 2: 'nat', 3: 'timestamp' },
+        2: { 0: 'nat', 1: 'timestamp' },
+        3: { 0: 'nat', 1: 'mutez', 2: 'timestamp' },
         4: 'nat',
       });
 
@@ -606,19 +606,19 @@ describe('Or token', () => {
           1: {
             __michelsonType: 'pair',
             schema: {
-              1: {
+              0: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              2: {
+              1: {
                 __michelsonType: 'mutez',
                 schema: 'mutez',
               },
-              3: {
+              2: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              4: {
+              3: {
                 __michelsonType: 'timestamp',
                 schema: 'timestamp',
               },
@@ -627,11 +627,11 @@ describe('Or token', () => {
           2: {
             __michelsonType: 'pair',
             schema: {
-              2: {
+              0: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              3: {
+              1: {
                 __michelsonType: 'timestamp',
                 schema: 'timestamp',
               },
@@ -640,15 +640,15 @@ describe('Or token', () => {
           3: {
             __michelsonType: 'pair',
             schema: {
-              3: {
+              0: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              4: {
+              1: {
                 __michelsonType: 'mutez',
                 schema: 'mutez',
               },
-              5: {
+              2: {
                 __michelsonType: 'timestamp',
                 schema: 'timestamp',
               },
@@ -663,9 +663,9 @@ describe('Or token', () => {
 
       expect(tokenComplex.ExtractSchema()).toEqual({
         option0: { 0: 'nat', 1: 'nat', 2: 'timestamp' },
-        option1: { 1: 'nat', 2: 'mutez', 3: 'nat', 4: 'timestamp' },
-        option2: { 2: 'nat', 3: 'timestamp' },
-        option3: { 3: 'nat', 4: 'mutez', 5: 'timestamp' },
+        option1: { 0: 'nat', 1: 'mutez', 2: 'nat', 3: 'timestamp' },
+        option2: { 0: 'nat', 1: 'timestamp' },
+        option3: { 0: 'nat', 1: 'mutez', 2: 'timestamp' },
         option4: 'nat',
       });
 
@@ -692,19 +692,19 @@ describe('Or token', () => {
           option1: {
             __michelsonType: 'pair',
             schema: {
-              1: {
+              0: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              2: {
+              1: {
                 __michelsonType: 'mutez',
                 schema: 'mutez',
               },
-              3: {
+              2: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              4: {
+              3: {
                 __michelsonType: 'timestamp',
                 schema: 'timestamp',
               },
@@ -713,11 +713,11 @@ describe('Or token', () => {
           option2: {
             __michelsonType: 'pair',
             schema: {
-              2: {
+              0: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              3: {
+              1: {
                 __michelsonType: 'timestamp',
                 schema: 'timestamp',
               },
@@ -726,15 +726,15 @@ describe('Or token', () => {
           option3: {
             __michelsonType: 'pair',
             schema: {
-              3: {
+              0: {
                 __michelsonType: 'nat',
                 schema: 'nat',
               },
-              4: {
+              1: {
                 __michelsonType: 'mutez',
                 schema: 'mutez',
               },
-              5: {
+              2: {
                 __michelsonType: 'timestamp',
                 schema: 'timestamp',
               },
@@ -856,7 +856,7 @@ describe('Or token', () => {
             },
           ],
         })
-      ).toEqual({ myPair: { 4: new BigNumber(3), 5: new BigNumber(4) } }); // { 4: { myPair: { 4: '3', 5: '4'} } }
+      ).toEqual({ myPair: { 0: new BigNumber(3), 1: new BigNumber(4) } }); // { 4: { myPair: { 4: '3', 5: '4'} } }
       expect(
         tokenNestedOr.Execute({
           prim: 'Right',
@@ -939,7 +939,7 @@ describe('Or token', () => {
             },
           ],
         })
-      ).toEqual({ 4: { 4: new BigNumber(3), 5: new BigNumber(4) } }); // { 4: { myPair: { 4: '3', 5: '4'} } }
+      ).toEqual({ 4: { 0: new BigNumber(3), 1: new BigNumber(4) } }); // { 4: { myPair: { 4: '3', 5: '4'} } }
       expect(
         tokenNestedOrWithoutAnnot.Execute({
           prim: 'Right',

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -32,8 +32,9 @@ import { ParserProvider } from './parser/interface';
 import { MichelCodecParser } from './parser/michel-codec-parser';
 import { Injector } from './injector/interface';
 import { RpcInjector } from './injector/rpc-injector';
+import { FieldNumberingStrategy, Token } from '@taquito/michelson-encoder';
 
-export { MichelsonMap, UnitValue } from '@taquito/michelson-encoder';
+export { FieldNumberingStrategy, Token, MichelsonMap, UnitValue } from '@taquito/michelson-encoder';
 export { Forger, ForgeParams, ForgeResponse } from '@taquito/local-forging';
 export * from './constants';
 export * from './context';
@@ -358,6 +359,14 @@ export class TezosToolkit {
       this._context.injector = injectorProvider;
       this._options.injectorProvider = injectorProvider;
     }
+  }
+
+  /**
+   * @description Sets the strategy used for field numbering in Token execute/encode/decode to convert Michelson values to/from javascript objects
+   * @param strategy a value of type FieldNumberingStrategy that controls how field numbers are calculated
+   */
+  setFieldNumberingStrategy(strategy: FieldNumberingStrategy) {
+    Token.fieldNumberingStrategy = strategy;
   }
 
   /**

--- a/packages/taquito/test/contract/contractAbstraction.spec.ts
+++ b/packages/taquito/test/contract/contractAbstraction.spec.ts
@@ -382,8 +382,8 @@ describe('ContractAbstraction test', () => {
       expect(method2).toBeInstanceOf(ContractMethod);
 
       const methodObject2 = contractAbs.methodsObject[2]({
-        2: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
-        3: '1',
+        0: 'tz1ZfrERcALBwmAqwonRXYVQBDT9BjNjBHJu',
+        1: '1',
       });
       expect(methodObject2).toBeInstanceOf(ContractMethodObject);
 


### PR DESCRIPTION
Closes #2927 
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [x] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [x] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet


This is a breaking change in (In API behaviour, not the API itself).
Previously, when Michelson Data was converted to javascript objects (For instance, by calling `storage` method of a contract abstraction), in the following scenario we would have an unexpected behaviour:
1. The javascript representation has nested objects, like having a `pair`, inside an `or` inside another `pair`
2. Some of the `pair`'s items don't have `annots`.

In this case, the the resulting javascript object would look like this

```
{
  '0': 'firstValue',
  '1': 'secondValue,
  '2': {
   '2': 'thirdValue',
   '3': 'fourthValue'
  }
```

Please note the the inner object's field numbers depend on the object's location in it's parent, and starts with '2' in this example. With this PR, this changes to:


```
{
  '0': 'firstValue',
  '1': 'secondValue,
  '2': {
   '0': 'thirdValue',
   '1': 'fourthValue'
  }
```

If your dApp code depends on the old behaviour (or changing it requires too much effort, you can call `Tezos.setFieldNumberingStrategy('Legacy')` to keep thew previous behaviour. But please note that in a future release, this option might be removed.

