### PR TITLE
added staking support in contract API, with unit and integration tests

### DIFF
--- a/integration-tests/__tests__/contract/operations/staking.spec.ts
+++ b/integration-tests/__tests__/contract/operations/staking.spec.ts
@@ -2,27 +2,31 @@ import { CONFIGS } from "../../../config";
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
-  let myPkh: string;
 
   describe(`Staking pseudo operations: ${rpc}`, () => {
 
     beforeAll(async () => {
       await setup(true);
 
-      myPkh = await Tezos.signer.publicKeyHash();
-      console.log(myPkh);
-
       const delegateOp = await Tezos.contract.setDelegate({
         delegate: 'tz1PZY3tEWmXGasYeehXYqwXuw2Z3iZ6QDnA',
-        source: myPkh,
+        source: await Tezos.signer.publicKeyHash()
       });
 
       await delegateOp.confirmation();
     });
 
-    it('should be able to inject the stake pseudo operation to a designated delegate', async () => {
+    it('should throw an error when the destination specified is not the same as source', async () => {
+      expect(async () => {
+        const op = await Tezos.contract.stake({
+          amount: 0.1,
+          to: 'tz1PZY3tEWmXGasYeehXYqwXuw2Z3iZ6QDnA'
+        });
+      }).rejects.toThrow();
+    });
+
+    it('should be able to stake funds to a designated delegate', async () => {
       const op = await Tezos.contract.stake({
-        to: myPkh,
         amount: 0.1
       });
       await op.confirmation();
@@ -33,7 +37,6 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
     it('should be able to unstake funds from a designated delegate', async () => {
       const op = await Tezos.contract.unstake({
-        to: myPkh,
         amount: 0.1
       });
       await op.confirmation();
@@ -43,10 +46,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     });
 
     it('should be able to finalize_unstake funds from a designated delegate', async () => {
-      const op = await Tezos.contract.finalizeUnstake({
-        to: myPkh,
-        amount: 0
-      });
+      const op = await Tezos.contract.finalizeUnstake({});
       await op.confirmation();
 
       expect(op.hash).toBeDefined();

--- a/integration-tests/__tests__/contract/operations/staking.spec.ts
+++ b/integration-tests/__tests__/contract/operations/staking.spec.ts
@@ -1,0 +1,56 @@
+import { CONFIGS } from "../../../config";
+
+CONFIGS().forEach(({ lib, rpc, setup }) => {
+  const Tezos = lib;
+  let myPkh: string;
+
+  describe(`Staking pseudo operations: ${rpc}`, () => {
+
+    beforeAll(async () => {
+      await setup(true);
+
+      myPkh = await Tezos.signer.publicKeyHash();
+      console.log(myPkh);
+
+      const delegateOp = await Tezos.contract.setDelegate({
+        delegate: 'tz1PZY3tEWmXGasYeehXYqwXuw2Z3iZ6QDnA',
+        source: myPkh,
+      });
+
+      await delegateOp.confirmation();
+    });
+
+    it('should be able to inject the stake pseudo operation to a designated delegate', async () => {
+      const op = await Tezos.contract.stake({
+        to: myPkh,
+        amount: 0.1
+      });
+      await op.confirmation();
+
+      expect(op.hash).toBeDefined();
+      expect(op.status).toEqual('applied');
+    });
+
+    it('should be able to unstake funds from a designated delegate', async () => {
+      const op = await Tezos.contract.unstake({
+        to: myPkh,
+        amount: 0.1
+      });
+      await op.confirmation();
+
+      expect(op.hash).toBeDefined();
+      expect(op.status).toEqual('applied');
+    });
+
+    it('should be able to finalize_unstake funds from a designated delegate', async () => {
+      const op = await Tezos.contract.finalizeUnstake({
+        to: myPkh,
+        amount: 0
+      });
+      await op.confirmation();
+
+      expect(op.hash).toBeDefined();
+      expect(op.status).toEqual('applied');
+    });
+  });
+});

--- a/packages/taquito-core/src/errors.ts
+++ b/packages/taquito-core/src/errors.ts
@@ -69,7 +69,7 @@ export class InvalidStakingAddressError extends ParameterValidationError {
   ) {
     super();
     this.name = 'InvalidStakingAddressError';
-    this.message = `Invalid staking address "${address}", you can only stake to your own address`;
+    this.message = `Invalid staking address "${address}", you can only set destination as your own address`;
   }
 }
 

--- a/packages/taquito-core/src/errors.ts
+++ b/packages/taquito-core/src/errors.ts
@@ -62,6 +62,28 @@ export class InvalidAddressError extends ParameterValidationError {
   }
 }
 
+export class InvalidStakingAddressError extends ParameterValidationError {
+  constructor(
+    public readonly address: string,
+    public readonly errorDetail?: string
+  ) {
+    super();
+    this.name = 'InvalidStakingAddressError';
+    this.message = `Invalid staking address "${address}", you can only stake to your own address`;
+  }
+}
+
+export class InvalidFinalizeUnstakeAmountError extends ParameterValidationError {
+  constructor(
+    public readonly address: string,
+    public readonly errorDetail?: string
+  ) {
+    super();
+    this.name = 'InvalidFinalizeUnstakeAmountError';
+    this.message = `The amount can only be 0 when finalizing an unstake`;
+  }
+}
+
 /**
  *  @category Error
  *  @description Error that indicates an invalid block hash being passed or used

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -31,7 +31,7 @@
     "node": ">=18"
   },
   "scripts": {
-    "test": "jest --coverage --testPathIgnorePatterns=operation-factory.spec.ts",
+    "test": "jest --coverage",
     "test:watch": "jest --coverage --watch",
     "test:prod": "npm run lint && npm run test -- --no-cache",
     "lint": "eslint --ext .js,.ts .",

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -25,6 +25,9 @@ import {
   SmartRollupOriginateParams,
   SmartRollupExecuteOutboxMessageParams,
   FailingNoopParams,
+  StakeParams,
+  UnstakeParams,
+  FinalizeUnstakeParams,
 } from '../operations/types';
 import { ContractAbstraction, ContractStorageType, DefaultContractType } from './contract';
 import { IncreasePaidStorageOperation } from '../operations/increase-paid-storage-operation';
@@ -157,6 +160,36 @@ export interface ContractProvider extends StorageProvider {
    * @param Transfer operation parameter
    */
   transfer(params: TransferParams): Promise<TransactionOperation>;
+
+  /**
+   *
+   * @description Stake tz from current address to a specific address. Built on top of the existing transaction operation
+   *
+   * @returns An operation handle with the result from the rpc node
+   *
+   * @param Stake pseudo-operation parameter
+   */
+  stake(params: StakeParams): Promise<TransactionOperation>;
+
+  /**
+   *
+   * @description Unstake tz from current address to a specific address. Built on top of the existing transaction operation
+   *
+   * @returns An operation handle with the result from the rpc node
+   *
+   * @param Unstake pseudo-operation parameter
+   */
+  unstake(params: UnstakeParams): Promise<TransactionOperation>;
+
+  /**
+   *
+   * @description Finalize unstake tz from current address to a specific address. Built on top of the existing transaction operation
+   *
+   * @returns An operation handle with the result from the rpc node
+   *
+   * @param finalize_unstake pseudo-operation parameter
+   */
+  finalizeUnstake(params: FinalizeUnstakeParams): Promise<TransactionOperation>;
 
   /**
    *

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -402,23 +402,23 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
 
   /**
    *
-   * @description Stake tz from current address to a specific address. Built on top of the existing transaction operation
+   * @description Stake a given amount for the source address
    *
    * @returns An operation handle with the result from the rpc node
    *
    * @param Stake pseudo-operation parameter
    */
   async stake(params: StakeParams) {
-    if (params.to === undefined) {
-      params.to = params.source;
-    }
-    if (params.to !== undefined && params.to !== params.source) {
-      throw new InvalidStakingAddressError(params.to);
-    }
-
     const sourceValidation = validateAddress(params.source ?? '');
     if (params.source && sourceValidation !== ValidationResult.VALID) {
       throw new InvalidAddressError(params.source, invalidDetail(sourceValidation));
+    }
+
+    if (!params?.to) {
+      params.to = params.source;
+    }
+    if (params?.to && params.to !== params.source) {
+      throw new InvalidStakingAddressError(params.to);
     }
 
     if (params.amount < 0) {
@@ -440,23 +440,26 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
 
   /**
    *
-   * @description Unstake tz from current address to a specific address. Built on top of the existing transaction operation
+   * @description Unstake the given amount. If "everything" is given as amount, unstakes everything from the staking balance.
+   * Unstaked tez remains frozen for a set amount of cycles (the slashing period) after the operation. Once this period is over,
+   * the operation "finalize unstake" must be called for the funds to appear in the liquid balance.
    *
    * @returns An operation handle with the result from the rpc node
    *
    * @param Unstake pseudo-operation parameter
    */
   async unstake(params: UnstakeParams) {
-    if (params.to === undefined) {
-      params.to = params.source;
-    }
-    if (params.to !== undefined && params.to !== params.source) {
-      throw new InvalidStakingAddressError(params.to);
-    }
-
     const sourceValidation = validateAddress(params.source ?? '');
     if (params.source && sourceValidation !== ValidationResult.VALID) {
       throw new InvalidAddressError(params.source, invalidDetail(sourceValidation));
+    }
+
+    if (!params?.to) {
+      params.to = params.source;
+    }
+
+    if (params?.to && params.to !== params.source) {
+      throw new InvalidStakingAddressError(params.to);
     }
 
     if (params.amount < 0) {
@@ -478,23 +481,22 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
 
   /**
    *
-   * @description Finalize unstake tz from current address to a specific address. Built on top of the existing transaction operation
-   *
+   * @description Transfer all the finalizable unstaked funds of the source to their liquid balance
    * @returns An operation handle with the result from the rpc node
    *
    * @param Finalize_unstake pseudo-operation parameter
    */
   async finalizeUnstake(params: FinalizeUnstakeParams) {
-    if (params.to === undefined) {
-      params.to = params.source;
-    }
-    if (params.to !== undefined && params.to !== params.source) {
-      throw new InvalidStakingAddressError(params.to);
-    }
-
     const sourceValidation = validateAddress(params.source ?? '');
     if (params.source && sourceValidation !== ValidationResult.VALID) {
       throw new InvalidAddressError(params.source, invalidDetail(sourceValidation));
+    }
+
+    if (!params?.to) {
+      params.to = params.source;
+    }
+    if (params?.to && params.to !== params.source) {
+      throw new InvalidStakingAddressError(params.to);
     }
 
     if (params.amount === undefined) {

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -414,10 +414,10 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       throw new InvalidAddressError(params.source, invalidDetail(sourceValidation));
     }
 
-    if (!params?.to) {
+    if (!params.to) {
       params.to = params.source;
     }
-    if (params?.to && params.to !== params.source) {
+    if (params.to && params.to !== params.source) {
       throw new InvalidStakingAddressError(params.to);
     }
 
@@ -454,11 +454,11 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       throw new InvalidAddressError(params.source, invalidDetail(sourceValidation));
     }
 
-    if (!params?.to) {
+    if (!params.to) {
       params.to = params.source;
     }
 
-    if (params?.to && params.to !== params.source) {
+    if (params.to && params.to !== params.source) {
       throw new InvalidStakingAddressError(params.to);
     }
 
@@ -492,10 +492,10 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       throw new InvalidAddressError(params.source, invalidDetail(sourceValidation));
     }
 
-    if (!params?.to) {
+    if (!params.to) {
       params.to = params.source;
     }
-    if (params?.to && params.to !== params.source) {
+    if (params.to && params.to !== params.source) {
       throw new InvalidStakingAddressError(params.to);
     }
 

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -499,7 +499,7 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       throw new InvalidStakingAddressError(params.to);
     }
 
-    if (params.amount === undefined) {
+    if (!params.amount) {
       params.amount = 0;
     }
     if (params.amount !== undefined && params.amount > 0) {

--- a/packages/taquito/src/estimate/estimate-provider-interface.ts
+++ b/packages/taquito/src/estimate/estimate-provider-interface.ts
@@ -14,6 +14,9 @@ import {
   SmartRollupAddMessagesParams,
   SmartRollupOriginateParams,
   SmartRollupExecuteOutboxMessageParams,
+  StakeParams,
+  UnstakeParams,
+  FinalizeUnstakeParams,
 } from '../operations/types';
 import { Estimate } from './estimate';
 import { ContractMethod, ContractMethodObject, ContractProvider } from '../contract';
@@ -38,6 +41,41 @@ export interface EstimationProvider {
    * @param Estimate
    */
   transfer({ fee, storageLimit, gasLimit, ...rest }: TransferParams): Promise<Estimate>;
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an stake pseudo-operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Estimate
+   */
+  stake({ fee, storageLimit, gasLimit, ...rest }: StakeParams): Promise<Estimate>;
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an unstake pseudo-operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Estimate
+   */
+  unstake({ fee, storageLimit, gasLimit, ...rest }: UnstakeParams): Promise<Estimate>;
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an finalize_unstake pseudo-operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Estimate
+   */
+  finalizeUnstake({
+    fee,
+    storageLimit,
+    gasLimit,
+    ...rest
+  }: FinalizeUnstakeParams): Promise<Estimate>;
 
   /**
    *

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -220,7 +220,7 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
       throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
     }
 
-    if (!rest?.to) {
+    if (!rest.to) {
       rest.to = rest.source;
     }
     if (rest.to && rest.to !== rest.source) {
@@ -260,7 +260,7 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
       throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
     }
 
-    if (!rest?.to) {
+    if (!rest.to) {
       rest.to = rest.source;
     }
     if (rest.to && rest.to !== rest.source) {
@@ -300,7 +300,7 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
       throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
     }
 
-    if (!rest?.to) {
+    if (!rest.to) {
       rest.to = rest.source;
     }
     if (rest.to && rest.to !== rest.source) {

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -17,6 +17,9 @@ import {
   SmartRollupAddMessagesParams,
   SmartRollupOriginateParams,
   SmartRollupExecuteOutboxMessageParams,
+  StakeParams,
+  UnstakeParams,
+  FinalizeUnstakeParams,
 } from '../operations/types';
 import { Estimate, EstimateProperties } from './estimate';
 import { EstimationProvider } from '../estimate/estimate-provider-interface';
@@ -188,6 +191,114 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
       throw new InvalidAmountError(rest.amount.toString());
     }
     const preparedOperation = await this.prepare.transaction({
+      fee,
+      storageLimit,
+      gasLimit,
+      ...rest,
+    });
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+    const estimateProperties = await this.calculateEstimates(preparedOperation, protocolConstants);
+
+    if (preparedOperation.opOb.contents[0].kind === 'reveal') {
+      estimateProperties.shift();
+      estimateProperties[0].opSize -= this.OP_SIZE_REVEAL / 2;
+    }
+    return Estimate.createEstimateInstanceFromProperties(estimateProperties);
+  }
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an stake pseudo-operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Stake pseudo-operation parameter
+   */
+  async stake({ fee, storageLimit, gasLimit, ...rest }: StakeParams) {
+    const toValidation = validateAddress(rest.to);
+    if (toValidation !== ValidationResult.VALID) {
+      throw new InvalidAddressError(rest.to, invalidDetail(toValidation));
+    }
+    const sourceValidation = validateAddress(rest.source ?? '');
+    if (rest.source && sourceValidation !== ValidationResult.VALID) {
+      throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
+    }
+    if (rest.amount < 0) {
+      throw new InvalidAmountError(rest.amount.toString());
+    }
+    const preparedOperation = await this.prepare.stake({
+      fee,
+      storageLimit,
+      gasLimit,
+      ...rest,
+    });
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+    const estimateProperties = await this.calculateEstimates(preparedOperation, protocolConstants);
+
+    if (preparedOperation.opOb.contents[0].kind === 'reveal') {
+      estimateProperties.shift();
+      estimateProperties[0].opSize -= this.OP_SIZE_REVEAL / 2;
+    }
+    return Estimate.createEstimateInstanceFromProperties(estimateProperties);
+  }
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an Unstake pseudo-operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param Unstake pseudo-operation parameter
+   */
+  async unstake({ fee, storageLimit, gasLimit, ...rest }: UnstakeParams) {
+    const toValidation = validateAddress(rest.to);
+    if (toValidation !== ValidationResult.VALID) {
+      throw new InvalidAddressError(rest.to, invalidDetail(toValidation));
+    }
+    const sourceValidation = validateAddress(rest.source ?? '');
+    if (rest.source && sourceValidation !== ValidationResult.VALID) {
+      throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
+    }
+    if (rest.amount < 0) {
+      throw new InvalidAmountError(rest.amount.toString());
+    }
+    const preparedOperation = await this.prepare.unstake({
+      fee,
+      storageLimit,
+      gasLimit,
+      ...rest,
+    });
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+    const estimateProperties = await this.calculateEstimates(preparedOperation, protocolConstants);
+
+    if (preparedOperation.opOb.contents[0].kind === 'reveal') {
+      estimateProperties.shift();
+      estimateProperties[0].opSize -= this.OP_SIZE_REVEAL / 2;
+    }
+    return Estimate.createEstimateInstanceFromProperties(estimateProperties);
+  }
+
+  /**
+   *
+   * @description Estimate gasLimit, storageLimit and fees for an finalize_unstake pseudo-operation
+   *
+   * @returns An estimation of gasLimit, storageLimit and fees for the operation
+   *
+   * @param finalize_unstake pseudo-operation parameter
+   */
+  async finalizeUnstake({ fee, storageLimit, gasLimit, ...rest }: FinalizeUnstakeParams) {
+    const toValidation = validateAddress(rest.to);
+    if (toValidation !== ValidationResult.VALID) {
+      throw new InvalidAddressError(rest.to, invalidDetail(toValidation));
+    }
+    const sourceValidation = validateAddress(rest.source ?? '');
+    if (rest.source && sourceValidation !== ValidationResult.VALID) {
+      throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
+    }
+    if (rest.amount < 0) {
+      throw new InvalidAmountError(rest.amount.toString());
+    }
+    const preparedOperation = await this.prepare.finalizeUnstake({
       fee,
       storageLimit,
       gasLimit,

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -307,7 +307,7 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
       throw new InvalidStakingAddressError(rest.to);
     }
 
-    if (rest.amount === undefined) {
+    if (!rest.amount) {
       rest.amount = 0;
     }
     if (rest.amount !== undefined && rest.amount !== 0) {

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -215,17 +215,18 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
    * @param Stake pseudo-operation parameter
    */
   async stake({ fee, storageLimit, gasLimit, ...rest }: StakeParams) {
-    if (rest.to === undefined) {
-      rest.to = rest.source;
-    }
-    if (rest.to !== undefined && rest.to !== rest.source) {
-      throw new InvalidStakingAddressError(rest.to);
-    }
-
     const sourceValidation = validateAddress(rest.source ?? '');
     if (rest.source && sourceValidation !== ValidationResult.VALID) {
       throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
     }
+
+    if (!rest?.to) {
+      rest.to = rest.source;
+    }
+    if (rest.to && rest.to !== rest.source) {
+      throw new InvalidStakingAddressError(rest.to);
+    }
+
     if (rest.amount < 0) {
       throw new InvalidAmountError(rest.amount.toString());
     }
@@ -254,17 +255,18 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
    * @param Unstake pseudo-operation parameter
    */
   async unstake({ fee, storageLimit, gasLimit, ...rest }: UnstakeParams) {
-    if (rest.to === undefined) {
-      rest.to = rest.source;
-    }
-    if (rest.to !== undefined && rest.to !== rest.source) {
-      throw new InvalidStakingAddressError(rest.to);
-    }
-
     const sourceValidation = validateAddress(rest.source ?? '');
     if (rest.source && sourceValidation !== ValidationResult.VALID) {
       throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
     }
+
+    if (!rest?.to) {
+      rest.to = rest.source;
+    }
+    if (rest.to && rest.to !== rest.source) {
+      throw new InvalidStakingAddressError(rest.to);
+    }
+
     if (rest.amount < 0) {
       throw new InvalidAmountError(rest.amount.toString());
     }
@@ -293,16 +295,18 @@ export class RPCEstimateProvider extends Provider implements EstimationProvider 
    * @param finalize_unstake pseudo-operation parameter
    */
   async finalizeUnstake({ fee, storageLimit, gasLimit, ...rest }: FinalizeUnstakeParams) {
-    if (rest.to === undefined) {
-      rest.to = rest.source;
-    }
-    if (rest.to !== undefined && rest.to !== rest.source) {
-      throw new InvalidStakingAddressError(rest.to);
-    }
     const sourceValidation = validateAddress(rest.source ?? '');
     if (rest.source && sourceValidation !== ValidationResult.VALID) {
       throw new InvalidAddressError(rest.source, invalidDetail(sourceValidation));
     }
+
+    if (!rest?.to) {
+      rest.to = rest.source;
+    }
+    if (rest.to && rest.to !== rest.source) {
+      throw new InvalidStakingAddressError(rest.to);
+    }
+
     if (rest.amount === undefined) {
       rest.amount = 0;
     }

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -311,6 +311,21 @@ export interface TransferParams {
 }
 
 /**
+ * @description RPC Stake pseudo operation params
+ */
+export interface StakeParams extends TransferParams {}
+
+/**
+ * @description RPC unstake pseudo operation params
+ */
+export interface UnstakeParams extends TransferParams {}
+
+/**
+ * @description RPC finalize_unstake pseudo operation params
+ */
+export interface FinalizeUnstakeParams extends TransferParams {}
+
+/**
  * @description RPC register global constant operation
  */
 export interface RPCRegisterGlobalConstantOperation {

--- a/packages/taquito/src/operations/types.ts
+++ b/packages/taquito/src/operations/types.ts
@@ -313,17 +313,44 @@ export interface TransferParams {
 /**
  * @description RPC Stake pseudo operation params
  */
-export interface StakeParams extends TransferParams {}
+export interface StakeParams {
+  to?: string;
+  source?: string;
+  amount: number;
+  fee?: number;
+  parameter?: TransactionOperationParameter;
+  gasLimit?: number;
+  storageLimit?: number;
+  mutez?: boolean;
+}
 
 /**
  * @description RPC unstake pseudo operation params
  */
-export interface UnstakeParams extends TransferParams {}
+export interface UnstakeParams {
+  to?: string;
+  source?: string;
+  amount: number;
+  fee?: number;
+  parameter?: TransactionOperationParameter;
+  gasLimit?: number;
+  storageLimit?: number;
+  mutez?: boolean;
+}
 
 /**
  * @description RPC finalize_unstake pseudo operation params
  */
-export interface FinalizeUnstakeParams extends TransferParams {}
+export interface FinalizeUnstakeParams {
+  to?: string;
+  source?: string;
+  amount?: number;
+  fee?: number;
+  parameter?: TransactionOperationParameter;
+  gasLimit?: number;
+  storageLimit?: number;
+  mutez?: boolean;
+}
 
 /**
  * @description RPC register global constant operation

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -28,6 +28,9 @@ import {
   isOpWithFee,
   RegisterDelegateParams,
   ActivationParams,
+  StakeParams,
+  UnstakeParams,
+  FinalizeUnstakeParams,
 } from '../operations/types';
 import { PreparationProvider, PreparedOperation } from './interface';
 import { REVEAL_STORAGE_LIMIT, Protocols, getRevealFee, getRevealGasLimit } from '../constants';
@@ -441,6 +444,141 @@ export class PrepareProvider extends Provider implements PreparationProvider {
     this.#counters = {};
     const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
 
+    const contents = this.constructOpContents(ops, headCounter, pkh, rest.source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  /**
+   *
+   * @description Method to prepare a stake pseudo-operation
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   * @returns a PreparedOperation object
+   */
+  async stake({ fee, storageLimit, gasLimit, ...rest }: StakeParams): Promise<PreparedOperation> {
+    const { pkh } = await this.getKeys();
+
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+    const DEFAULT_PARAMS = await this.getOperationLimits(protocolConstants);
+    const op = await createTransferOperation({
+      ...rest,
+      ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
+      parameter: {
+        entrypoint: 'stake',
+        value: {
+          prim: 'Unit',
+        },
+      },
+    });
+
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    this.#counters = {};
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+    const contents = this.constructOpContents(ops, headCounter, pkh, rest.source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  /**
+   *
+   * @description Method to prepare a unstake pseudo-operation
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   * @returns a PreparedOperation object
+   */
+  async unstake({
+    fee,
+    storageLimit,
+    gasLimit,
+    ...rest
+  }: UnstakeParams): Promise<PreparedOperation> {
+    const { pkh } = await this.getKeys();
+
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+    const DEFAULT_PARAMS = await this.getOperationLimits(protocolConstants);
+    const op = await createTransferOperation({
+      ...rest,
+      ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
+      parameter: {
+        entrypoint: 'unstake',
+        value: { prim: 'Unit' },
+      },
+    });
+
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    this.#counters = {};
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
+    const contents = this.constructOpContents(ops, headCounter, pkh, rest.source);
+
+    return {
+      opOb: {
+        branch: hash,
+        contents,
+        protocol,
+      },
+      counter: headCounter,
+    };
+  }
+
+  /**
+   *
+   * @description Method to prepare a finalize_unstake pseudo-operation
+   * @param operation RPCOperation object or RPCOperation array
+   * @param source string or undefined source pkh
+   * @returns a PreparedOperation object
+   */
+  async finalizeUnstake({
+    fee,
+    storageLimit,
+    gasLimit,
+    ...rest
+  }: FinalizeUnstakeParams): Promise<PreparedOperation> {
+    const { pkh } = await this.getKeys();
+
+    const protocolConstants = await this.context.readProvider.getProtocolConstants('head');
+    const DEFAULT_PARAMS = await this.getOperationLimits(protocolConstants);
+    const op = await createTransferOperation({
+      ...rest,
+      ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
+      parameter: {
+        entrypoint: 'finalize_unstake',
+        value: { prim: 'Unit' },
+      },
+    });
+
+    const operation = await this.addRevealOperationIfNeeded(op, pkh);
+    const ops = this.convertIntoArray(operation);
+
+    const hash = await this.getBlockHash();
+    const protocol = await this.getProtocolHash();
+
+    this.#counters = {};
+    const headCounter = parseInt(await this.getHeadCounter(pkh), 10);
     const contents = this.constructOpContents(ops, headCounter, pkh, rest.source);
 
     return {

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -470,6 +470,7 @@ export class PrepareProvider extends Provider implements PreparationProvider {
     const DEFAULT_PARAMS = await this.getOperationLimits(protocolConstants);
     const op = await createTransferOperation({
       ...rest,
+      to: pkh,
       ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
       parameter: {
         entrypoint: 'stake',
@@ -518,6 +519,7 @@ export class PrepareProvider extends Provider implements PreparationProvider {
     const DEFAULT_PARAMS = await this.getOperationLimits(protocolConstants);
     const op = await createTransferOperation({
       ...rest,
+      to: pkh,
       ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
       parameter: {
         entrypoint: 'unstake',
@@ -564,6 +566,8 @@ export class PrepareProvider extends Provider implements PreparationProvider {
     const DEFAULT_PARAMS = await this.getOperationLimits(protocolConstants);
     const op = await createTransferOperation({
       ...rest,
+      to: pkh,
+      amount: 0,
       ...mergeLimits({ fee, storageLimit, gasLimit }, DEFAULT_PARAMS),
       parameter: {
         entrypoint: 'finalize_unstake',

--- a/packages/taquito/test/contract/helper.ts
+++ b/packages/taquito/test/contract/helper.ts
@@ -1658,3 +1658,186 @@ export const smartRollupExecuteOutboxMessageNoReveal = {
   signature:
     'sigs8LVwSkqcMLzTVZWa1yS8aNz26A8bzR6QUHws5uVELh6kcmH7dWz5aKPqW3RXoFfynf5kVCvLJcsP3ucB5P6DEbD2YcQR',
 };
+
+export const stakeNoReveal = {
+  contents: [
+    {
+      kind: 'transaction',
+      source: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+      fee: '623',
+      counter: '390',
+      gas_limit: '3630',
+      storage_limit: '0',
+      amount: '6000000000',
+      destination: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+      parameters: {
+        entrypoint: 'stake',
+        value: {
+          prim: 'Unit',
+        },
+      },
+      metadata: {
+        balance_updates: [
+          {
+            kind: 'contract',
+            contract: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+            change: '-623',
+            origin: 'block',
+          },
+          {
+            kind: 'accumulator',
+            category: 'block fees',
+            change: '623',
+            origin: 'block',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          balance_updates: [
+            {
+              kind: 'contract',
+              contract: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+              change: '-6000000000',
+              origin: 'block',
+            },
+            {
+              kind: 'freezer',
+              category: 'deposits',
+              staker: {
+                baker: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+              },
+              change: '6000000000',
+              origin: 'block',
+            },
+          ],
+          consumed_milligas: '3629020',
+        },
+      },
+    },
+  ],
+  signature:
+    'sigRn6MmipGZEBYYCrN5MYQmc8A6ye8iBJdahUY4gfHwFAP8kFXaoRvEx51bmo2qmfEDobuUJ4Ld9HKyuS9tV45qmKzLhuVE',
+};
+
+export const unstakeNoReveal = {
+  contents: [
+    {
+      kind: 'transaction',
+      source: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+      fee: '689',
+      counter: '408',
+      gas_limit: '4250',
+      storage_limit: '0',
+      amount: '99999999999000000',
+      destination: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+      parameters: {
+        entrypoint: 'unstake',
+        value: {
+          prim: 'Unit',
+        },
+      },
+      metadata: {
+        balance_updates: [
+          {
+            kind: 'contract',
+            contract: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+            change: '-689',
+            origin: 'block',
+          },
+          {
+            kind: 'accumulator',
+            category: 'block fees',
+            change: '689',
+            origin: 'block',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          balance_updates: [
+            {
+              kind: 'staking',
+              category: 'delegate_denominator',
+              delegate: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+              change: '-1000000000',
+              origin: 'block',
+            },
+            {
+              kind: 'staking',
+              category: 'delegator_numerator',
+              delegator: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+              change: '-1000000000',
+              origin: 'block',
+            },
+            {
+              kind: 'freezer',
+              category: 'deposits',
+              staker: {
+                contract: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+                delegate: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+              },
+              change: '-1000000000',
+              origin: 'block',
+            },
+            {
+              kind: 'freezer',
+              category: 'unstaked_deposits',
+              staker: {
+                contract: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+                delegate: 'tz1X1TKpLiZuPEo2YVvDiqQ47Zp9a797ejkp',
+              },
+              cycle: 37,
+              change: '1000000000',
+              origin: 'block',
+            },
+          ],
+          consumed_milligas: '4249152',
+        },
+      },
+    },
+  ],
+  signature:
+    'sighibvGpL1NnZUyBfHPpPqE67tCb3aFK9L5JWhXA1GS9GqcizyZEEUfAGvzLMHxFG9oohhDzCJdMLFxppy3xbS9ZX45tWhM',
+};
+
+export const finalizeUnstakeNoReveal = {
+  contents: [
+    {
+      kind: 'transaction',
+      source: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+      fee: '409',
+      counter: '409',
+      gas_limit: '1529',
+      storage_limit: '0',
+      amount: '0',
+      destination: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+      parameters: {
+        entrypoint: 'finalize_unstake',
+        value: {
+          prim: 'Unit',
+        },
+      },
+      metadata: {
+        balance_updates: [
+          {
+            kind: 'contract',
+            contract: 'tz1eDDguimfor6kkt96Ri4pBeEZXEzvuyjQX',
+            change: '-409',
+            origin: 'block',
+          },
+          {
+            kind: 'accumulator',
+            category: 'block fees',
+            change: '409',
+            origin: 'block',
+          },
+        ],
+        operation_result: {
+          status: 'applied',
+          consumed_milligas: '1528887',
+        },
+      },
+    },
+  ],
+  signature:
+    'sigoVqiaKpRr5jctRcRXmpJaeRFPxKTRAaUyEbhGXWbKyo1EZ1eBCjVzN7Cg7nzSexQLWit75o2cJPd3bfJn1ciwHRHDLCSf',
+};

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -637,7 +637,6 @@ describe('RpcContractProvider test', () => {
   describe('transfer - staking pseudo operations', () => {
     it('should be able to produce a reveal and stake pseudo operation', async () => {
       const result = await rpcContractProvider.stake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
         fee: 10000,
         gasLimit: 10600,
@@ -664,7 +663,7 @@ describe('RpcContractProvider test', () => {
               gas_limit: '10600',
               storage_limit: '300',
               amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'stake',
                 value: {
@@ -682,12 +681,23 @@ describe('RpcContractProvider test', () => {
       });
     });
 
+    it('should be able to produce an error if destination is passed and is different than the source', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.stake.mockResolvedValue(estimate);
+
+      expect(async () => {
+        await rpcContractProvider.stake({
+          to: 'tz1iedjFYksExq8snZK9MNo4AvXHBdXfTsGX',
+          amount: 2,
+        });
+      }).rejects.toThrow();
+    });
+
     it('should be able to produce a stake operation when no fees are specified', async () => {
       const estimate = new Estimate(1000, 1000, 180, 1000);
       mockEstimate.stake.mockResolvedValue(estimate);
 
       const result = await rpcContractProvider.stake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
       });
 
@@ -711,7 +721,7 @@ describe('RpcContractProvider test', () => {
               gas_limit: '1',
               storage_limit: '1000',
               amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'stake',
                 value: {
@@ -736,7 +746,6 @@ describe('RpcContractProvider test', () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);
 
       const result = await rpcContractProvider.stake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
       });
 
@@ -751,7 +760,7 @@ describe('RpcContractProvider test', () => {
               gas_limit: '1',
               storage_limit: '1000',
               amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'stake',
                 value: {
@@ -771,7 +780,6 @@ describe('RpcContractProvider test', () => {
 
     it('should be able to produce a reveal and unstake pseudo operation', async () => {
       const result = await rpcContractProvider.unstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
         fee: 10000,
         gasLimit: 10600,
@@ -798,7 +806,7 @@ describe('RpcContractProvider test', () => {
               gas_limit: '10600',
               storage_limit: '300',
               amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'unstake',
                 value: {
@@ -821,7 +829,6 @@ describe('RpcContractProvider test', () => {
       mockEstimate.unstake.mockResolvedValue(estimate);
 
       const result = await rpcContractProvider.unstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
       });
 
@@ -845,7 +852,7 @@ describe('RpcContractProvider test', () => {
               gas_limit: '1',
               storage_limit: '1000',
               amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'unstake',
                 value: {
@@ -870,7 +877,6 @@ describe('RpcContractProvider test', () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);
 
       const result = await rpcContractProvider.unstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
       });
 
@@ -885,7 +891,7 @@ describe('RpcContractProvider test', () => {
               gas_limit: '1',
               storage_limit: '1000',
               amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'unstake',
                 value: {
@@ -905,8 +911,6 @@ describe('RpcContractProvider test', () => {
 
     it('should be able to produce a reveal and finalize_unstake pseudo operation', async () => {
       const result = await rpcContractProvider.finalizeUnstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-        amount: 2,
         fee: 10000,
         gasLimit: 10600,
         storageLimit: 300,
@@ -931,8 +935,8 @@ describe('RpcContractProvider test', () => {
               fee: '10000',
               gas_limit: '10600',
               storage_limit: '300',
-              amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              amount: '0',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'finalize_unstake',
                 value: {
@@ -950,14 +954,19 @@ describe('RpcContractProvider test', () => {
       });
     });
 
+    it('should throw an error when an amount other than 0 is specified on a finalize_unstake pseudo-operation', async () => {
+      await expect(
+        rpcContractProvider.finalizeUnstake({
+          amount: 2,
+        })
+      ).rejects.toThrow();
+    });
+
     it('should be able to produce a reveal and finalize_unstake pseudo operation when no fees are specified', async () => {
       const estimate = new Estimate(1000, 1000, 180, 1000);
       mockEstimate.finalizeUnstake.mockResolvedValue(estimate);
 
-      const result = await rpcContractProvider.finalizeUnstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-        amount: 2,
-      });
+      const result = await rpcContractProvider.finalizeUnstake({});
 
       expect(result.raw).toEqual({
         opbytes: 'test',
@@ -978,8 +987,8 @@ describe('RpcContractProvider test', () => {
               fee: '301',
               gas_limit: '1',
               storage_limit: '1000',
-              amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              amount: '0',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'finalize_unstake',
                 value: {
@@ -1003,10 +1012,7 @@ describe('RpcContractProvider test', () => {
 
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);
 
-      const result = await rpcContractProvider.finalizeUnstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-        amount: 2,
-      });
+      const result = await rpcContractProvider.finalizeUnstake({});
 
       expect(result.raw).toEqual({
         opbytes: 'test',
@@ -1018,8 +1024,8 @@ describe('RpcContractProvider test', () => {
               fee: '301',
               gas_limit: '1',
               storage_limit: '1000',
-              amount: '2000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              amount: '0',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'finalize_unstake',
                 value: {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -87,6 +87,9 @@ describe('RpcContractProvider test', () => {
     contractCall: jest.Mock<any, any>;
     smartRollupOriginate: jest.Mock<any, any>;
     smartRollupExecuteOutboxMessage: jest.Mock<any, any>;
+    stake: jest.Mock<any, any>;
+    unstake: jest.Mock<any, any>;
+    finalizeUnstake: jest.Mock<any, any>;
   };
 
   beforeEach(() => {
@@ -146,6 +149,9 @@ describe('RpcContractProvider test', () => {
       contractCall: jest.fn(),
       smartRollupOriginate: jest.fn(),
       smartRollupExecuteOutboxMessage: jest.fn(),
+      stake: jest.fn(),
+      unstake: jest.fn(),
+      finalizeUnstake: jest.fn(),
     };
 
     // Required for operations confirmation polling
@@ -624,6 +630,410 @@ describe('RpcContractProvider test', () => {
           signature: 'test_sig',
         },
         opbytes: 'test',
+      });
+    });
+  });
+
+  describe('transfer - staking pseudo operations', () => {
+    it('should be able to produce a reveal and stake pseudo operation', async () => {
+      const result = await rpcContractProvider.stake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '10000',
+              gas_limit: '10600',
+              storage_limit: '300',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'stake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a stake operation when no fees are specified', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.stake.mockResolvedValue(estimate);
+
+      const result = await rpcContractProvider.stake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '301',
+              gas_limit: '1',
+              storage_limit: '1000',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'stake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a stake operation without reveal when manager is defined', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.stake.mockResolvedValue(estimate);
+
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      const result = await rpcContractProvider.stake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '301',
+              gas_limit: '1',
+              storage_limit: '1000',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'stake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a reveal and unstake pseudo operation', async () => {
+      const result = await rpcContractProvider.unstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '10000',
+              gas_limit: '10600',
+              storage_limit: '300',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a reveal and unstake pseudo operation when no fees are specified', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.unstake.mockResolvedValue(estimate);
+
+      const result = await rpcContractProvider.unstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '301',
+              gas_limit: '1',
+              storage_limit: '1000',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a reveal and unstake pseudo operation without reveal when account is revealed', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.unstake.mockResolvedValue(estimate);
+
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      const result = await rpcContractProvider.unstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '301',
+              gas_limit: '1',
+              storage_limit: '1000',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a reveal and finalize_unstake pseudo operation', async () => {
+      const result = await rpcContractProvider.finalizeUnstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '10000',
+              gas_limit: '10600',
+              storage_limit: '300',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'finalize_unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a reveal and finalize_unstake pseudo operation when no fees are specified', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.finalizeUnstake.mockResolvedValue(estimate);
+
+      const result = await rpcContractProvider.finalizeUnstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '301',
+              gas_limit: '1',
+              storage_limit: '1000',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'finalize_unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should be able to produce a reveal and finalize_unstake pseudo operation without reveal when account is revealed', async () => {
+      const estimate = new Estimate(1000, 1000, 180, 1000);
+      mockEstimate.finalizeUnstake.mockResolvedValue(estimate);
+
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      const result = await rpcContractProvider.finalizeUnstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(result.raw).toEqual({
+        opbytes: 'test',
+        opOb: {
+          branch: 'test',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '301',
+              gas_limit: '1',
+              storage_limit: '1000',
+              amount: '2000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'finalize_unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_proto',
+          signature: 'test_sig',
+        },
+        counter: 0,
       });
     });
   });

--- a/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
@@ -186,7 +186,6 @@ describe('RPCEstimateProvider test signer', () => {
       mockRpcClient.simulateOperation.mockResolvedValue(stakeNoReveal);
 
       const estimate = await estimateProvider.stake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
       });
 
@@ -197,7 +196,6 @@ describe('RPCEstimateProvider test signer', () => {
       mockRpcClient.simulateOperation.mockResolvedValue(unstakeNoReveal);
 
       const estimate = await estimateProvider.unstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 2,
       });
 
@@ -207,10 +205,7 @@ describe('RPCEstimateProvider test signer', () => {
     it('should return estimates for finalize_unstake pseudo-operation', async () => {
       mockRpcClient.simulateOperation.mockResolvedValue(finalizeUnstakeNoReveal);
 
-      const estimate = await estimateProvider.finalizeUnstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-        amount: 2,
-      });
+      const estimate = await estimateProvider.finalizeUnstake({});
 
       expect(estimate.gasLimit).toEqual(1629);
     });

--- a/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
@@ -22,6 +22,9 @@ import {
   smartRollupAddMessagesNoReveal,
   smartRollupOriginateWithReveal,
   smartRollupExecuteOutboxMessageNoReveal,
+  stakeNoReveal,
+  unstakeNoReveal,
+  finalizeUnstakeNoReveal,
 } from '../contract/helper';
 import { OpKind, PvmKind } from '@taquito/rpc';
 import { TransferTicketParams } from '../../src/operations/types';
@@ -175,6 +178,41 @@ describe('RPCEstimateProvider test signer', () => {
         init: '{}',
       });
       expect(estimate.gasLimit).toEqual(1100);
+    });
+  });
+
+  describe('staking', () => {
+    it('should return estimates for stake pseudo-operation', async () => {
+      mockRpcClient.simulateOperation.mockResolvedValue(stakeNoReveal);
+
+      const estimate = await estimateProvider.stake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(estimate.gasLimit).toEqual(3730);
+    });
+
+    it('should return estimates for unstake pseudo-operation', async () => {
+      mockRpcClient.simulateOperation.mockResolvedValue(unstakeNoReveal);
+
+      const estimate = await estimateProvider.unstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(estimate.gasLimit).toEqual(4350);
+    });
+
+    it('should return estimates for finalize_unstake pseudo-operation', async () => {
+      mockRpcClient.simulateOperation.mockResolvedValue(finalizeUnstakeNoReveal);
+
+      const estimate = await estimateProvider.finalizeUnstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+      });
+
+      expect(estimate.gasLimit).toEqual(1629);
     });
   });
 

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -269,7 +269,6 @@ describe('PrepareProvider test', () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(false);
 
       const prepared = await prepareProvider.stake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 1000000000,
       });
 
@@ -292,7 +291,7 @@ describe('PrepareProvider test', () => {
               gas_limit: '1040000',
               storage_limit: '60000',
               amount: '1000000000000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'stake',
                 value: {
@@ -313,7 +312,6 @@ describe('PrepareProvider test', () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);
 
       const prepared = await prepareProvider.stake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 1000000000,
       });
 
@@ -327,7 +325,7 @@ describe('PrepareProvider test', () => {
               gas_limit: '1040000',
               storage_limit: '60000',
               amount: '1000000000000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'stake',
                 value: {
@@ -350,7 +348,6 @@ describe('PrepareProvider test', () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(false);
 
       const prepared = await prepareProvider.unstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 9999,
       });
 
@@ -373,7 +370,7 @@ describe('PrepareProvider test', () => {
               gas_limit: '1040000',
               storage_limit: '60000',
               amount: '9999000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'unstake',
                 value: {
@@ -394,7 +391,6 @@ describe('PrepareProvider test', () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);
 
       const prepared = await prepareProvider.unstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
         amount: 9999,
       });
 
@@ -408,7 +404,7 @@ describe('PrepareProvider test', () => {
               gas_limit: '1040000',
               storage_limit: '60000',
               amount: '9999000000',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'unstake',
                 value: {
@@ -430,10 +426,7 @@ describe('PrepareProvider test', () => {
     it('should return a prepared finalize_unstake pseudo operation with a reveal op', async () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(false);
 
-      const prepared = await prepareProvider.finalizeUnstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-        amount: 0,
-      });
+      const prepared = await prepareProvider.finalizeUnstake({});
 
       expect(prepared).toEqual({
         opOb: {
@@ -454,7 +447,7 @@ describe('PrepareProvider test', () => {
               gas_limit: '1040000',
               storage_limit: '60000',
               amount: '0',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'finalize_unstake',
                 value: {
@@ -474,10 +467,7 @@ describe('PrepareProvider test', () => {
     it('should return a prepared finalize_unstake pseudo operation without a reveal op', async () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);
 
-      const prepared = await prepareProvider.finalizeUnstake({
-        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
-        amount: 0,
-      });
+      const prepared = await prepareProvider.finalizeUnstake({});
 
       expect(prepared).toEqual({
         opOb: {
@@ -489,7 +479,7 @@ describe('PrepareProvider test', () => {
               gas_limit: '1040000',
               storage_limit: '60000',
               amount: '0',
-              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              destination: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
               parameters: {
                 entrypoint: 'finalize_unstake',
                 value: {

--- a/packages/taquito/test/prepare/prepare-provider.spec.ts
+++ b/packages/taquito/test/prepare/prepare-provider.spec.ts
@@ -264,6 +264,249 @@ describe('PrepareProvider test', () => {
     });
   });
 
+  describe('stake', () => {
+    it('should return a prepared stake pseudo operation with a reveal op', async () => {
+      mockReadProvider.isAccountRevealed.mockResolvedValue(false);
+
+      const prepared = await prepareProvider.stake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 1000000000,
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '0',
+              gas_limit: '1040000',
+              storage_limit: '60000',
+              amount: '1000000000000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'stake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should return a prepared stake pseudo operation without a reveal op', async () => {
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      const prepared = await prepareProvider.stake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 1000000000,
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '0',
+              gas_limit: '1040000',
+              storage_limit: '60000',
+              amount: '1000000000000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'stake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+  });
+
+  describe('finalize_unstake', () => {
+    it('should return an unstake pseudo operation with a reveal op', async () => {
+      mockReadProvider.isAccountRevealed.mockResolvedValue(false);
+
+      const prepared = await prepareProvider.unstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 9999,
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '0',
+              gas_limit: '1040000',
+              storage_limit: '60000',
+              amount: '9999000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should return an unstake pseudo operation without a reveal op', async () => {
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      const prepared = await prepareProvider.unstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 9999,
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '0',
+              gas_limit: '1040000',
+              storage_limit: '60000',
+              amount: '9999000000',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+  });
+
+  describe('finalize_unstake', () => {
+    it('should return a prepared finalize_unstake pseudo operation with a reveal op', async () => {
+      mockReadProvider.isAccountRevealed.mockResolvedValue(false);
+
+      const prepared = await prepareProvider.finalizeUnstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 0,
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'reveal',
+              fee: '331',
+              public_key: 'test_pub_key',
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              gas_limit: '625',
+              storage_limit: '0',
+              counter: '1',
+            },
+            {
+              kind: 'transaction',
+              fee: '0',
+              gas_limit: '1040000',
+              storage_limit: '60000',
+              amount: '0',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'finalize_unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '2',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+
+    it('should return a prepared finalize_unstake pseudo operation without a reveal op', async () => {
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      const prepared = await prepareProvider.finalizeUnstake({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 0,
+      });
+
+      expect(prepared).toEqual({
+        opOb: {
+          branch: 'test_block_hash',
+          contents: [
+            {
+              kind: 'transaction',
+              fee: '0',
+              gas_limit: '1040000',
+              storage_limit: '60000',
+              amount: '0',
+              destination: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+              parameters: {
+                entrypoint: 'finalize_unstake',
+                value: {
+                  prim: 'Unit',
+                },
+              },
+              source: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+              counter: '1',
+            },
+          ],
+          protocol: 'test_protocol',
+        },
+        counter: 0,
+      });
+    });
+  });
+
   describe('drainDelegate', () => {
     it('should return a prepared drain_delegate operation', async () => {
       mockReadProvider.isAccountRevealed.mockResolvedValue(true);


### PR DESCRIPTION
closes #2886 

- implemented stake, unstake, and finalize_unstake in the Contract API (estimate, prepare, contract provider)
- updated unit and integration tests
- updated types and interfaces to accommodate new pseudo operations

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [x] You have added integration tests (if relevant/appropriate)
- [x] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
