### PR TITLE
add Tezos Foundation RPCs

### DIFF
--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -29,6 +29,9 @@ values={[
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |
 | Tezos Foundation | Mainnet      | https://rpc.tzbeta.net/                  | [Check](https://rpc.tzbeta.net/chains/main/blocks/head/header)                  |
+| Tezos Foundation | Ghostnet     | https://rpc.ghostnet.teztnets.com/       | [Check](https://rpc.ghostnet.teztnets.com/chains/main/blocks/head/header)       |
+| Tezos Foundation | Oxfordnet    | https://rpc.oxfordnet.teztnets.com/      | [Check](https://rpc.oxfordnet.teztnets.com/chains/main/blocks/head/header)      |
+| Tezos Foundation | Parisnet     | https://rpc.parisnet.teztnets.com/       | [Check](https://rpc.parisnet.teztnets.com/chains/main/blocks/head/header)       |
 | Marigold         | Mainnet      | https://mainnet.tezos.marigold.dev/      | [Check](https://mainnet.tezos.marigold.dev/chains/main/blocks/head/header)      |
 | Marigold         | Ghostnet     | https://ghostnet.tezos.marigold.dev/     | [Check](https://ghostnet.tezos.marigold.dev/chains/main/blocks/head/header)     |
 | Marigold         | Oxfordnet    | https://oxfordnet.tezos.marigold.dev/    | [Check](https://oxfordnet.tezos.marigold.dev/chains/main/blocks/head/header)    |


### PR DESCRIPTION
closes [#2933](https://github.com/ecadlabs/taquito/issues/2933)

Adds the following Tezos Foundation links to the [RPC nodes page](https://taquito.io/docs/rpc_nodes/):

* Ghostnet: https://rpc.ghostnet.teztnets.com/
* Oxfordnet: https://rpc.oxfordnet.teztnets.com/
* Parisnet: https://rpc.parisnet.teztnets.com/