### PR TITLE
2958 eventsub

### DIFF
--- a/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
+++ b/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
@@ -40,7 +40,6 @@ export class BeaconWallet implements WalletProvider {
     this.client = getDAppClientInstance(options);
 
     this.client.subscribeToEvent(BeaconEvent.ACTIVE_ACCOUNT_SET, async (data) => {
-      console.log(`${BeaconEvent.ACTIVE_ACCOUNT_SET} triggered: `, data);
       this.account = data;
     });
   }

--- a/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
+++ b/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
@@ -67,7 +67,6 @@ export class BeaconWallet implements WalletProvider {
   }
 
   async getPKH() {
-    // const account = await this.client.getActiveAccount();
     if (!this.account) {
       throw new BeaconWalletNotInitialized();
     }
@@ -75,7 +74,6 @@ export class BeaconWallet implements WalletProvider {
   }
 
   async getPK() {
-    // const account = await this.client.getActiveAccount();
     if (!this.account) {
       throw new BeaconWalletNotInitialized();
     }
@@ -175,7 +173,6 @@ export class BeaconWallet implements WalletProvider {
   }
 
   async sendOperations(params: any[]) {
-    // const account = await this.client.getActiveAccount();
     if (!this.account) {
       throw new BeaconWalletNotInitialized();
     }

--- a/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
+++ b/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
@@ -38,7 +38,6 @@ export class BeaconWallet implements WalletProvider {
 
   constructor(options: DAppClientOptions) {
     this.client = getDAppClientInstance(options);
-
     this.client.subscribeToEvent(BeaconEvent.ACTIVE_ACCOUNT_SET, async (data) => {
       this.account = data;
     });


### PR DESCRIPTION
closes #2958 
Updated taquito beacon wallet to use `subscribeToEvent` instead of `getActiveAccount`

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [x] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
