### PR TITLE
chore: update node v16 github actions

### DIFF
--- a/.github/workflows/bundle_webpack.yml
+++ b/.github/workflows/bundle_webpack.yml
@@ -13,29 +13,25 @@ jobs:
   bundle-webpack:
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Checkout repository
-      uses: actions/checkout@v2
-    -
-      uses: actions/setup-node@v2
-      with:
-        node-version: lts/hydrogen
-    - run: npm ci
-    - run: npm run build
-    - run: npm -w packages/taquito-local-forging run build-webpack
-    -
-      uses: actions/upload-artifact@v3
-      with:
-        name: taquito-local-forging-vanilla
-        path: |
-          packages/taquito-local-forging/dist/taquito_local_forging.js
-          packages/taquito-local-forging/dist/taquito_local_forging.js.map
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/hydrogen
+      - run: npm ci
+      - run: npm run build
+      - run: npm -w packages/taquito-local-forging run build-webpack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: taquito-local-forging-vanilla
+          path: |
+            packages/taquito-local-forging/dist/taquito_local_forging.js
+            packages/taquito-local-forging/dist/taquito_local_forging.js.map
 
-    - run: npm -w packages/taquito-beacon-wallet run build-webpack
-    -
-      uses: actions/upload-artifact@v3
-      with:
-        name: taquito-beacon-wallet-vanilla
-        path: |
-          packages/taquito-beacon-wallet/dist/taquito_beacon_wallet.js
-          packages/taquito-beacon-wallet/dist/taquito_beacon_wallet.js.map
+      - run: npm -w packages/taquito-beacon-wallet run build-webpack
+      - uses: actions/upload-artifact@v3
+        with:
+          name: taquito-beacon-wallet-vanilla
+          path: |
+            packages/taquito-beacon-wallet/dist/taquito_beacon_wallet.js
+            packages/taquito-beacon-wallet/dist/taquito_beacon_wallet.js.map

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
@@ -23,33 +23,33 @@ jobs:
       security-events: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        config-file: ./.github/codeql/codeql-config.yml
-      # Override language selection by uncommenting this and choosing your languages
-      # with:
-      #   languages: go, javascript, csharp, python, cpp, java
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          config-file: ./.github/codeql/codeql-config.yml
+        # Override language selection by uncommenting this and choosing your languages
+        # with:
+        #   languages: go, javascript, csharp, python, cpp, java
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -17,26 +17,26 @@ jobs:
     env:
       VERDACCIO_TOKEN: ${{ secrets.EDGE_VERDACCIO_TOKEN }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
-      with:
-        node-version: lts/hydrogen
-    - run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-    - run: echo "PACKAGE_VERSION=`node -p "require('./packages/taquito/package.json').version"`" >> $GITHUB_ENV
-    - run: echo "BRANCH_NAME=$(git branch --show-current)" >> $GITHUB_ENV
-    - run: echo "TARGET_VERSION=${PACKAGE_VERSION}-${SHORT_SHA}--${BRANCH_NAME}" >> $GITHUB_ENV
-    - run: npm ci
-    - run: find packages/ -mindepth 1 -maxdepth 2 -name README.md | xargs sed -i '1s/^/# WARNING This build is produced from a feature branch and could contain unreviewed changes from the public. Use with caution, do not use in production\n\n/'
-    - run: npx lerna version "${TARGET_VERSION}" --no-push --no-git-tag-version --yes
-    - run: npm run version-stamp
-    - run: npm run build
-    - run: npm run -w @taquito/taquito build:release
-    - run: git config user.email "actions@github.com" && git config user.name "Github Actions"
-    - run: git add . && git commit -m "committing changes to files to make lerna happy in next step, this is expected to never be pushed to remote"
-    - run: echo ${VERDACCIO_TOKEN} >> ~/.npmrc
-    - run: npx lerna publish --dist-tag edge from-package --yes --registry https://npm.preview.tezostaquito.io/
-    - if: ${{ github.event_name == 'pull_request' }}
-      run: |
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/hydrogen
+      - run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - run: echo "PACKAGE_VERSION=`node -p "require('./packages/taquito/package.json').version"`" >> $GITHUB_ENV
+      - run: echo "BRANCH_NAME=$(git branch --show-current)" >> $GITHUB_ENV
+      - run: echo "TARGET_VERSION=${PACKAGE_VERSION}-${SHORT_SHA}--${BRANCH_NAME}" >> $GITHUB_ENV
+      - run: npm ci
+      - run: find packages/ -mindepth 1 -maxdepth 2 -name README.md | xargs sed -i '1s/^/# WARNING This build is produced from a feature branch and could contain unreviewed changes from the public. Use with caution, do not use in production\n\n/'
+      - run: npx lerna version "${TARGET_VERSION}" --no-push --no-git-tag-version --yes
+      - run: npm run version-stamp
+      - run: npm run build
+      - run: npm run -w @taquito/taquito build:release
+      - run: git config user.email "actions@github.com" && git config user.name "Github Actions"
+      - run: git add . && git commit -m "committing changes to files to make lerna happy in next step, this is expected to never be pushed to remote"
+      - run: echo ${VERDACCIO_TOKEN} >> ~/.npmrc
+      - run: npx lerna publish --dist-tag edge from-package --yes --registry https://npm.preview.tezostaquito.io/
+      - if: ${{ github.event_name == 'pull_request' }}
+        run: |
           echo "COMMENT_BODY<<EOF"  >> $GITHUB_ENV
           echo "New packages have been deployed to the preview repository at https://npm.preview.tezostaquito.io/." >> $GITHUB_ENV
           echo "" >> $GITHUB_ENV
@@ -45,8 +45,8 @@ jobs:
           find packages/ -mindepth 1 -maxdepth 2 -name package.json | xargs -I{} node -pe "require('./{}')['name']" | sed "s/^\(.*\)$/npm i \1@${TARGET_VERSION} --registry https:\/\/npm.preview.tezostaquito.io\//" >> $GITHUB_ENV
           echo "\`\`\`" >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
-    - if: ${{ github.event_name == 'pull_request' }}
-      uses: marocchino/sticky-pull-request-comment@v2
-      with:
-        header: deploy-packages
-        message: ${{ env.COMMENT_BODY }}
+      - if: ${{ github.event_name == 'pull_request' }}
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: deploy-packages
+          message: ${{ env.COMMENT_BODY }}

--- a/.github/workflows/deploy_test_dapp.yml
+++ b/.github/workflows/deploy_test_dapp.yml
@@ -19,28 +19,28 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: lts/hydrogen
-    - run: npm ci
-    - run: npm run build
-    - run: npm -w taquito-test-dapp-vite run build
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/hydrogen
+      - run: npm ci
+      - run: npm run build
+      - run: npm -w taquito-test-dapp-vite run build
 
-    - name: Publish to Cloudflare Pages
-      id: cloudflare_publish
-      uses: cloudflare/pages-action@v1
-      with:
-        apiToken: ${{ secrets.CF_API_TOKEN }}
-        accountId: ${{ secrets.CF_ACCOUNT_ID }}
-        projectName: taquito-test-dapp
-        directory: apps/taquito-test-dapp/dist
-        gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-        wranglerVersion: '3'
+      - name: Publish to Cloudflare Pages
+        id: cloudflare_publish
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: taquito-test-dapp
+          directory: apps/taquito-test-dapp/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          wranglerVersion: '3'
 
-    # Notify the PR of the deploy preview
-    - uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
-      with:
-        header: Test Dapp Preview
-        message: 'A new deploy preview is available on Cloudflare Pages at ${{ steps.cloudflare_publish.outputs.URL }}'
+      # Notify the PR of the deploy preview
+      - uses: marocchino/sticky-pull-request-comment@v2
+        if: github.event_name == 'pull_request'
+        with:
+          header: Test Dapp Preview
+          message: 'A new deploy preview is available on Cloudflare Pages at ${{ steps.cloudflare_publish.outputs.URL }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,22 +20,22 @@ jobs:
           - 'lts/hydrogen'
           - 'lts/iron'
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node }}
-    - run: npm ci
-    - run: npm run build
-    - run: npm run lint
-    - run: npm run build-docs
-    - run: npm run test -- --runInBand
-    - name: Codecov
-      uses: codecov/codecov-action@v3.1.1
-      with:
-        file: .coverage/*.json
-      env:
-        CI: true
-        RUN_INTEGRATION: true
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm run build-docs
+      - run: npm run test -- --runInBand
+      - name: Codecov
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          file: .coverage/*.json
+        env:
+          CI: true
+          RUN_INTEGRATION: true
 
   integration-tests-testnet:
     runs-on: ubuntu-latest
@@ -46,22 +46,22 @@ jobs:
           - testnet: oxfordnet
             testnet_uppercase: OXFORDNET
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: lts/hydrogen
-    - run: npm ci
-    - run: npm run build
-    - if: ${{ !github.event.pull_request.head.repo.fork }}
-      name: Tailscale
-      uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-        version: 1.32.2
-    - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=4
-      env:
-        # Ternary operator workaround
-        TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.event.pull_request.head.repo.fork && format('https://{0}.ecadinfra.com', matrix.testnet) || null }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/hydrogen
+      - run: npm ci
+      - run: npm run build
+      - if: ${{ !github.event.pull_request.head.repo.fork }}
+        name: Tailscale
+        uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          version: 1.32.2
+      - run: npm -w integration-tests run test:${{ matrix.testnet }} -- --maxWorkers=4
+        env:
+          # Ternary operator workaround
+          TEZOS_RPC_${{ matrix.testnet_uppercase }}: ${{ github.event.pull_request.head.repo.fork && format('https://{0}.ecadinfra.com', matrix.testnet) || null }}
 
   integration-tests-flextesa:
     runs-on: ubuntu-latest
@@ -74,52 +74,52 @@ jobs:
             testnet_uppercase: NAIROBINET
             flextesa_docker_image: oxheadalpha/flextesa:20230607
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: lts/hydrogen
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/hydrogen
 
-    ## The 4 Bootstrap Accounts (alias, pk, pkh, sk)
-    # alice,edpkvGfYw3LyB1UcCahKQk4rF2tvbMUk8GFiTuMjL75uGXrpvKXhjn,tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb,unencrypted:edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq
-    # bob,edpkurPsQ8eUApnLUJ9ZPDvu98E8VNj4KtJa1aZr16Cr5ow5VHKnz4,tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6,unencrypted:edsk3RFfvaFaxbHx8BMtEW1rKQcPtDML3LXjNqMNLCzC3wLC1bWbAt
-    # charlie,edpkuvMuRuZ6ZbAquJH1XxBFfUmuBFz1zp9ENEqjCVgLp3NcY3Ww9M,tz1RDVcKmFcqzvTpJirvg4JaUVgZbjtnRT26,unencrypted:edsk3RgWvbKKA1atEUcaGwivge7QtckHkTL9nQJUXQKY5r8WKp4pF4
-    # donald,edpkvXGp1BMZxHkwg3mKnWfJYS6HTJ5JtufD8YXxLtH8UKqLZkZVun,tz1eSWp4B9s1qhtNMMNXAkaf2oqCnDHd2iAm,unencrypted:edsk3S8mG2sSBmSRbikAcZVLCz4SrCq4DjmsQRic6MGktqNFijfrS2
-    - name: Generate Flextesa bootstrap accounts
-      run: |-
-        echo "alice=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key alice)" >> $GITHUB_ENV
-        echo "bob=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key bob)" >> $GITHUB_ENV
-        echo "charlie=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key charlie)" >> $GITHUB_ENV
-        echo "donald=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key donald)" >> $GITHUB_ENV
-    - name: Provision Flextesa ${{ matrix.protocol }} container
-      run: |-
-        docker run \
-        --rm \
-        --name my-sandbox \
-        --detach \
-        -p 20000:20000 \
-        ${{ matrix.flextesa_docker_image }} \
-        flextesa mini-net \
-          --root /tmp/mini-box --size 1 \
-          --set-history-mode N000:archive \
-          --number-of-b 1 \
-          --balance-of-bootstrap-accounts tez:100_000_000 \
-          --time-b 1 \
-          --add-bootstrap-account="${alice}@2_000_000_000_000" \
-          --add-bootstrap-account="${bob}@2_000_000_000_000" \
-          --add-bootstrap-account="${charlie}@2_000_000_000_000" \
-          --add-bootstrap-account="${donald}@2_000_000_000_000" \
-          --no-daemons-for=donald \
-          --until-level 200_000_000 \
-          --protocol-kind ${{ matrix.protocol }}
-    - run: npm ci
-    - run: npm run build
-    - run: source ./integration-tests/sandbox-env.sh
-    - run: npm -w integration-tests run test:nairobinet-secret-key sandbox-ballot-operation.spec.ts
-    - run: npm -w integration-tests run test:nairobinet-secret-key sandbox-drain-delegate-operation.spec.ts
-      env:
-        RUN_${{ matrix.testnet_uppercase }}_WITH_SECRET_KEY: true
-        SECRET_KEY: edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq
-        TEZOS_RPC_${{ matrix.testnet_uppercase }}: http://localhost:20000
-        POLLING_INTERVAL_MILLISECONDS: 100
-        RPC_CACHE_MILLISECONDS: 0
-        TEZOS_BAKER: tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb
+      ## The 4 Bootstrap Accounts (alias, pk, pkh, sk)
+      # alice,edpkvGfYw3LyB1UcCahKQk4rF2tvbMUk8GFiTuMjL75uGXrpvKXhjn,tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb,unencrypted:edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq
+      # bob,edpkurPsQ8eUApnLUJ9ZPDvu98E8VNj4KtJa1aZr16Cr5ow5VHKnz4,tz1aSkwEot3L2kmUvcoxzjMomb9mvBNuzFK6,unencrypted:edsk3RFfvaFaxbHx8BMtEW1rKQcPtDML3LXjNqMNLCzC3wLC1bWbAt
+      # charlie,edpkuvMuRuZ6ZbAquJH1XxBFfUmuBFz1zp9ENEqjCVgLp3NcY3Ww9M,tz1RDVcKmFcqzvTpJirvg4JaUVgZbjtnRT26,unencrypted:edsk3RgWvbKKA1atEUcaGwivge7QtckHkTL9nQJUXQKY5r8WKp4pF4
+      # donald,edpkvXGp1BMZxHkwg3mKnWfJYS6HTJ5JtufD8YXxLtH8UKqLZkZVun,tz1eSWp4B9s1qhtNMMNXAkaf2oqCnDHd2iAm,unencrypted:edsk3S8mG2sSBmSRbikAcZVLCz4SrCq4DjmsQRic6MGktqNFijfrS2
+      - name: Generate Flextesa bootstrap accounts
+        run: |-
+          echo "alice=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key alice)" >> $GITHUB_ENV
+          echo "bob=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key bob)" >> $GITHUB_ENV
+          echo "charlie=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key charlie)" >> $GITHUB_ENV
+          echo "donald=$(docker run --rm ${{ matrix.flextesa_docker_image }} flextesa key donald)" >> $GITHUB_ENV
+      - name: Provision Flextesa ${{ matrix.protocol }} container
+        run: |-
+          docker run \
+          --rm \
+          --name my-sandbox \
+          --detach \
+          -p 20000:20000 \
+          ${{ matrix.flextesa_docker_image }} \
+          flextesa mini-net \
+            --root /tmp/mini-box --size 1 \
+            --set-history-mode N000:archive \
+            --number-of-b 1 \
+            --balance-of-bootstrap-accounts tez:100_000_000 \
+            --time-b 1 \
+            --add-bootstrap-account="${alice}@2_000_000_000_000" \
+            --add-bootstrap-account="${bob}@2_000_000_000_000" \
+            --add-bootstrap-account="${charlie}@2_000_000_000_000" \
+            --add-bootstrap-account="${donald}@2_000_000_000_000" \
+            --no-daemons-for=donald \
+            --until-level 200_000_000 \
+            --protocol-kind ${{ matrix.protocol }}
+      - run: npm ci
+      - run: npm run build
+      - run: source ./integration-tests/sandbox-env.sh
+      - run: npm -w integration-tests run test:nairobinet-secret-key sandbox-ballot-operation.spec.ts
+      - run: npm -w integration-tests run test:nairobinet-secret-key sandbox-drain-delegate-operation.spec.ts
+        env:
+          RUN_${{ matrix.testnet_uppercase }}_WITH_SECRET_KEY: true
+          SECRET_KEY: edsk3QoqBuvdamxouPhin7swCvkQNgq4jP5KZPbwWNnwdZpSpJiEbq
+          TEZOS_RPC_${{ matrix.testnet_uppercase }}: http://localhost:20000
+          POLLING_INTERVAL_MILLISECONDS: 100
+          RPC_CACHE_MILLISECONDS: 0
+          TEZOS_BAKER: tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb

--- a/.github/workflows/mondaynet.yml
+++ b/.github/workflows/mondaynet.yml
@@ -13,60 +13,57 @@ jobs:
   integration-tests-mondaynet:
     runs-on: ubuntu-latest
     steps:
-    - name: Tailscale
-      uses: tailscale/github-action@v1
-      with:
-        authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
-        version: 1.32.2
+      - name: Tailscale
+        uses: tailscale/github-action@v1
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          version: 1.32.2
 
-    - name: Configure SSH
-      run: |
-        mkdir -p ~/.ssh/
-        echo "$SSH_KEY" > ~/.ssh/id.key
-        chmod 600 ~/.ssh/id.key
-        cat >>~/.ssh/config <<END
-        Host mondaynet
-          HostName $SSH_HOST
-          User $SSH_USER
-          IdentityFile ~/.ssh/id.key
-          StrictHostKeyChecking no
-        END
-      env:
-        SSH_USER: ${{ secrets.MONDAYNET_TORU_SSH_USER }}
-        SSH_KEY: ${{ secrets.MONDAYNET_TORU_SSH_KEY }}
-        SSH_HOST: ecad-mondaynet-archive
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/id.key
+          chmod 600 ~/.ssh/id.key
+          cat >>~/.ssh/config <<END
+          Host mondaynet
+            HostName $SSH_HOST
+            User $SSH_USER
+            IdentityFile ~/.ssh/id.key
+            StrictHostKeyChecking no
+          END
+        env:
+          SSH_USER: ${{ secrets.MONDAYNET_TORU_SSH_USER }}
+          SSH_KEY: ${{ secrets.MONDAYNET_TORU_SSH_KEY }}
+          SSH_HOST: ecad-mondaynet-archive
 
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: lts/hydrogen
-    - run: npm ci
-    - run: npm run build
-    -
-      id: originate-contracts-mondaynet
-      working-directory: ./integration-tests
-      env:
-        MONDAYNET: true
-      run: npm run originate-known-contracts
-    -
-      if: always()
-      id: integration-tests-mondaynet
-      working-directory: ./integration-tests
-      env:
-        TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
-        TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
-        TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
-        TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
-        TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT: ${{ steps.originate-contracts-mondaynet.outputs.knownOnChainViewContractAddress }}
-      run: npm run test:weeklynet -- --maxWorkers=2
-    -
-      name: Slack Notification
-      if: always()
-      uses: ravsamhq/notify-slack-action@v1
-      with:
-        status: ${{ job.status }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        notification_title: "Taquito Mondaynet Integration Tests ${{job.status}}"
-        message_format: "{emoji} *{workflow}* {status_message} on <{commit_url}|{commit_sha}> | <{run_url}|View Run>"
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.INTEGRATION_TESTS_SLACK_WEBHOOK }}
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/hydrogen
+      - run: npm ci
+      - run: npm run build
+      - id: originate-contracts-mondaynet
+        working-directory: ./integration-tests
+        env:
+          MONDAYNET: true
+        run: npm run originate-known-contracts
+      - if: always()
+        id: integration-tests-mondaynet
+        working-directory: ./integration-tests
+        env:
+          TEZOS_MONDAYNET_CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownContractAddress }}
+          TEZOS_MONDAYNET_BIGMAPCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownBigMapContractAddress }}
+          TEZOS_MONDAYNET_TZIP1216CONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownTzip12BigMapOffChainContractAddress }}
+          TEZOS_MONDAYNET_SAPLINGCONTRACT_ADDRESS: ${{ steps.originate-contracts-mondaynet.outputs.knownSaplingContractAddress }}
+          TEZOS_MONDAYNET_ON_CHAIN_VIEW_CONTRACT: ${{ steps.originate-contracts-mondaynet.outputs.knownOnChainViewContractAddress }}
+        run: npm run test:weeklynet -- --maxWorkers=2
+      - name: Slack Notification
+        if: always()
+        uses: ravsamhq/notify-slack-action@v1
+        with:
+          status: ${{ job.status }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          notification_title: 'Taquito Mondaynet Integration Tests ${{job.status}}'
+          message_format: '{emoji} *{workflow}* {status_message} on <{commit_url}|{commit_sha}> | <{run_url}|View Run>'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.INTEGRATION_TESTS_SLACK_WEBHOOK }}


### PR DESCRIPTION
>Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, cloudflare/pages-action@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

We need to upgrade some of our GitHub actions to newer versions to prevent any issues once the old versions are deprecated. 