### PR TITLE
added keepalive=false in createRequest

### DIFF
--- a/docs/cancel_http_requests.md
+++ b/docs/cancel_http_requests.md
@@ -43,6 +43,7 @@ class CancellableHttpBackend extends HttpBackend {
     
     try {
       const response = await fetch(urlWithQuery, {
+        keepalive: false, // generally only for Node 19 and above
         method,
         headers,
         body: JSON.stringify(data),

--- a/integration-tests/__tests__/contract/estimation-tests.spec.ts
+++ b/integration-tests/__tests__/contract/estimation-tests.spec.ts
@@ -41,11 +41,11 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       const estimate = await LowAmountTez.estimate.transfer({ to: await Tezos.signer.publicKeyHash(), amount: 0.019 });
       expect(estimate.gasLimit).toEqual(101);
       expect(estimate.storageLimit).toEqual(0);
-      expect(estimate.suggestedFeeMutez).toEqual(186);
+      expect(estimate.suggestedFeeMutez).toEqual(188);
       expect(estimate.burnFeeMutez).toEqual(0);
-      expect(estimate.minimalFeeMutez).toEqual(166);
-      expect(estimate.totalCost).toEqual(166);
-      expect(estimate.usingBaseFeeMutez).toEqual(166);
+      expect(estimate.minimalFeeMutez).toEqual(168);
+      expect(estimate.totalCost).toEqual(168);
+      expect(estimate.usingBaseFeeMutez).toEqual(168);
       expect(estimate.consumedMilligas).toEqual(100040);
     });
 
@@ -53,11 +53,11 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       const estimate = await LowAmountTez.estimate.transfer({ to: await (await createAddress()).signer.publicKeyHash(), amount: 0.017 });
       expect(estimate.gasLimit).toEqual(101);
       expect(estimate.storageLimit).toEqual(277);
-      expect(estimate.suggestedFeeMutez).toEqual(186);
+      expect(estimate.suggestedFeeMutez).toEqual(188);
       expect(estimate.burnFeeMutez).toEqual(69250);
-      expect(estimate.minimalFeeMutez).toEqual(166);
-      expect(estimate.totalCost).toEqual(69416);
-      expect(estimate.usingBaseFeeMutez).toEqual(166);
+      expect(estimate.minimalFeeMutez).toEqual(168);
+      expect(estimate.totalCost).toEqual(69418);
+      expect(estimate.usingBaseFeeMutez).toEqual(168);
       expect(estimate.consumedMilligas).toEqual(100040);
     });
 
@@ -69,11 +69,11 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       });
       expect(estimate.gasLimit).toEqual(677);
       expect(estimate.storageLimit).toEqual(591);
-      expect(estimate.suggestedFeeMutez).toEqual(535);
+      expect(estimate.suggestedFeeMutez).toEqual(537);
       expect(estimate.burnFeeMutez).toEqual(147750);
-      expect(estimate.minimalFeeMutez).toEqual(515);
-      expect(estimate.totalCost).toEqual(148265);
-      expect(estimate.usingBaseFeeMutez).toEqual(515);
+      expect(estimate.minimalFeeMutez).toEqual(517);
+      expect(estimate.totalCost).toEqual(148267);
+      expect(estimate.usingBaseFeeMutez).toEqual(517);
       expect(estimate.consumedMilligas).toEqual(676402);
     });
 
@@ -84,11 +84,11 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       });
       expect(estimate.gasLimit).toEqual(100);
       expect(estimate.storageLimit).toEqual(0);
-      expect(estimate.suggestedFeeMutez).toEqual(181);
+      expect(estimate.suggestedFeeMutez).toEqual(183);
       expect(estimate.burnFeeMutez).toEqual(0);
-      expect(estimate.minimalFeeMutez).toEqual(161);
-      expect(estimate.totalCost).toEqual(161);
-      expect(estimate.usingBaseFeeMutez).toEqual(161);
+      expect(estimate.minimalFeeMutez).toEqual(163);
+      expect(estimate.totalCost).toEqual(163);
+      expect(estimate.usingBaseFeeMutez).toEqual(163);
       expect(estimate.consumedMilligas).toEqual(100000);
     });
 
@@ -97,12 +97,12 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       const estimate = await LowAmountTez.estimate.transfer(tx);
       expect(estimate.gasLimit).toEqual(1457);
       expect(estimate.storageLimit).toEqual(0);
-      expect(estimate.suggestedFeeMutez).toEqual(394);
+      expect(estimate.suggestedFeeMutez).toEqual(396);
       expect(estimate.burnFeeMutez).toEqual(0);
-      expect(estimate.minimalFeeMutez).toEqual(374);
-      expect(estimate.totalCost).toEqual(374);
-      expect(estimate.usingBaseFeeMutez).toEqual(374);
-      expect(estimate.consumedMilligas).toEqual(1456056);
+      expect(estimate.minimalFeeMutez).toEqual(376);
+      expect(estimate.totalCost).toEqual(376);
+      expect(estimate.usingBaseFeeMutez).toEqual(376);
+      expect(estimate.consumedMilligas).toEqual(1456142);
     });
 
     it('Verify .estimate.transfer for multiple internal transfers to unallocated account', async () => {
@@ -114,12 +114,12 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       const estimate = await LowAmountTez.estimate.transfer(tx);
       expect(estimate.gasLimit).toEqual(1571);
       expect(estimate.storageLimit).toEqual(534);
-      expect(estimate.suggestedFeeMutez).toEqual(465);
+      expect(estimate.suggestedFeeMutez).toEqual(467);
       expect(estimate.burnFeeMutez).toEqual(133500);
-      expect(estimate.minimalFeeMutez).toEqual(445);
-      expect(estimate.totalCost).toEqual((133945));
-      expect(estimate.usingBaseFeeMutez).toEqual(445);
-      expect(estimate.consumedMilligas).toEqual(1570585);
+      expect(estimate.minimalFeeMutez).toEqual(447);
+      expect(estimate.totalCost).toEqual(133947);
+      expect(estimate.usingBaseFeeMutez).toEqual(447);
+      expect(estimate.consumedMilligas).toEqual(1570671);
     });
 
     it('Verify .estimate.transfer for internal origination', async () => {
@@ -127,12 +127,12 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       const estimate = await LowAmountTez.estimate.transfer(tx);
       expect(estimate.gasLimit).toEqual(1867);
       expect(estimate.storageLimit).toEqual(337);
-      expect(estimate.suggestedFeeMutez).toEqual(441);
+      expect(estimate.suggestedFeeMutez).toEqual(443);
       expect(estimate.burnFeeMutez).toEqual(84250);
-      expect(estimate.minimalFeeMutez).toEqual(421);
-      expect(estimate.totalCost).toEqual(84671);
-      expect(estimate.usingBaseFeeMutez).toEqual(421);
-      expect(estimate.consumedMilligas).toEqual(1866680);
+      expect(estimate.minimalFeeMutez).toEqual(423);
+      expect(estimate.totalCost).toEqual(84673);
+      expect(estimate.usingBaseFeeMutez).toEqual(423);
+      expect(estimate.consumedMilligas).toEqual(1866766);
     });
 
     it('Verify .estimate.transfer for multiple internal originations', async () => {
@@ -140,12 +140,12 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       const estimate = await LowAmountTez.estimate.transfer(tx);
       expect(estimate.gasLimit).toEqual(2392);
       expect(estimate.storageLimit).toEqual(654);
-      expect(estimate.suggestedFeeMutez).toEqual(559);
+      expect(estimate.suggestedFeeMutez).toEqual(561);
       expect(estimate.burnFeeMutez).toEqual(163500);
-      expect(estimate.minimalFeeMutez).toEqual(539);
-      expect(estimate.totalCost).toEqual(164039);
-      expect(estimate.usingBaseFeeMutez).toEqual(539);
-      expect(estimate.consumedMilligas).toEqual(2391833);
+      expect(estimate.minimalFeeMutez).toEqual(541);
+      expect(estimate.totalCost).toEqual(164041);
+      expect(estimate.usingBaseFeeMutez).toEqual(541);
+      expect(estimate.consumedMilligas).toEqual(2391919);
       // Do the actual operation
       const op2 = await contract.methods.do(originate2()).send();
       await op2.confirmation();
@@ -176,11 +176,11 @@ CONFIGS().forEach(({ lib, setup, knownBaker, createAddress, rpc }) => {
       let estimate = await LowAmountTez.estimate.transfer({ to: await Tezos.signer.publicKeyHash(), mutez: true, amount: amt - (1382 + getRevealFee(await LowAmountTez.signer.publicKeyHash())) });
       expect(estimate.gasLimit).toEqual(101);
       expect(estimate.storageLimit).toEqual(0);
-      expect(estimate.suggestedFeeMutez).toEqual(185);
+      expect(estimate.suggestedFeeMutez).toEqual(187);
       expect(estimate.burnFeeMutez).toEqual(0);
-      expect(estimate.minimalFeeMutez).toEqual(165);
-      expect(estimate.totalCost).toEqual(165);
-      expect(estimate.usingBaseFeeMutez).toEqual(165);
+      expect(estimate.minimalFeeMutez).toEqual(167);
+      expect(estimate.totalCost).toEqual(167);
+      expect(estimate.usingBaseFeeMutez).toEqual(167);
       expect(estimate.consumedMilligas).toEqual(100040);
     });
 

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -91,6 +91,7 @@ export class HttpBackend {
 
     try {
       const response = await fetch(urlWithQuery, {
+        keepalive: false,
         method,
         headers,
         body: JSON.stringify(data),

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -91,7 +91,7 @@ export class HttpBackend {
 
     try {
       const response = await fetch(urlWithQuery, {
-        keepalive: false,
+        keepalive: false, // Disable keepalive (keepalive defaults to true starting from Node 19 & 20)
         method,
         headers,
         body: JSON.stringify(data),


### PR DESCRIPTION
closes #2973 

- updated taquito-http-util fetch call to include `keepalive=false`. Node 19 onwards now defaults keepalive to `true`, which were causing the socket hangup errors

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
