### PR TITLE
fix: beacon-wallet open handles in tests

### DIFF
--- a/packages/taquito-beacon-wallet/test/__mocks__/broadcast-channel.ts
+++ b/packages/taquito-beacon-wallet/test/__mocks__/broadcast-channel.ts
@@ -1,0 +1,47 @@
+interface MessageListener {
+  (message: any): void;
+}
+
+class BroadcastChannel {
+  name: string;
+  listeners: MessageListener[];
+
+  constructor(name: string) {
+    this.name = name;
+    this.listeners = [];
+  }
+
+  postMessage(message: any) {
+    // Mock implementation of postMessage
+    this.listeners.forEach((listener) => listener(message));
+  }
+
+  addEventListener(event: string, listener: MessageListener) {
+    if (event === 'message') {
+      this.listeners.push(listener);
+    }
+  }
+
+  removeEventListener(event: string, listener: MessageListener) {
+    if (event === 'message') {
+      this.listeners = this.listeners.filter((l) => l !== listener);
+    }
+  }
+
+  close() {
+    // Mock implementation of close
+    this.listeners = [];
+  }
+}
+
+function createLeaderElection(_channel: BroadcastChannel) {
+  // Mock implementation of createLeaderElection
+  return {
+    awaitLeadership: jest.fn(),
+    hasLeader: jest.fn().mockReturnValue(true),
+    isLeader: jest.fn().mockReturnValue(true),
+    die: jest.fn(),
+  };
+}
+
+export { BroadcastChannel, createLeaderElection };

--- a/packages/taquito-beacon-wallet/test/taquito-beacon-wallet.spec.ts
+++ b/packages/taquito-beacon-wallet/test/taquito-beacon-wallet.spec.ts
@@ -10,6 +10,25 @@ global.localStorage = new LocalStorageMock();
 global.indexedDB = indexedDB;
 global.window = { addEventListener: jest.fn() } as any;
 
+jest.mock('@airgap/beacon-transport-postmessage', () => {
+  jest.useFakeTimers()
+  const originalModule = jest.requireActual('@airgap/beacon-transport-postmessage');
+  jest.runAllTimers()
+
+  return {
+    ...originalModule,
+    PostMessageTransport: jest.fn().mockImplementation(() => {
+      return {
+        connect: jest.fn(),
+        startOpenChannelListener: jest.fn(),
+        getPairingRequestInfo: jest.fn(),
+        listen: jest.fn(),
+      };
+    }),
+    getAvailableExtensions: jest.fn(),
+  };
+});
+
 describe('Beacon Wallet tests', () => {
   it('Verify that BeaconWallet is instantiable', () => {
     const wallet = new BeaconWallet({ name: 'testWallet' });


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [X] Your code builds cleanly without any errors or warnings
- [X] You have run the linter against the changes
- [X] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

Hi all,

After extensive investigation, it appears that the issue lies not with the `broadcast-channel` module itself, but with the base `BroadcastChannel` module, as using the latter also results in the same problems.

Additionally, for some reason, Jest is detecting a timeout inside [PostMessageTransport](https://github.com/airgap-it/beacon-sdk/blob/master/packages/beacon-transport-postmessage/src/PostMessageTransport.ts#L87-#L92) as an open handle.

To address this, I have mocked the entire class and used fake timers to ensure handles are freed promptly.

Thank you in advance for the time you will dedicate to reviewing my PR.
