### PR TITLE
fix: adding export for SmartRollupExecuteOutboxMessageParams

### DIFF
--- a/packages/taquito/src/operations/index.ts
+++ b/packages/taquito/src/operations/index.ts
@@ -31,6 +31,8 @@ export {
   RPCSmartRollupAddMessagesOperation,
   SmartRollupOriginateParams,
   RPCSmartRollupOriginateOperation,
+  SmartRollupExecuteOutboxMessageParams,
+  RPCSmartRollupOutboxMessageOperation,
   ActivationParams,
   RPCActivateOperation,
   BallotParams,


### PR DESCRIPTION
Adding `SmartRollupExecuteOutboxMessageParams` to the list of exported types. 
It is used in `ParamsWithKind` but it's only one which was not exported.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes

## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
