### PR TITLE
feat(wallet connect): sign payload using wc in test-dapp

### DIFF
--- a/apps/taquito-test-dapp/src/lib/TestContainer.svelte
+++ b/apps/taquito-test-dapp/src/lib/TestContainer.svelte
@@ -80,6 +80,14 @@
             title: "Confirmations through observable",
             body: result.confirmationObsOutput,
           };
+        } else if (test.id === "show-public-key") {
+          testResult = {
+            id: test.id,
+            title: "Public Key",
+            body: {
+              output: result.output
+            }
+          }
         }
       } else {
         error = result.error;

--- a/apps/taquito-test-dapp/src/lib/Wallet.svelte
+++ b/apps/taquito-test-dapp/src/lib/Wallet.svelte
@@ -55,15 +55,18 @@
     });
     wallet.signClient.on("session_ping", ({ id, topic }) => {
       console.log("session_ping in test dapp", id, topic);
+      store.addEvent("session_ping");
     });
     wallet.signClient.on("session_delete", ({ topic }) => {
-      console.log("EVEN: session_delete", topic);
+      console.log("EVENT: session_delete", topic);
+      store.addEvent("session_delete");
       if (!wallet.isActiveSession()) {
         resetApp();
       }
     });
     wallet.signClient.on("session_update", async ({ topic }) => {
-      console.log("EVEN: session_update", topic);
+      console.log("EVENT: session_update", topic);
+      store.addEvent("session_update");
       const allAccounts = wallet.getAccounts();
       await updateStore(wallet, allAccounts);
     });
@@ -75,7 +78,7 @@
       permissionScope: {
         networks: [$store.networkType as NetworkTypeWc2],
         events: [],
-        methods: [PermissionScopeMethods.TEZOS_SEND, PermissionScopeMethods.TEZOS_SIGN],
+        methods: [PermissionScopeMethods.TEZOS_SEND, PermissionScopeMethods.TEZOS_SIGN, PermissionScopeMethods.TEZOS_GET_ACCOUNTS],
       },
       pairingTopic,
       registryUrl: "https://www.tezos.help/wcdata/"

--- a/apps/taquito-test-dapp/src/lib/Wallet.svelte
+++ b/apps/taquito-test-dapp/src/lib/Wallet.svelte
@@ -80,8 +80,7 @@
         events: [],
         methods: [PermissionScopeMethods.TEZOS_SEND, PermissionScopeMethods.TEZOS_SIGN, PermissionScopeMethods.TEZOS_GET_ACCOUNTS],
       },
-      pairingTopic,
-      registryUrl: "https://www.tezos.help/wcdata/"
+      pairingTopic
     });
     const allAccounts = wallet.getAccounts();
     await updateStore(wallet, allAccounts);

--- a/docs/wallet_connect_2.md
+++ b/docs/wallet_connect_2.md
@@ -13,7 +13,7 @@ The first step is to instantiate `WalletConnect2` by passing your dapp details a
 import { WalletConnect2 } from "@taquito/wallet-connect-2";
 
 const walletConnect = await WalletConnect2.init({
-  projectId: "YOUR_PROJECT_ID", // Your Project ID gives you access to WalletConnect Cloud
+  projectId: "YOUR_PROJECT_ID", // Your Project ID gives you access to Reown Cloud
   metadata: {
     name: "YOUR_DAPP_NAME",
     description: "YOUR_DAPP_DESCRIPTION",
@@ -22,7 +22,7 @@ const walletConnect = await WalletConnect2.init({
   },
 });
 ```
-`YOUR_PROJECT_ID` can be obtained from [WalletConnect Cloud](https://cloud.walletconnect.com/sign-in)
+`YOUR_PROJECT_ID` can be obtained from [Reown Cloud](https://cloud.reown.com)
 
 The second step is to establish a connection to a wallet using the `requestPermissions` method:
 
@@ -33,10 +33,11 @@ await walletConnect.requestPermissions({
   permissionScope: {
     networks: [NetworkType.GHOSTNET],
     methods: [
-      PermissionScopeMethods.TEZOS_SEND, PermissionScopeMethods.TEZOS_SIGN
+      PermissionScopeMethods.TEZOS_SEND, 
+      PermissionScopeMethods.TEZOS_SIGN, 
+      PermissionScopeMethods.TEZOS_GET_ACCOUNTS
     ],
-  },
-  // registryUrl: "https://www.tezos.help/wcdata/"
+  }
 });
 ```
 
@@ -80,7 +81,6 @@ WalletConnect2.init({
           networks: [NetworkType.GHOSTNET],
           methods: [PermissionScopeMethods.TEZOS_SEND],
         },
-        // registryUrl: 'https://www.tezos.help/wcdata/',
       })
       .then(() => {
         Tezos.setWalletProvider(walletConnect);
@@ -99,7 +99,7 @@ WalletConnect2.init({
 
 ## Sign payload with `WalletConnect2`
 
-The `signPayload` method of `WalletConnect2` can be called to sign a payload. The response will be a string representing the signature. The permission `PermissionScopeMethods.TEZOS_SIGN` must have been granted, or the error `MissingRequiredScope` will be thrown.
+The `sign` method of `WalletConnect2` can be called to sign a payload. The response will be a string representing the signature. The permission `PermissionScopeMethods.TEZOS_SIGN` must have been granted, or the error `MissingRequiredScope` will be thrown.
 
 ## Events handling
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
       "^@taquito/tzip12$": "<rootDir>/packages/taquito-tzip12/src/taquito-tzip12.ts",
       "^@taquito/tzip16$": "<rootDir>/packages/taquito-tzip16/src/taquito-tzip16.ts",
       "^@taquito/utils$": "<rootDir>/packages/taquito-utils/src/taquito-utils.ts",
-      "^@taquito/wallet-connect-2$": "<rootDir>/packages/taquito-wallet-connect-2/src/wallet-connect-2.ts"
+      "^@taquito/wallet-connect-2$": "<rootDir>/packages/taquito-wallet-connect-2/src/taquito-wallet-connect-2.ts"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-wallet-connect-2/README.md
+++ b/packages/taquito-wallet-connect-2/README.md
@@ -1,0 +1,58 @@
+# Taquito Wallet Connect 2 / Reown package
+
+_Documentation can be found [here](https://taquito.io/docs/wallet_connect_2)_  
+
+## General Information
+
+`@taquito/wallet-connect-2` is an npm package that provides developers a way to connect a dapp built with Taquito to a wallet giving the freedom to the users of the dapp to choose the wallet via the WalletConnect/Reown protocol. The `WalletConnect2` class implements the `WalletProvider` interface, providing an alternative to `BeaconWallet`.
+Note: Currently, a QR code is displayed to establish a connection with a wallet. As more Tezos wallets integrate with WalletConnect, we plan showing a list of available wallets alongside the QR code.
+
+## Install
+
+Install the package as follows
+
+```
+npm install @taquito/wallet-connect-2
+```
+
+## Usage
+
+Create a wallet instance with defined option parameters and set the wallet provider using `setWalletProvider` to the `TezosToolkit` instance
+
+```ts
+import { TezosToolkit } from '@taquito/taquito';
+import { WalletConnect2 } from '@taquito/wallet-connect-2';
+
+const wallet = await WalletConnect2.init({
+    projectId: "861613623da99d7285aaad8279a87ee9", // Your Project ID gives you access to WalletConnect Cloud.
+    metadata: {
+        name: "Taquito Test Dapp",
+        description: "Test Taquito with WalletConnect2",
+        icons: [],
+        url: "",
+    },
+});
+
+await wallet.requestPermissions({
+    permissionScope: {
+        networks: [NetworkType.GHOSTNET],
+        events: [],
+        methods: [
+            PermissionScopeMethods.TEZOS_SEND, 
+            PermissionScopeMethods.TEZOS_SIGN, 
+            PermissionScopeMethods.TEZOS_GET_ACCOUNTS
+        ],
+    }
+});
+
+const Tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL');
+Tezos.setWalletProvider(wallet);
+```
+
+## Additional Info
+
+See the top-level [https://github.com/ecadlabs/taquito](https://github.com/ecadlabs/taquito) file for details on reporting issues, contributing and versioning.
+
+## Disclaimer
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/taquito-wallet-connect-2/src/errors.ts
+++ b/packages/taquito-wallet-connect-2/src/errors.ts
@@ -147,3 +147,11 @@ export class InvalidSession extends Error {
     super(message);
   }
 }
+
+export class PublicKeyRetrievalError extends Error {
+  name = 'PublicKeyRetrievalError';
+
+  constructor() {
+    super(`Unable to retrieve public key`);
+  }
+}

--- a/packages/taquito-wallet-connect-2/src/taquito-wallet-connect-2.ts
+++ b/packages/taquito-wallet-connect-2/src/taquito-wallet-connect-2.ts
@@ -58,6 +58,13 @@ export * from './types';
 
 const TEZOS_PLACEHOLDER = 'tezos';
 
+/**
+ * @description The `WalletConnect2` class implements the `WalletProvider` interface, providing an alternative to `BeaconWallet`.
+ * This package enables dapps built with Taquito to connect to wallets via the WalletConnect/Reown protocol.
+ * 
+ * @note Currently, a QR code is displayed to establish a connection with a wallet. As more Tezos wallets integrate with WalletConnect,
+ * we plan showing a list of available wallets alongside the QR code.
+ */
 export class WalletConnect2 implements WalletProvider {
   public signClient: Client;
   private session: SessionTypes.Struct | undefined;
@@ -298,7 +305,6 @@ export class WalletConnect2 implements WalletProvider {
     return this.activeAccount;
   }
 
-  // TODO need test-dapp test
   /**
    * @description Access the public key of the active account
    * @error ActiveAccountUnspecified thrown when there are multiple Tezos account in the session and none is set as the active one

--- a/packages/taquito-wallet-connect-2/src/types.ts
+++ b/packages/taquito-wallet-connect-2/src/types.ts
@@ -47,6 +47,12 @@ export enum SigningType {
   MICHELINE = 'micheline',
 }
 
+export interface TezosAccount {
+  algo: string;
+  address: string;
+  pubkey: string;
+}
+
 type WalletDefinedFields = 'source' | 'gas_limit' | 'storage_limit' | 'fee';
 interface WalletOptionalFields {
   gas_limit?: string;


### PR DESCRIPTION
Added support to sign payload in the test-dapp using wallet connect, fix getPk and sign in the wallet connect package

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
