### PR TITLE
chore: update ECAD Infra RPC addresses to new format

### DIFF
--- a/apps/taquito-test-dapp/src/config.ts
+++ b/apps/taquito-test-dapp/src/config.ts
@@ -4,10 +4,10 @@ import { NetworkType as NetworkTypeWc } from "@taquito/wallet-connect";
 export type SupportedNetworks = NetworkTypeBeacon.MAINNET | NetworkTypeBeacon.GHOSTNET | NetworkTypeBeacon.PARISNET | NetworkTypeWc.MAINNET | NetworkTypeWc.GHOSTNET | NetworkTypeWc.PARISNET | NetworkTypeBeacon.CUSTOM;
 
 const rpcUrls: Record<SupportedNetworks, string> = {
-  [NetworkTypeBeacon.MAINNET]: "https://mainnet.ecadinfra.com",
-  [NetworkTypeBeacon.GHOSTNET]: "https://ghostnet.ecadinfra.com/",
+  [NetworkTypeBeacon.MAINNET]: "https://mainnet.tezos.ecadinfra.com",
+  [NetworkTypeBeacon.GHOSTNET]: "https://ghostnet.tezos.ecadinfra.com/",
   [NetworkTypeBeacon.PARISNET]: "https://rpc.pariscnet.teztnets.com/",
-  [NetworkTypeBeacon.CUSTOM]: "https://ghostnet.ecadinfra.com/",
+  [NetworkTypeBeacon.CUSTOM]: "https://ghostnet.tezos.ecadinfra.com/",
 };
 
 export const getRpcUrl = (networkType: SupportedNetworks): string => {

--- a/docs/complex_parameters.md
+++ b/docs/complex_parameters.md
@@ -52,7 +52,7 @@ An annotation identifies every argument. Therefore we can ignore optional values
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
 // import { importKey } from '@taquito/signer';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 //%data
 const dataMap = new MichelsonMap();
@@ -129,7 +129,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -153,7 +153,7 @@ importKey(Tezos, secretKey)
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -184,7 +184,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/docs/drain_account.md
+++ b/docs/drain_account.md
@@ -22,7 +22,7 @@ In the following example, we have not revealed the account that we want to empty
 :::
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 // import { getRevealFee } from "@taquito/taquito";
 
 Tezos.signer
@@ -87,7 +87,7 @@ The contract we originate is a `manager contract.` It has a `do` method taking a
 In the example, we estimate the transfer operation before doing it. The associated fees are deducted from the manager's address when draining the account. Thus, for the operation to be successful, the manager's address for that account must contain funds to cover the gas.
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 function transferImplicit(key, mutez) {
   return [

--- a/docs/estimate.md
+++ b/docs/estimate.md
@@ -43,7 +43,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -68,7 +68,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -109,7 +109,7 @@ The `contractCall()` member method can now be used to estimate contract calls as
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 Tezos.contract
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
   .then((contract) => {
@@ -137,7 +137,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
@@ -178,7 +178,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate
@@ -208,7 +208,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate

--- a/docs/inmemory_signer.md
+++ b/docs/inmemory_signer.md
@@ -41,7 +41,7 @@ The `fromSecretKey` method takes a secret that is base58 encoded as a parameter.
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb')
   .then((theSigner) => {
@@ -58,7 +58,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('spsk2Fiz7sGP5fNMJrokp6ynTa4bcFbsRhw58FHXbNf5ProDNFJ5Xq')
   .then((theSigner) => {
@@ -78,7 +78,7 @@ When required, Taquito offers the `b58cencode` function allowing to encode the s
 // import { b58cencode, prefix, Prefix } from '@taquito/utils';
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const b58encodedSecret = b58cencode(
   '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d',
@@ -119,7 +119,7 @@ Here are three examples with encrypted private keys where the passphrase used is
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'edesk1GXwWmGjXiLHBKxGBxwmNvG21vKBh6FBxc4CyJ8adQQE2avP5vBB57ZUZ93Anm7i4k8RmsHaPzVAvpnHkFF',
@@ -139,7 +139,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'spesk24UQkAiJk8X6AufNtRv1WWPp2BAssEgmijCTQPMgUXweSKPmLdbyAjPmCG1pR2dC9P5UZZVeZcb7zVodUHZ',
@@ -159,7 +159,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T',
@@ -188,7 +188,7 @@ With ed25519 default derivation path (Reminder Must be hardened with either h or
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   // ed25519 must have all hardened paths
 
@@ -212,7 +212,7 @@ With a non-default derivation path non-hardened with a tz2 address
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   const params = {
     mnemonic: 'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business',

--- a/docs/ledger_signer.md
+++ b/docs/ledger_signer.md
@@ -199,7 +199,7 @@ _Note that this example is not intended to be a complete example of paths scanni
 //import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';
 //import { TezosToolkit } from '@taquito/taquito';
 // import TransportWebHID from "@ledgerhq/hw-transport-webhid";
-//const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+//const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 TransportWebHID.create().then((transport) => {
   for (let index = 0, p = Promise.resolve(); index < 10; index++) {

--- a/docs/making_transfers.md
+++ b/docs/making_transfers.md
@@ -23,7 +23,7 @@ In the following example, we transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNj
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 render(`Fetching a private key...`);
 fetch('https://keygen.ecadinfra.com/ghostnet/', {

--- a/docs/maps_bigmaps.md
+++ b/docs/maps_bigmaps.md
@@ -903,7 +903,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')
@@ -933,7 +933,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')

--- a/docs/michelsonmap.md
+++ b/docs/michelsonmap.md
@@ -29,7 +29,7 @@ import { BigNumber } from 'bignumber.js';
 
 const contractAddress: string = 'KT1M5C76aSjpWXdoBvuzRdi3UJoC3jEzrSUW';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const contract = await Tezos.contract.at(contractAddress);
 const storage: MichelsonMap<string, BigNumber> = await contract.storage();

--- a/docs/originate.md
+++ b/docs/originate.md
@@ -35,7 +35,7 @@ This requires a signer to be configured, ie:
 ```
 import { importKey } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 
@@ -45,7 +45,7 @@ importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 const option = { name: "nameOfWallet", network: { type: 'ghostnet' }, enableMetrics: true};
 const wallet = new BeaconWallet(option);
 
@@ -93,7 +93,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -122,7 +122,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -164,7 +164,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -189,7 +189,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -225,7 +225,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -262,7 +262,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -57,7 +57,7 @@ Alternatively, you can use a `WalletProvider` to interact with a wallet. Please 
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.tz
   .getBalance('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')

--- a/docs/rpc_nodes.md
+++ b/docs/rpc_nodes.md
@@ -23,8 +23,8 @@ values={[
 
 | Provider         | Net          | URL                                      | Header                                                                          |
 |------------------|--------------|------------------------------------------|---------------------------------------------------------------------------------|
-| ECAD Labs        | Mainnet      | https://mainnet.ecadinfra.com            | [Check](https://mainnet.ecadinfra.com/chains/main/blocks/head/header)           |
-| ECAD Labs        | Ghostnet     | https://ghostnet.ecadinfra.com           | [Check](https://ghostnet.ecadinfra.com/chains/main/blocks/head/header)          |
+| ECAD Labs        | Mainnet      | https://mainnet.tezos.ecadinfra.com            | [Check](https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/header)           |
+| ECAD Labs        | Ghostnet     | https://ghostnet.tezos.ecadinfra.com           | [Check](https://ghostnet.tezos.ecadinfra.com/chains/main/blocks/head/header)          |
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |
 | Tezos Foundation | Mainnet      | https://rpc.tzbeta.net/                  | [Check](https://rpc.tzbeta.net/chains/main/blocks/head/header)                  |

--- a/docs/rpc_package.md
+++ b/docs/rpc_package.md
@@ -18,7 +18,7 @@ Methods in the RPC package map one-to-one to the corresponding Tezos RPC API end
 
 import { RpcClient } from '@taquito/rpc';
 
-const client = new RpcClient(' https://ghostnet.ecadinfra.com/', 'NetXLH1uAxK7CCh');
+const client = new RpcClient(' https://ghostnet.tezos.ecadinfra.com/', 'NetXLH1uAxK7CCh');
 ```
 
 The `RpcClient` constructor takes the URL of the node you want to use and the chain ID.

--- a/docs/sapling.md
+++ b/docs/sapling.md
@@ -53,7 +53,7 @@ import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 
@@ -86,7 +86,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -119,7 +119,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -156,7 +156,7 @@ Here is an example of how to prepare and inject a shielded transaction using Taq
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -228,7 +228,7 @@ Here is an example of how to prepare and inject a Sapling transaction using Taqu
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -286,7 +286,7 @@ Here is an example of how to prepare and inject an unshielded transaction using 
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -342,7 +342,7 @@ import { InMemoryViewingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -177,7 +177,7 @@ values={[
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
 // import { stringToBytes, num2PaddedHex } from '@taquito/utils';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 let magicByte = '0x80'
 let magicString = 'tezos signed offchain message'
@@ -205,7 +205,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
 // import { stringToBytes, num2PaddedHex } from '@taquito/utils';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 let magicByte = '0x80'
 let magicString = 'tezos signed offchain message'

--- a/docs/smartcontracts.md
+++ b/docs/smartcontracts.md
@@ -75,7 +75,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -90,7 +90,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -123,7 +123,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -167,7 +167,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -188,7 +188,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -230,7 +230,7 @@ values={[
 In the following example, a contract's `set_child_record` method will be called by passing the parameter in an object format. The `methodsObject` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -251,7 +251,7 @@ The preceding example returns an object giving indication on how to structure th
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -282,7 +282,7 @@ importKey(Tezos, secretKey)
 In the following example, a contract's `set_child_record` method will be called by passing the arguments using the flattened representation. The `methods` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -303,7 +303,7 @@ The preceding example returns an array which contains the different possible sig
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/docs/storage_annotations.md
+++ b/docs/storage_annotations.md
@@ -36,7 +36,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -62,7 +62,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -111,7 +111,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -188,7 +188,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -215,7 +215,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({

--- a/docs/tezos_domains.md
+++ b/docs/tezos_domains.md
@@ -22,7 +22,7 @@ const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the domain name if found or the provided address
 const fetchTezosDomainFromAddress = async (address: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(domainContractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
@@ -53,7 +53,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the address if found or the provided domain name
 const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.records.get(stringToBytes(domainName));
@@ -82,7 +82,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // this function return the expiry date of a domain name
 const fetchExpiryDate = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const expiryDate = await storage.store.expiry_map.get(stringToBytes(domainName));

--- a/docs/timelock.md
+++ b/docs/timelock.md
@@ -146,7 +146,7 @@ Let's originate the contract with initial storage values `level` of 0, a stub ch
 // import { stringToBytes } from '@taquito/utils';
 // import { timelockCode, timelockStorage } from './timelock-flip-contract';
 
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const originate = await Tezos.contract.originate({ code: timelockCode, init: timelockStorage });
 await originate.confirmation()

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -98,7 +98,7 @@ Now, open the file `index.ts` and replace the code with the following:
 ```ts
 import { TezosToolkit } from "@taquito/taquito";
 
-var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
 tezosToolkit.tz.getBalance("tz1YvE7Sfo92ueEPEdZceNWd5MWNeMNSt16L").then(balance => {
     console.log(balance.toNumber());
@@ -198,7 +198,7 @@ import { InMemorySigner } from "@taquito/signer";
 import { TezosToolkit } from "@taquito/taquito";
 
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     // WARNING: DO NOT DO THIS IN PRODUCTION, KEEP YOUR SECRETS SAFE
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
@@ -246,8 +246,8 @@ For the purpose of this section, I have created a new address and funded it on t
     docker run --pull always -it --entrypoint sh docker.io/tezos/tezos:latest
 
     # now you are inside the docker container
-    octez-client -E https://ghostnet.ecadinfra.com gen keys mysamplekey -s secp256k1
-    octez-client -E https://ghostnet.ecadinfra.com show address mysamplekey -S
+    octez-client -E https://ghostnet.tezos.ecadinfra.com gen keys mysamplekey -s secp256k1
+    octez-client -E https://ghostnet.tezos.ecadinfra.com show address mysamplekey -S
   ```
   The new address you just created has a balance of zero. For the testnet, You can go to [ghostnet faucet](https://faucet.ghostnet.teztnets.xyz/) and send some ꜩ to it for free. On mainnet, you need to buy actual Tez on an exchange.
 </details>
@@ -272,7 +272,7 @@ Open the file `index.ts` and change the `main` function to the following:
 
 ```ts
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
     tezosToolkit.setProvider({ signer });
@@ -431,7 +431,7 @@ import { BeaconWallet } from "@taquito/beacon-wallet";
 
 const App = () => {
   const [Tezos] = useState<TezosToolkit>(
-    new TezosToolkit("https://ghostnet.ecadinfra.com")
+    new TezosToolkit("https://ghostnet.tezos.ecadinfra.com")
   );
   const [wallet, setWallet] = useState<BeaconWallet | undefined>(undefined);
   const [userAddress, setUserAddress] = useState<string | undefined>(undefined);
@@ -485,7 +485,7 @@ const ConnectButton = ({
       await wallet!.requestPermissions({
         network: {
           type: NetworkType.GHOSTNET,
-          rpcUrl: "https://ghostnet.ecadinfra.com",
+          rpcUrl: "https://ghostnet.tezos.ecadinfra.com",
         },
       });
       const userAddress = await wallet!.getPKH();

--- a/docs/version.md
+++ b/docs/version.md
@@ -1249,7 +1249,7 @@ Note for the users of the lower level APIs: injecting more than one manager oper
 The `increase_paid_storage` operation allows increasing the paid storage of a smart contract by a specified bytes amount. The smart contract owner doesn't have to do it; any user can increase the storage. The operation is of interest for high-traffic dapps as it allows prepaying for storage and prevents transactions from failing because of an unpredictable storage burn.
 
 ```typescript
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const op = await Tezos.contract.increasePaidStorage({
     amount: 5,
@@ -2362,7 +2362,7 @@ In version 9.2.0-beta of Taquito, the ability to send more than one operation in
 The default streamer set on the `TezosToolkit` used a hardcoded polling interval of 20 seconds, and there was no easy way to change this. To reduce the probability of missing blocks, it is now possible to configure the interval as follow:
 
 ```ts
-const tezos = new TezosToolkit('https://mainnet.ecadinfra.com')
+const tezos = new TezosToolkit('https://mainnet.tezos.ecadinfra.com')
 tezos.setProvider({ config: { streamerPollingIntervalMilliseconds: 15000 } });
 
 const sub = tezos.stream.subscribeOperation(filter)

--- a/docs/wallet_API.md
+++ b/docs/wallet_API.md
@@ -42,7 +42,7 @@ To start, let's import the Tezos Toolkit from Taquito and create a new instance 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 ```
 
 This object exposes different methods we are going to use to set up our wallet. TZIP-10 has become the official standard of communication and interaction between wallets and dapps, so let's start with the `@taquito/beacon-wallet` package that implements this standard!
@@ -543,7 +543,7 @@ Now, we have everything we need to originate a new contract!
 Before doing so, we have to choose the network we want to originate it to:
 
 ```js
-Tezos.setProvider({ rpc: 'https://ghostnet.ecadinfra.com/' });
+Tezos.setProvider({ rpc: 'https://ghostnet.tezos.ecadinfra.com/' });
 ```
 
 Then, we can start the process. The Tezos singleton has a `wallet` property with an `originate` method. This is the one that must be called to originate the contract. This method takes an argument, an object with two properties: `code` that holds the parsed Michelson code to be originated and `storage` that has the initial storage. After passing this argument, you call the `send()` method to originate the contract.

--- a/docs/walletconnect.md
+++ b/docs/walletconnect.md
@@ -65,7 +65,7 @@ In the same order of ideas, `setActiveNetwork` must be called to specify the act
 Here is a complete example of using wallet connect to perform a transfer operation:
 
 ```js live noInline noConfig
-Tezos.setRpcProvider('https://ghostnet.ecadinfra.com/');
+Tezos.setRpcProvider('https://ghostnet.tezos.ecadinfra.com/');
 
 WalletConnect.init({
   logger: 'debug',

--- a/example/contract-schema.ts
+++ b/example/contract-schema.ts
@@ -2,7 +2,7 @@ import { TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
-    const provider = 'https://ghostnet.ecadinfra.com';
+    const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/deploy-docs-live-code-contracts.ts
+++ b/example/deploy-docs-live-code-contracts.ts
@@ -32,7 +32,7 @@ import { fa2Contract } from '../integration-tests/data/fa2_contract';
 import BigNumber from 'bignumber.js';
 
 
-const provider = 'https://ghostnet.ecadinfra.com/';
+const provider = 'https://ghostnet.tezos.ecadinfra.com/';
 export const signer = new InMemorySigner(
   'edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca'
 );

--- a/example/example-MapValuesMultipleBigMaps.ts
+++ b/example/example-MapValuesMultipleBigMaps.ts
@@ -3,7 +3,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { tokenCode } from '../integration-tests/data/tokens';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-contract-originate-Ligo-Simple.ts
+++ b/example/example-contract-originate-Ligo-Simple.ts
@@ -3,7 +3,7 @@ import { ligoSample } from '../integration-tests/data/ligo-simple-contract';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-contract-originate-Ligo-vote.ts
+++ b/example/example-contract-originate-Ligo-vote.ts
@@ -3,7 +3,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { voteInitSample, voteSample } from '../integration-tests/data/vote-contract';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-contract-originate-Michelson-tutorial.ts
+++ b/example/example-contract-originate-Michelson-tutorial.ts
@@ -2,7 +2,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-contract-originate-hello-world.ts
+++ b/example/example-contract-originate-hello-world.ts
@@ -1,7 +1,7 @@
 import { TezosToolkit } from '@taquito/taquito';
 import { InMemorySigner } from '@taquito/signer';
 
-const provider = 'https://ghostnet.ecadinfra.com';
+const provider = 'https://ghostnet.tezos.ecadinfra.com';
 
 async function example() {
   const tezos = new TezosToolkit(provider);

--- a/example/example-lambda-origination-one.ts
+++ b/example/example-lambda-origination-one.ts
@@ -3,7 +3,7 @@ import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { tzip7Contract } from '../integration-tests/data/tzip_7_contract';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-lambda-origination-two.ts
+++ b/example/example-lambda-origination-two.ts
@@ -3,7 +3,7 @@ import { MichelsonMap, TezosToolkit } from '@taquito/taquito';
 import { fa2Contract } from '../integration-tests/data/fa2_contract';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-node.ts
+++ b/example/example-node.ts
@@ -3,7 +3,7 @@ import { RpcClient } from '../packages/taquito-rpc/src/taquito-rpc';
 import { castToString } from '../packages/taquito-rpc/src/utils/utils';
 import BigNumber from 'bignumber.js';
 
-const provider = 'https://ghostnet.ecadinfra.com';
+const provider = 'https://ghostnet.tezos.ecadinfra.com';
 
 const client = new RpcClient(provider);
 

--- a/example/example-parallel-bigmap-local-vs-rpc-pack.ts
+++ b/example/example-parallel-bigmap-local-vs-rpc-pack.ts
@@ -1,7 +1,7 @@
 import { BigMapAbstraction, TezosToolkit, MichelCodecPacker } from '@taquito/taquito';
 import BigNumber from 'bignumber.js';
 
-const rpc = 'https://ghostnet.ecadinfra.com';
+const rpc = 'https://ghostnet.tezos.ecadinfra.com';
 const numberOfValueToFetch = 410; // max 410
 const repeat = 1; // How many time we want to fetch all the keys
 

--- a/example/example-sapling-load-test.ts
+++ b/example/example-sapling-load-test.ts
@@ -7,7 +7,7 @@ let totalTime = 0;
 
 async function example() {
     try {
-        const provider = 'https://ghostnet.ecadinfra.com';
+        const provider = 'https://ghostnet.tezos.ecadinfra.com';
         const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
         const tezos = new TezosToolkit(provider);
         tezos.setSignerProvider(signer);

--- a/example/example-sequential-bigmap-local-vs-rpc-pack.ts
+++ b/example/example-sequential-bigmap-local-vs-rpc-pack.ts
@@ -1,7 +1,7 @@
 import { BigMapAbstraction, TezosToolkit, MichelCodecPacker } from '@taquito/taquito';
 import BigNumber from 'bignumber.js';
 
-const rpc = 'https://ghostnet.ecadinfra.com';
+const rpc = 'https://ghostnet.tezos.ecadinfra.com';
 const numberOfValueToFetch = 410; // max 410
 const repeat = 1; // How many times we want to fetch all the keys
 

--- a/example/example-smart-contract-origination.ts
+++ b/example/example-smart-contract-origination.ts
@@ -2,7 +2,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-streamer-custom-retry-logic.ts
+++ b/example/example-streamer-custom-retry-logic.ts
@@ -3,7 +3,7 @@ import { delay, retryWhen, tap, scan } from 'rxjs/operators';
 
 async function example() {
   // This example will intentionally fail after two attempts as the RPC URL is invalid.
-  const provider = 'https://mainnet.ecadinfra.com/notValid';
+  const provider = 'https://mainnet.tezos.ecadinfra.com/notValid';
   const tezos = new TezosToolkit(provider);
   tezos.setStreamProvider(tezos.getFactory(PollingSubscribeProvider)({
     shouldObservableSubscriptionRetry: true, observableSubscriptionRetryFunction:

--- a/example/example-streamer-log-time-between-blocks.ts
+++ b/example/example-streamer-log-time-between-blocks.ts
@@ -5,7 +5,7 @@ import { PollingSubscribeProvider, TezosToolkit } from '@taquito/taquito';
 // When a new block is seen, the time between the new block and the precedent is logged with the block level
 // If a block is missed when polling, 'Missed block: `level`' is logged.
 
-const provider = 'https://ghostnet.ecadinfra.com';
+const provider = 'https://ghostnet.tezos.ecadinfra.com';
 const pollingIntervalMilliseconds = 5000;
 let date: Date;
 let level: number;

--- a/example/example-streamer.ts
+++ b/example/example-streamer.ts
@@ -1,7 +1,7 @@
 import { PollingSubscribeProvider, TezosToolkit } from '@taquito/taquito';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com/';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com/';
   const tezos = new TezosToolkit(provider)
   tezos.setStreamProvider(tezos.getFactory(PollingSubscribeProvider)({ shouldObservableSubscriptionRetry: true, pollingIntervalMilliseconds: 15000 }));
   try {

--- a/example/example-tzip-12-big-map-off-chain.ts
+++ b/example/example-tzip-12-big-map-off-chain.ts
@@ -5,7 +5,7 @@ import { b58cencode, stringToBytes, Prefix, prefix } from '@taquito/utils';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const nodeCrypto = require('crypto');
 
-const provider = 'https://ghostnet.ecadinfra.com';
+const provider = 'https://ghostnet.tezos.ecadinfra.com';
 
 async function createAddress() {
   const tezos = new TezosToolkit(provider)

--- a/example/example-tzip-12-big-map-token-metadata.ts
+++ b/example/example-tzip-12-big-map-token-metadata.ts
@@ -6,7 +6,7 @@ import { fa2TokenFactory } from '../integration-tests/data/fa2-token-factory';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const nodeCrypto = require('crypto');
 
-const provider = 'https://ghostnet.ecadinfra.com';
+const provider = 'https://ghostnet.tezos.ecadinfra.com';
 
 async function createAddress() {
   const tezos = new TezosToolkit(provider)

--- a/example/example-tzip-16-IPFS.ts
+++ b/example/example-tzip-16-IPFS.ts
@@ -4,7 +4,7 @@ import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-cont
 import { stringToBytes } from '@taquito/utils';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
     const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
     const tezos = new TezosToolkit(provider);
     tezos.setSignerProvider(signer);

--- a/example/example-tzip-16-SHA256.ts
+++ b/example/example-tzip-16-SHA256.ts
@@ -4,7 +4,7 @@ import { stringToBytes } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/example-tzip-16-contract-origination-hostile-strings.ts
+++ b/example/example-tzip-16-contract-origination-hostile-strings.ts
@@ -5,7 +5,7 @@ import { MichelsonMap } from "@taquito/taquito";
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/example-tzip-16-https.ts
+++ b/example/example-tzip-16-https.ts
@@ -4,7 +4,7 @@ import { tacoContractTzip16 } from "../integration-tests/data/modified-taco-cont
 import { stringToBytes } from '@taquito/utils';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/example-tzip-16-on-chain-one.ts
+++ b/example/example-tzip-16-on-chain-one.ts
@@ -4,7 +4,7 @@ import { stringToBytes } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/example-tzip-16-on-chain-two.ts
+++ b/example/example-tzip-16-on-chain-two.ts
@@ -4,7 +4,7 @@ import { contractCode, metadataViewsExample2 } from '../integration-tests/data/m
 import { stringToBytes } from '@taquito/utils';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/example-tzip-16-storage.ts
+++ b/example/example-tzip-16-storage.ts
@@ -4,7 +4,7 @@ import { stringToBytes } from '@taquito/utils';
 import { InMemorySigner } from '@taquito/signer';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/example-tzip-16.ts
+++ b/example/example-tzip-16.ts
@@ -4,7 +4,7 @@ import { tzip16, Tzip16Module } from '@taquito/tzip16';
 async function example() {
   try {
 
-    const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+    const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
     tezos.addExtension(new Tzip16Module());
     const contract = await tezos.contract.at("KT1JZVozQHLZN7TaACnX6NGBxUkhNjn6tmTB", tzip16)
     const metadata = await contract.tzip16().getMetadata();

--- a/example/pretty-print-contract.ts
+++ b/example/pretty-print-contract.ts
@@ -1,7 +1,7 @@
 import { Parser, emitMicheline } from '@taquito/michel-codec'
 import { TezosToolkit } from '@taquito/taquito';
 
-const provider = 'https://mainnet.ecadinfra.com/';
+const provider = 'https://mainnet.tezos.ecadinfra.com/';
 
 const example = async () => {
 

--- a/example/scan-path-ledger.ts
+++ b/example/scan-path-ledger.ts
@@ -11,7 +11,7 @@ async function example() {
 
     const transport = await TransportNodeHid.create();
     let index = 0;
-    const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+    const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
     while (index < 8) {
         const ledgerSigner = new LedgerSigner(transport, `44'/1729'/${index}'/0'`, false, DerivationType.ED25519);
         tezos.setProvider({ signer: ledgerSigner });

--- a/example/wallet-originate-areyouthere.ts
+++ b/example/wallet-originate-areyouthere.ts
@@ -2,7 +2,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/example/wallet-originate-contract-transfer.ts
+++ b/example/wallet-originate-contract-transfer.ts
@@ -2,7 +2,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 
 async function example() {
-  const provider = 'https://ghostnet.ecadinfra.com';
+  const provider = 'https://ghostnet.tezos.ecadinfra.com';
   const signer = new InMemorySigner('edskRtmEwZxRzwd1obV9pJzAoLoxXFWTSHbgqpDBRHx1Ktzo5yVuJ37e2R4nzjLnNbxFU4UiBU1iHzAy52pK5YBRpaFwLbByca');
   const tezos = new TezosToolkit(provider);
   tezos.setSignerProvider(signer);

--- a/integration-tests/__tests__/http-backend-request-error-handling.spec.ts
+++ b/integration-tests/__tests__/http-backend-request-error-handling.spec.ts
@@ -6,11 +6,11 @@ describe('HttpBackend request', () => {
       const http: HttpBackend = new HttpBackend(1);
       await http.createRequest<string>({
         method: 'GET',
-        url: 'https://mainnet.ecadinfra.com/chains/main/blocks/head/hash'
+        url: 'https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/hash'
       });
     } catch (err: any) {
       expect(err.name).toEqual('HttpTimeoutError');
-      expect(err.url).toContain('https://mainnet.ecadinfra.com/chains/main/blocks/head/hash');
+      expect(err.url).toContain('https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/hash');
       expect(err.message).toContain('timeout of 1ms exceeded');
     }
   });
@@ -20,7 +20,7 @@ describe('HttpBackend request', () => {
       const http: HttpBackend = new HttpBackend();
       await http.createRequest<string>({
         method: 'GET',
-        url: 'https://mainnet.ecadinfra.com/chains/main/blocks/head/helpers/baking_rights',
+        url: 'https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/helpers/baking_rights',
         query: {
           level: 0
         }
@@ -28,7 +28,7 @@ describe('HttpBackend request', () => {
     } catch (err: any) {
       expect(err.name).toEqual('HttpResponseError');
       expect(err.status).toEqual(404);
-      expect(err.url).toEqual('https://mainnet.ecadinfra.com/chains/main/blocks/head/helpers/baking_rights?level=0');
+      expect(err.url).toEqual('https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/helpers/baking_rights?level=0');
       expect(err.message).toContain('Not Found');
     }
   });

--- a/integration-tests/__tests__/rpc/get-protocol-constants.spec.ts
+++ b/integration-tests/__tests__/rpc/get-protocol-constants.spec.ts
@@ -8,7 +8,7 @@ CONFIGS().forEach(({ lib, protocol, rpc, networkType }) => {
   const parisnet = (networkType == NetworkType.TESTNET && protocol === Protocols.PsParisCZ) ? test : test.skip;
   const weeklynet = (networkType == NetworkType.TESTNET && protocol === Protocols.ProtoALpha) ? test : test.skip;
   describe('Test fetching constants for all protocols on Mainnet', () => {
-    const rpcUrl = 'https://mainnet.ecadinfra.com/';
+    const rpcUrl = 'https://mainnet.tezos.ecadinfra.com/';
     Tezos.setRpcProvider(rpcUrl);
     it(`should successfully fetch Proto20(Paris) constants at head`, async () => {
       const constants: ConstantsResponseProto020 = await Tezos.rpc.getConstants();

--- a/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
+++ b/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
@@ -90,7 +90,7 @@ export class RpcClientCache implements RpcClientInterface {
    * @param rpcClient rpcClient responsible of the interaction with Tezos network through an rpc node
    * @param ttl number representing the time to live (default 1000 milliseconds)
    *
-   * @example new RpcClientCache(new RpcClient('https://mainnet.ecadinfra.com/'))
+   * @example new RpcClientCache(new RpcClient('https://mainnet.tezos.ecadinfra.com/'))
    */
   constructor(
     private rpcClient: RpcClientInterface,

--- a/packages/taquito-rpc/src/taquito-rpc.ts
+++ b/packages/taquito-rpc/src/taquito-rpc.ts
@@ -107,7 +107,7 @@ export class RpcClient implements RpcClientInterface {
    * @param httpBackend Http backend that issue http request.
    * You can override it by providing your own if you which to hook in the request/response
    *
-   * @example new RpcClient('https://mainnet.ecadinfra.com/', 'main') this will use https://mainnet.ecadinfra.com//chains/main
+   * @example new RpcClient('https://mainnet.tezos.ecadinfra.com/', 'main') this will use https://mainnet.tezos.ecadinfra.com//chains/main
    */
   constructor(
     protected url: string,

--- a/packages/taquito-rpc/test/taquito-rpc.spec.ts
+++ b/packages/taquito-rpc/test/taquito-rpc.spec.ts
@@ -3731,11 +3731,11 @@ describe('RpcClient test', () => {
 
   describe('getRpcUrl', () => {
     it('should return the RPC Url', () => {
-      const url = 'https://mainnet.ecadinfra.com/';
+      const url = 'https://mainnet.tezos.ecadinfra.com/';
       const rpcUrlMainnet = new RpcClient(url).getRpcUrl();
-      expect(rpcUrlMainnet).toEqual('https://mainnet.ecadinfra.com/');
-      const rpcUrlCarthagenet = new RpcClient('https://ghostnet.ecadinfra.com').getRpcUrl();
-      expect(rpcUrlCarthagenet).toEqual('https://ghostnet.ecadinfra.com');
+      expect(rpcUrlMainnet).toEqual('https://mainnet.tezos.ecadinfra.com/');
+      const rpcUrlCarthagenet = new RpcClient('https://ghostnet.tezos.ecadinfra.com').getRpcUrl();
+      expect(rpcUrlCarthagenet).toEqual('https://ghostnet.tezos.ecadinfra.com');
     });
   });
 

--- a/packages/taquito-sapling/README.md
+++ b/packages/taquito-sapling/README.md
@@ -24,7 +24,7 @@ The returned balance is in mutez.
 import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 
@@ -50,7 +50,7 @@ A shielded transaction allows sending tokens from a Tezos account (tz1, tz2, tz3
 import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit, InMemorySpendingKey } from '@taquito/sapling';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 // set up your signer on the TezosToolkit as usual
 const saplingContract = await tezos.contract.at('KT1UYwMR6Q6LZnwQEi77DSBrAjKT1tEJb245');
 

--- a/packages/taquito/src/taquito.ts
+++ b/packages/taquito/src/taquito.ts
@@ -130,7 +130,7 @@ export class TezosToolkit {
    *
    * @param options rpc url or rpcClient to use to interact with the Tezos network
    *
-   * @example Tezos.setProvider({rpc: 'https://mainnet.ecadinfra.com/', signer: new InMemorySigner.fromSecretKey(“edsk...”)})
+   * @example Tezos.setProvider({rpc: 'https://mainnet.tezos.ecadinfra.com/', signer: new InMemorySigner.fromSecretKey(“edsk...”)})
    * @example Tezos.setProvider({ config: { confirmationPollingTimeoutSecond: 300 }})
    *
    */
@@ -189,7 +189,7 @@ export class TezosToolkit {
    *
    * @param options rpc url or rpcClient to use to interact with the Tezos network
    *
-   * @example Tezos.setRpcProvider('https://mainnet.ecadinfra.com/')
+   * @example Tezos.setRpcProvider('https://mainnet.tezos.ecadinfra.com/')
    *
    */
   setRpcProvider(rpc?: SetProviderOptions['rpc']) {

--- a/website/src/theme/CodeBlock/index.js
+++ b/website/src/theme/CodeBlock/index.js
@@ -98,7 +98,7 @@ export default ({
         wallet = new BeaconWallet({ name:"exampleWallet", network: { type: 'ghostnet'}, enableMetrics: true, });
         wallet.client.subscribeToEvent(BeaconEvent.ACTIVE_ACCOUNT_SET, account => console.log(`${BeaconEvent.ACTIVE_ACCOUNT_SET} triggered: `, account));
       }
-      const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+      const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
       setDependencies({
         Tezos,
         wallet,

--- a/website/versioned_docs/version-19.0.0/complex_parameters.md
+++ b/website/versioned_docs/version-19.0.0/complex_parameters.md
@@ -52,7 +52,7 @@ An annotation identifies every argument. Therefore we can ignore optional values
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
 // import { importKey } from '@taquito/signer';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 //%data
 const dataMap = new MichelsonMap();
@@ -129,7 +129,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -153,7 +153,7 @@ importKey(Tezos, secretKey)
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -184,7 +184,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-19.0.0/drain_account.md
+++ b/website/versioned_docs/version-19.0.0/drain_account.md
@@ -22,7 +22,7 @@ In the following example, we have not revealed the account that we want to empty
 :::
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 // import { getRevealFee } from "@taquito/taquito";
 
 Tezos.signer
@@ -87,7 +87,7 @@ The contract we originate is a `manager contract.` It has a `do` method taking a
 In the example, we estimate the transfer operation before doing it. The associated fees are deducted from the manager's address when draining the account. Thus, for the operation to be successful, the manager's address for that account must contain funds to cover the gas.
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 function transferImplicit(key, mutez) {
   return [

--- a/website/versioned_docs/version-19.0.0/estimate.md
+++ b/website/versioned_docs/version-19.0.0/estimate.md
@@ -39,7 +39,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -64,7 +64,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -105,7 +105,7 @@ The `contractCall()` member method can now be used to estimate contract calls as
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 Tezos.contract
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
   .then((contract) => {
@@ -133,7 +133,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
@@ -174,7 +174,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate
@@ -204,7 +204,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate

--- a/website/versioned_docs/version-19.0.0/inmemory_signer.md
+++ b/website/versioned_docs/version-19.0.0/inmemory_signer.md
@@ -41,7 +41,7 @@ The `fromSecretKey` method takes a secret that is base58 encoded as a parameter.
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb')
   .then((theSigner) => {
@@ -58,7 +58,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('spsk2Fiz7sGP5fNMJrokp6ynTa4bcFbsRhw58FHXbNf5ProDNFJ5Xq')
   .then((theSigner) => {
@@ -78,7 +78,7 @@ When required, Taquito offers the `b58cencode` function allowing to encode the s
 // import { b58cencode, prefix, Prefix } from '@taquito/utils';
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const b58encodedSecret = b58cencode(
   '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d',
@@ -119,7 +119,7 @@ Here are three examples with encrypted private keys where the passphrase used is
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'edesk1GXwWmGjXiLHBKxGBxwmNvG21vKBh6FBxc4CyJ8adQQE2avP5vBB57ZUZ93Anm7i4k8RmsHaPzVAvpnHkFF',
@@ -139,7 +139,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'spesk24UQkAiJk8X6AufNtRv1WWPp2BAssEgmijCTQPMgUXweSKPmLdbyAjPmCG1pR2dC9P5UZZVeZcb7zVodUHZ',
@@ -159,7 +159,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T',
@@ -188,7 +188,7 @@ With ed25519 default derivation path (Reminder Must be hardened with either h or
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   // ed25519 must have all hardened paths
 
@@ -212,7 +212,7 @@ With a non-default derivation path non-hardened with a tz2 address
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   const params = {
     mnemonic: 'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business',

--- a/website/versioned_docs/version-19.0.0/ledger_signer.md
+++ b/website/versioned_docs/version-19.0.0/ledger_signer.md
@@ -199,7 +199,7 @@ _Note that this example is not intended to be a complete example of paths scanni
 //import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';
 //import { TezosToolkit } from '@taquito/taquito';
 // import TransportWebHID from "@ledgerhq/hw-transport-webhid";
-//const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+//const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 TransportWebHID.create().then((transport) => {
   for (let index = 0, p = Promise.resolve(); index < 10; index++) {

--- a/website/versioned_docs/version-19.0.0/making_transfers.md
+++ b/website/versioned_docs/version-19.0.0/making_transfers.md
@@ -23,7 +23,7 @@ In the following example, we transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNj
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 render(`Fetching a private key...`);
 fetch('https://keygen.ecadinfra.com/ghostnet/', {

--- a/website/versioned_docs/version-19.0.0/maps_bigmaps.md
+++ b/website/versioned_docs/version-19.0.0/maps_bigmaps.md
@@ -903,7 +903,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')
@@ -933,7 +933,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')

--- a/website/versioned_docs/version-19.0.0/michelsonmap.md
+++ b/website/versioned_docs/version-19.0.0/michelsonmap.md
@@ -29,7 +29,7 @@ import { BigNumber } from 'bignumber.js';
 
 const contractAddress: string = 'KT1M5C76aSjpWXdoBvuzRdi3UJoC3jEzrSUW';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const contract = await Tezos.contract.at(contractAddress);
 const storage: MichelsonMap<string, BigNumber> = await contract.storage();

--- a/website/versioned_docs/version-19.0.0/originate.md
+++ b/website/versioned_docs/version-19.0.0/originate.md
@@ -35,7 +35,7 @@ This requires a signer to be configured, ie:
 ```
 import { importKey } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 
@@ -45,7 +45,7 @@ importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 const option = { name: "nameOfWallet", network: { type: 'ghostnet' }}
 const wallet = new BeaconWallet(option)
 await wallet.requestPermissions()
@@ -85,7 +85,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -114,7 +114,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -156,7 +156,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -181,7 +181,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -217,7 +217,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -254,7 +254,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation

--- a/website/versioned_docs/version-19.0.0/quick_start.md
+++ b/website/versioned_docs/version-19.0.0/quick_start.md
@@ -57,7 +57,7 @@ Alternatively, you can use a `WalletProvider` to interact with a wallet. Please 
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.tz
   .getBalance('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')

--- a/website/versioned_docs/version-19.0.0/rpc_nodes.md
+++ b/website/versioned_docs/version-19.0.0/rpc_nodes.md
@@ -23,8 +23,8 @@ values={[
 
 | Provider         | Net          | URL                                      | Header                                                                          |
 |------------------|--------------|------------------------------------------|---------------------------------------------------------------------------------|
-| ECAD Labs        | Mainnet      | https://mainnet.ecadinfra.com            | [Check](https://mainnet.ecadinfra.com/chains/main/blocks/head/header)           |
-| ECAD Labs        | Ghostnet     | https://ghostnet.ecadinfra.com           | [Check](https://ghostnet.ecadinfra.com/chains/main/blocks/head/header)          |
+| ECAD Labs        | Mainnet      | https://mainnet.tezos.ecadinfra.com            | [Check](https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/header)           |
+| ECAD Labs        | Ghostnet     | https://ghostnet.tezos.ecadinfra.com           | [Check](https://ghostnet.tezos.ecadinfra.com/chains/main/blocks/head/header)          |
 | ECAD Labs        | Oxfordnet    | https://oxfordnet.ecadinfra.com          | [Check](https://oxfordnet.ecadinfra.com/chains/main/blocks/head/header)         |
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |

--- a/website/versioned_docs/version-19.0.0/rpc_package.md
+++ b/website/versioned_docs/version-19.0.0/rpc_package.md
@@ -18,7 +18,7 @@ Methods in the RPC package map one-to-one to the corresponding Tezos RPC API end
 
 import { RpcClient } from '@taquito/rpc';
 
-const client = new RpcClient(' https://ghostnet.ecadinfra.com/', 'NetXLH1uAxK7CCh');
+const client = new RpcClient(' https://ghostnet.tezos.ecadinfra.com/', 'NetXLH1uAxK7CCh');
 ```
 
 The `RpcClient` constructor takes the URL of the node you want to use and the chain ID.

--- a/website/versioned_docs/version-19.0.0/sapling.md
+++ b/website/versioned_docs/version-19.0.0/sapling.md
@@ -53,7 +53,7 @@ import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 
@@ -86,7 +86,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -119,7 +119,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -156,7 +156,7 @@ Here is an example of how to prepare and inject a shielded transaction using Taq
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -228,7 +228,7 @@ Here is an example of how to prepare and inject a Sapling transaction using Taqu
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -286,7 +286,7 @@ Here is an example of how to prepare and inject an unshielded transaction using 
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -342,7 +342,7 @@ import { InMemoryViewingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 

--- a/website/versioned_docs/version-19.0.0/smartcontracts.md
+++ b/website/versioned_docs/version-19.0.0/smartcontracts.md
@@ -75,7 +75,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -90,7 +90,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -123,7 +123,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -167,7 +167,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -188,7 +188,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -230,7 +230,7 @@ values={[
 In the following example, a contract's `set_child_record` method will be called by passing the parameter in an object format. The `methodsObject` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -251,7 +251,7 @@ The preceding example returns an object giving indication on how to structure th
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -282,7 +282,7 @@ importKey(Tezos, secretKey)
 In the following example, a contract's `set_child_record` method will be called by passing the arguments using the flattened representation. The `methods` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -303,7 +303,7 @@ The preceding example returns an array which contains the different possible sig
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-19.0.0/storage_annotations.md
+++ b/website/versioned_docs/version-19.0.0/storage_annotations.md
@@ -36,7 +36,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -62,7 +62,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -111,7 +111,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -188,7 +188,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -215,7 +215,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({

--- a/website/versioned_docs/version-19.0.0/tezos_domains.md
+++ b/website/versioned_docs/version-19.0.0/tezos_domains.md
@@ -22,7 +22,7 @@ const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the domain name if found or the provided address
 const fetchTezosDomainFromAddress = async (address: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(domainContractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
@@ -53,7 +53,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the address if found or the provided domain name
 const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.records.get(char2Bytes(domainName));
@@ -82,7 +82,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // this function return the expiry date of a domain name
 const fetchExpiryDate = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const expiryDate = await storage.store.expiry_map.get(char2Bytes(domainName));

--- a/website/versioned_docs/version-19.0.0/tutorial.md
+++ b/website/versioned_docs/version-19.0.0/tutorial.md
@@ -98,7 +98,7 @@ Now, open the file `index.ts` and replace the code with the following:
 ```ts
 import { TezosToolkit } from "@taquito/taquito";
 
-var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
 tezosToolkit.tz.getBalance("tz1YvE7Sfo92ueEPEdZceNWd5MWNeMNSt16L").then(balance => {
     console.log(balance.toNumber());
@@ -198,7 +198,7 @@ import { InMemorySigner } from "@taquito/signer";
 import { TezosToolkit } from "@taquito/taquito";
 
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     // WARNING: DO NOT DO THIS IN PRODUCTION, KEEP YOUR SECRETS SAFE
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
@@ -246,8 +246,8 @@ For the purpose of this section, I have created a new address and funded it on t
     docker run --pull always -it --entrypoint sh docker.io/tezos/tezos:latest
 
     # now you are inside the docker container
-    octez-client -E https://ghostnet.ecadinfra.com gen keys mysamplekey -s secp256k1
-    octez-client -E https://ghostnet.ecadinfra.com show address mysamplekey -S
+    octez-client -E https://ghostnet.tezos.ecadinfra.com gen keys mysamplekey -s secp256k1
+    octez-client -E https://ghostnet.tezos.ecadinfra.com show address mysamplekey -S
   ```
   The new address you just created has a balance of zero. For the testnet, You can go to [ghostnet faucet](https://faucet.ghostnet.teztnets.xyz/) and send some ꜩ to it for free. On mainnet, you need to buy actual Tez on an exchange.
 </details>
@@ -272,7 +272,7 @@ Open the file `index.ts` and change the `main` function to the following:
 
 ```ts
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
     tezosToolkit.setProvider({ signer });
@@ -431,7 +431,7 @@ import { BeaconWallet } from "@taquito/beacon-wallet";
 
 const App = () => {
   const [Tezos] = useState<TezosToolkit>(
-    new TezosToolkit("https://ghostnet.ecadinfra.com")
+    new TezosToolkit("https://ghostnet.tezos.ecadinfra.com")
   );
   const [wallet, setWallet] = useState<BeaconWallet | undefined>(undefined);
   const [userAddress, setUserAddress] = useState<string | undefined>(undefined);
@@ -485,7 +485,7 @@ const ConnectButton = ({
       await wallet!.requestPermissions({
         network: {
           type: NetworkType.GHOSTNET,
-          rpcUrl: "https://ghostnet.ecadinfra.com",
+          rpcUrl: "https://ghostnet.tezos.ecadinfra.com",
         },
       });
       const userAddress = await wallet!.getPKH();

--- a/website/versioned_docs/version-19.0.0/version.md
+++ b/website/versioned_docs/version-19.0.0/version.md
@@ -1042,7 +1042,7 @@ Note for the users of the lower level APIs: injecting more than one manager oper
 The `increase_paid_storage` operation allows increasing the paid storage of a smart contract by a specified bytes amount. The smart contract owner doesn't have to do it; any user can increase the storage. The operation is of interest for high-traffic dapps as it allows prepaying for storage and prevents transactions from failing because of an unpredictable storage burn.
 
 ```typescript
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const op = await Tezos.contract.increasePaidStorage({
     amount: 5,
@@ -2155,7 +2155,7 @@ In version 9.2.0-beta of Taquito, the ability to send more than one operation in
 The default streamer set on the `TezosToolkit` used a hardcoded polling interval of 20 seconds, and there was no easy way to change this. To reduce the probability of missing blocks, it is now possible to configure the interval as follow:
 
 ```ts
-const tezos = new TezosToolkit('https://mainnet.ecadinfra.com')
+const tezos = new TezosToolkit('https://mainnet.tezos.ecadinfra.com')
 tezos.setProvider({ config: { streamerPollingIntervalMilliseconds: 15000 } });
 
 const sub = tezos.stream.subscribeOperation(filter)

--- a/website/versioned_docs/version-19.0.0/wallet_API.md
+++ b/website/versioned_docs/version-19.0.0/wallet_API.md
@@ -42,7 +42,7 @@ To start, let's import the Tezos Toolkit from Taquito and create a new instance 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 ```
 
 This object exposes different methods we are going to use to set up our wallet. TZIP-10 has become the official standard of communication and interaction between wallets and dapps, so let's start with the `@taquito/beacon-wallet` package that implements this standard!
@@ -547,7 +547,7 @@ Now, we have everything we need to originate a new contract!
 Before doing so, we have to choose the network we want to originate it to:
 
 ```js
-Tezos.setProvider({ rpc: 'https://ghostnet.ecadinfra.com/' });
+Tezos.setProvider({ rpc: 'https://ghostnet.tezos.ecadinfra.com/' });
 ```
 
 Then, we can start the process. The Tezos singleton has a `wallet` property with an `originate` method. This is the one that must be called to originate the contract. This method takes an argument, an object with two properties: `code` that holds the parsed Michelson code to be originated and `storage` that has the initial storage. After passing this argument, you call the `send()` method to originate the contract.

--- a/website/versioned_docs/version-19.1.0/complex_parameters.md
+++ b/website/versioned_docs/version-19.1.0/complex_parameters.md
@@ -52,7 +52,7 @@ An annotation identifies every argument. Therefore we can ignore optional values
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
 // import { importKey } from '@taquito/signer';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 //%data
 const dataMap = new MichelsonMap();
@@ -129,7 +129,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -153,7 +153,7 @@ importKey(Tezos, secretKey)
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -184,7 +184,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-19.1.0/drain_account.md
+++ b/website/versioned_docs/version-19.1.0/drain_account.md
@@ -22,7 +22,7 @@ In the following example, we have not revealed the account that we want to empty
 :::
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 // import { getRevealFee } from "@taquito/taquito";
 
 Tezos.signer
@@ -87,7 +87,7 @@ The contract we originate is a `manager contract.` It has a `do` method taking a
 In the example, we estimate the transfer operation before doing it. The associated fees are deducted from the manager's address when draining the account. Thus, for the operation to be successful, the manager's address for that account must contain funds to cover the gas.
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 function transferImplicit(key, mutez) {
   return [

--- a/website/versioned_docs/version-19.1.0/estimate.md
+++ b/website/versioned_docs/version-19.1.0/estimate.md
@@ -43,7 +43,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -68,7 +68,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -109,7 +109,7 @@ The `contractCall()` member method can now be used to estimate contract calls as
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 Tezos.contract
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
   .then((contract) => {
@@ -137,7 +137,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
@@ -178,7 +178,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate
@@ -208,7 +208,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate

--- a/website/versioned_docs/version-19.1.0/inmemory_signer.md
+++ b/website/versioned_docs/version-19.1.0/inmemory_signer.md
@@ -41,7 +41,7 @@ The `fromSecretKey` method takes a secret that is base58 encoded as a parameter.
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb')
   .then((theSigner) => {
@@ -58,7 +58,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('spsk2Fiz7sGP5fNMJrokp6ynTa4bcFbsRhw58FHXbNf5ProDNFJ5Xq')
   .then((theSigner) => {
@@ -78,7 +78,7 @@ When required, Taquito offers the `b58cencode` function allowing to encode the s
 // import { b58cencode, prefix, Prefix } from '@taquito/utils';
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const b58encodedSecret = b58cencode(
   '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d',
@@ -119,7 +119,7 @@ Here are three examples with encrypted private keys where the passphrase used is
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'edesk1GXwWmGjXiLHBKxGBxwmNvG21vKBh6FBxc4CyJ8adQQE2avP5vBB57ZUZ93Anm7i4k8RmsHaPzVAvpnHkFF',
@@ -139,7 +139,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'spesk24UQkAiJk8X6AufNtRv1WWPp2BAssEgmijCTQPMgUXweSKPmLdbyAjPmCG1pR2dC9P5UZZVeZcb7zVodUHZ',
@@ -159,7 +159,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T',
@@ -188,7 +188,7 @@ With ed25519 default derivation path (Reminder Must be hardened with either h or
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   // ed25519 must have all hardened paths
 
@@ -212,7 +212,7 @@ With a non-default derivation path non-hardened with a tz2 address
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   const params = {
     mnemonic: 'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business',

--- a/website/versioned_docs/version-19.1.0/ledger_signer.md
+++ b/website/versioned_docs/version-19.1.0/ledger_signer.md
@@ -199,7 +199,7 @@ _Note that this example is not intended to be a complete example of paths scanni
 //import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';
 //import { TezosToolkit } from '@taquito/taquito';
 // import TransportWebHID from "@ledgerhq/hw-transport-webhid";
-//const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+//const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 TransportWebHID.create().then((transport) => {
   for (let index = 0, p = Promise.resolve(); index < 10; index++) {

--- a/website/versioned_docs/version-19.1.0/making_transfers.md
+++ b/website/versioned_docs/version-19.1.0/making_transfers.md
@@ -23,7 +23,7 @@ In the following example, we transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNj
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 render(`Fetching a private key...`);
 fetch('https://keygen.ecadinfra.com/ghostnet/', {

--- a/website/versioned_docs/version-19.1.0/maps_bigmaps.md
+++ b/website/versioned_docs/version-19.1.0/maps_bigmaps.md
@@ -903,7 +903,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')
@@ -933,7 +933,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')

--- a/website/versioned_docs/version-19.1.0/michelsonmap.md
+++ b/website/versioned_docs/version-19.1.0/michelsonmap.md
@@ -29,7 +29,7 @@ import { BigNumber } from 'bignumber.js';
 
 const contractAddress: string = 'KT1M5C76aSjpWXdoBvuzRdi3UJoC3jEzrSUW';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const contract = await Tezos.contract.at(contractAddress);
 const storage: MichelsonMap<string, BigNumber> = await contract.storage();

--- a/website/versioned_docs/version-19.1.0/originate.md
+++ b/website/versioned_docs/version-19.1.0/originate.md
@@ -35,7 +35,7 @@ This requires a signer to be configured, ie:
 ```
 import { importKey } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 
@@ -45,7 +45,7 @@ importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 const option = { name: "nameOfWallet", network: { type: 'ghostnet' }}
 const wallet = new BeaconWallet(option)
 await wallet.requestPermissions()
@@ -85,7 +85,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -114,7 +114,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -156,7 +156,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -181,7 +181,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -217,7 +217,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -254,7 +254,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation

--- a/website/versioned_docs/version-19.1.0/quick_start.md
+++ b/website/versioned_docs/version-19.1.0/quick_start.md
@@ -57,7 +57,7 @@ Alternatively, you can use a `WalletProvider` to interact with a wallet. Please 
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.tz
   .getBalance('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')

--- a/website/versioned_docs/version-19.1.0/rpc_nodes.md
+++ b/website/versioned_docs/version-19.1.0/rpc_nodes.md
@@ -23,8 +23,8 @@ values={[
 
 | Provider         | Net          | URL                                      | Header                                                                          |
 |------------------|--------------|------------------------------------------|---------------------------------------------------------------------------------|
-| ECAD Labs        | Mainnet      | https://mainnet.ecadinfra.com            | [Check](https://mainnet.ecadinfra.com/chains/main/blocks/head/header)           |
-| ECAD Labs        | Ghostnet     | https://ghostnet.ecadinfra.com           | [Check](https://ghostnet.ecadinfra.com/chains/main/blocks/head/header)          |
+| ECAD Labs        | Mainnet      | https://mainnet.tezos.ecadinfra.com            | [Check](https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/header)           |
+| ECAD Labs        | Ghostnet     | https://ghostnet.tezos.ecadinfra.com           | [Check](https://ghostnet.tezos.ecadinfra.com/chains/main/blocks/head/header)          |
 | ECAD Labs        | Oxfordnet    | https://oxfordnet.ecadinfra.com          | [Check](https://oxfordnet.ecadinfra.com/chains/main/blocks/head/header)         |
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |

--- a/website/versioned_docs/version-19.1.0/rpc_package.md
+++ b/website/versioned_docs/version-19.1.0/rpc_package.md
@@ -18,7 +18,7 @@ Methods in the RPC package map one-to-one to the corresponding Tezos RPC API end
 
 import { RpcClient } from '@taquito/rpc';
 
-const client = new RpcClient(' https://ghostnet.ecadinfra.com/', 'NetXLH1uAxK7CCh');
+const client = new RpcClient(' https://ghostnet.tezos.ecadinfra.com/', 'NetXLH1uAxK7CCh');
 ```
 
 The `RpcClient` constructor takes the URL of the node you want to use and the chain ID.

--- a/website/versioned_docs/version-19.1.0/sapling.md
+++ b/website/versioned_docs/version-19.1.0/sapling.md
@@ -53,7 +53,7 @@ import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 
@@ -86,7 +86,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -119,7 +119,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -156,7 +156,7 @@ Here is an example of how to prepare and inject a shielded transaction using Taq
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -228,7 +228,7 @@ Here is an example of how to prepare and inject a Sapling transaction using Taqu
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -286,7 +286,7 @@ Here is an example of how to prepare and inject an unshielded transaction using 
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -342,7 +342,7 @@ import { InMemoryViewingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 

--- a/website/versioned_docs/version-19.1.0/smartcontracts.md
+++ b/website/versioned_docs/version-19.1.0/smartcontracts.md
@@ -75,7 +75,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -90,7 +90,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -123,7 +123,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -167,7 +167,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -188,7 +188,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -230,7 +230,7 @@ values={[
 In the following example, a contract's `set_child_record` method will be called by passing the parameter in an object format. The `methodsObject` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -251,7 +251,7 @@ The preceding example returns an object giving indication on how to structure th
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -282,7 +282,7 @@ importKey(Tezos, secretKey)
 In the following example, a contract's `set_child_record` method will be called by passing the arguments using the flattened representation. The `methods` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -303,7 +303,7 @@ The preceding example returns an array which contains the different possible sig
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-19.1.0/storage_annotations.md
+++ b/website/versioned_docs/version-19.1.0/storage_annotations.md
@@ -36,7 +36,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -62,7 +62,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -111,7 +111,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -188,7 +188,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -215,7 +215,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({

--- a/website/versioned_docs/version-19.1.0/tezos_domains.md
+++ b/website/versioned_docs/version-19.1.0/tezos_domains.md
@@ -22,7 +22,7 @@ const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the domain name if found or the provided address
 const fetchTezosDomainFromAddress = async (address: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(domainContractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
@@ -53,7 +53,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the address if found or the provided domain name
 const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.records.get(stringToBytes(domainName));
@@ -82,7 +82,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // this function return the expiry date of a domain name
 const fetchExpiryDate = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const expiryDate = await storage.store.expiry_map.get(stringToBytes(domainName));

--- a/website/versioned_docs/version-19.1.0/tutorial.md
+++ b/website/versioned_docs/version-19.1.0/tutorial.md
@@ -98,7 +98,7 @@ Now, open the file `index.ts` and replace the code with the following:
 ```ts
 import { TezosToolkit } from "@taquito/taquito";
 
-var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
 tezosToolkit.tz.getBalance("tz1YvE7Sfo92ueEPEdZceNWd5MWNeMNSt16L").then(balance => {
     console.log(balance.toNumber());
@@ -198,7 +198,7 @@ import { InMemorySigner } from "@taquito/signer";
 import { TezosToolkit } from "@taquito/taquito";
 
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     // WARNING: DO NOT DO THIS IN PRODUCTION, KEEP YOUR SECRETS SAFE
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
@@ -246,8 +246,8 @@ For the purpose of this section, I have created a new address and funded it on t
     docker run --pull always -it --entrypoint sh docker.io/tezos/tezos:latest
 
     # now you are inside the docker container
-    octez-client -E https://ghostnet.ecadinfra.com gen keys mysamplekey -s secp256k1
-    octez-client -E https://ghostnet.ecadinfra.com show address mysamplekey -S
+    octez-client -E https://ghostnet.tezos.ecadinfra.com gen keys mysamplekey -s secp256k1
+    octez-client -E https://ghostnet.tezos.ecadinfra.com show address mysamplekey -S
   ```
   The new address you just created has a balance of zero. For the testnet, You can go to [ghostnet faucet](https://faucet.ghostnet.teztnets.xyz/) and send some ꜩ to it for free. On mainnet, you need to buy actual Tez on an exchange.
 </details>
@@ -272,7 +272,7 @@ Open the file `index.ts` and change the `main` function to the following:
 
 ```ts
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
     tezosToolkit.setProvider({ signer });
@@ -431,7 +431,7 @@ import { BeaconWallet } from "@taquito/beacon-wallet";
 
 const App = () => {
   const [Tezos] = useState<TezosToolkit>(
-    new TezosToolkit("https://ghostnet.ecadinfra.com")
+    new TezosToolkit("https://ghostnet.tezos.ecadinfra.com")
   );
   const [wallet, setWallet] = useState<BeaconWallet | undefined>(undefined);
   const [userAddress, setUserAddress] = useState<string | undefined>(undefined);
@@ -485,7 +485,7 @@ const ConnectButton = ({
       await wallet!.requestPermissions({
         network: {
           type: NetworkType.GHOSTNET,
-          rpcUrl: "https://ghostnet.ecadinfra.com",
+          rpcUrl: "https://ghostnet.tezos.ecadinfra.com",
         },
       });
       const userAddress = await wallet!.getPKH();

--- a/website/versioned_docs/version-19.1.0/version.md
+++ b/website/versioned_docs/version-19.1.0/version.md
@@ -1095,7 +1095,7 @@ Note for the users of the lower level APIs: injecting more than one manager oper
 The `increase_paid_storage` operation allows increasing the paid storage of a smart contract by a specified bytes amount. The smart contract owner doesn't have to do it; any user can increase the storage. The operation is of interest for high-traffic dapps as it allows prepaying for storage and prevents transactions from failing because of an unpredictable storage burn.
 
 ```typescript
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const op = await Tezos.contract.increasePaidStorage({
     amount: 5,
@@ -2208,7 +2208,7 @@ In version 9.2.0-beta of Taquito, the ability to send more than one operation in
 The default streamer set on the `TezosToolkit` used a hardcoded polling interval of 20 seconds, and there was no easy way to change this. To reduce the probability of missing blocks, it is now possible to configure the interval as follow:
 
 ```ts
-const tezos = new TezosToolkit('https://mainnet.ecadinfra.com')
+const tezos = new TezosToolkit('https://mainnet.tezos.ecadinfra.com')
 tezos.setProvider({ config: { streamerPollingIntervalMilliseconds: 15000 } });
 
 const sub = tezos.stream.subscribeOperation(filter)

--- a/website/versioned_docs/version-19.1.0/wallet_API.md
+++ b/website/versioned_docs/version-19.1.0/wallet_API.md
@@ -42,7 +42,7 @@ To start, let's import the Tezos Toolkit from Taquito and create a new instance 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 ```
 
 This object exposes different methods we are going to use to set up our wallet. TZIP-10 has become the official standard of communication and interaction between wallets and dapps, so let's start with the `@taquito/beacon-wallet` package that implements this standard!
@@ -547,7 +547,7 @@ Now, we have everything we need to originate a new contract!
 Before doing so, we have to choose the network we want to originate it to:
 
 ```js
-Tezos.setProvider({ rpc: 'https://ghostnet.ecadinfra.com/' });
+Tezos.setProvider({ rpc: 'https://ghostnet.tezos.ecadinfra.com/' });
 ```
 
 Then, we can start the process. The Tezos singleton has a `wallet` property with an `originate` method. This is the one that must be called to originate the contract. This method takes an argument, an object with two properties: `code` that holds the parsed Michelson code to be originated and `storage` that has the initial storage. After passing this argument, you call the `send()` method to originate the contract.

--- a/website/versioned_docs/version-19.2.0/complex_parameters.md
+++ b/website/versioned_docs/version-19.2.0/complex_parameters.md
@@ -52,7 +52,7 @@ An annotation identifies every argument. Therefore we can ignore optional values
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
 // import { importKey } from '@taquito/signer';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 //%data
 const dataMap = new MichelsonMap();
@@ -129,7 +129,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -153,7 +153,7 @@ importKey(Tezos, secretKey)
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -184,7 +184,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-19.2.0/drain_account.md
+++ b/website/versioned_docs/version-19.2.0/drain_account.md
@@ -22,7 +22,7 @@ In the following example, we have not revealed the account that we want to empty
 :::
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 // import { getRevealFee } from "@taquito/taquito";
 
 Tezos.signer
@@ -87,7 +87,7 @@ The contract we originate is a `manager contract.` It has a `do` method taking a
 In the example, we estimate the transfer operation before doing it. The associated fees are deducted from the manager's address when draining the account. Thus, for the operation to be successful, the manager's address for that account must contain funds to cover the gas.
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 function transferImplicit(key, mutez) {
   return [

--- a/website/versioned_docs/version-19.2.0/estimate.md
+++ b/website/versioned_docs/version-19.2.0/estimate.md
@@ -43,7 +43,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -68,7 +68,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -109,7 +109,7 @@ The `contractCall()` member method can now be used to estimate contract calls as
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 Tezos.contract
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
   .then((contract) => {
@@ -137,7 +137,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
@@ -178,7 +178,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate
@@ -208,7 +208,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate

--- a/website/versioned_docs/version-19.2.0/inmemory_signer.md
+++ b/website/versioned_docs/version-19.2.0/inmemory_signer.md
@@ -41,7 +41,7 @@ The `fromSecretKey` method takes a secret that is base58 encoded as a parameter.
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb')
   .then((theSigner) => {
@@ -58,7 +58,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('spsk2Fiz7sGP5fNMJrokp6ynTa4bcFbsRhw58FHXbNf5ProDNFJ5Xq')
   .then((theSigner) => {
@@ -78,7 +78,7 @@ When required, Taquito offers the `b58cencode` function allowing to encode the s
 // import { b58cencode, prefix, Prefix } from '@taquito/utils';
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const b58encodedSecret = b58cencode(
   '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d',
@@ -119,7 +119,7 @@ Here are three examples with encrypted private keys where the passphrase used is
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'edesk1GXwWmGjXiLHBKxGBxwmNvG21vKBh6FBxc4CyJ8adQQE2avP5vBB57ZUZ93Anm7i4k8RmsHaPzVAvpnHkFF',
@@ -139,7 +139,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'spesk24UQkAiJk8X6AufNtRv1WWPp2BAssEgmijCTQPMgUXweSKPmLdbyAjPmCG1pR2dC9P5UZZVeZcb7zVodUHZ',
@@ -159,7 +159,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T',
@@ -188,7 +188,7 @@ With ed25519 default derivation path (Reminder Must be hardened with either h or
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   // ed25519 must have all hardened paths
 
@@ -212,7 +212,7 @@ With a non-default derivation path non-hardened with a tz2 address
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   const params = {
     mnemonic: 'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business',

--- a/website/versioned_docs/version-19.2.0/ledger_signer.md
+++ b/website/versioned_docs/version-19.2.0/ledger_signer.md
@@ -199,7 +199,7 @@ _Note that this example is not intended to be a complete example of paths scanni
 //import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';
 //import { TezosToolkit } from '@taquito/taquito';
 // import TransportWebHID from "@ledgerhq/hw-transport-webhid";
-//const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+//const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 TransportWebHID.create().then((transport) => {
   for (let index = 0, p = Promise.resolve(); index < 10; index++) {

--- a/website/versioned_docs/version-19.2.0/making_transfers.md
+++ b/website/versioned_docs/version-19.2.0/making_transfers.md
@@ -23,7 +23,7 @@ In the following example, we transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNj
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 render(`Fetching a private key...`);
 fetch('https://keygen.ecadinfra.com/ghostnet/', {

--- a/website/versioned_docs/version-19.2.0/maps_bigmaps.md
+++ b/website/versioned_docs/version-19.2.0/maps_bigmaps.md
@@ -903,7 +903,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')
@@ -933,7 +933,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')

--- a/website/versioned_docs/version-19.2.0/michelsonmap.md
+++ b/website/versioned_docs/version-19.2.0/michelsonmap.md
@@ -29,7 +29,7 @@ import { BigNumber } from 'bignumber.js';
 
 const contractAddress: string = 'KT1M5C76aSjpWXdoBvuzRdi3UJoC3jEzrSUW';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const contract = await Tezos.contract.at(contractAddress);
 const storage: MichelsonMap<string, BigNumber> = await contract.storage();

--- a/website/versioned_docs/version-19.2.0/originate.md
+++ b/website/versioned_docs/version-19.2.0/originate.md
@@ -35,7 +35,7 @@ This requires a signer to be configured, ie:
 ```
 import { importKey } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 
@@ -45,7 +45,7 @@ importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 const option = { name: "nameOfWallet", network: { type: 'ghostnet' }, enableMetrics: true};
 const wallet = new BeaconWallet(option);
 
@@ -93,7 +93,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -122,7 +122,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -164,7 +164,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -189,7 +189,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -225,7 +225,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -262,7 +262,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation

--- a/website/versioned_docs/version-19.2.0/quick_start.md
+++ b/website/versioned_docs/version-19.2.0/quick_start.md
@@ -57,7 +57,7 @@ Alternatively, you can use a `WalletProvider` to interact with a wallet. Please 
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.tz
   .getBalance('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')

--- a/website/versioned_docs/version-19.2.0/rpc_nodes.md
+++ b/website/versioned_docs/version-19.2.0/rpc_nodes.md
@@ -23,8 +23,8 @@ values={[
 
 | Provider         | Net          | URL                                      | Header                                                                          |
 |------------------|--------------|------------------------------------------|---------------------------------------------------------------------------------|
-| ECAD Labs        | Mainnet      | https://mainnet.ecadinfra.com            | [Check](https://mainnet.ecadinfra.com/chains/main/blocks/head/header)           |
-| ECAD Labs        | Ghostnet     | https://ghostnet.ecadinfra.com           | [Check](https://ghostnet.ecadinfra.com/chains/main/blocks/head/header)          |
+| ECAD Labs        | Mainnet      | https://mainnet.tezos.ecadinfra.com            | [Check](https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/header)           |
+| ECAD Labs        | Ghostnet     | https://ghostnet.tezos.ecadinfra.com           | [Check](https://ghostnet.tezos.ecadinfra.com/chains/main/blocks/head/header)          |
 | ECAD Labs        | Oxfordnet    | https://oxfordnet.ecadinfra.com          | [Check](https://oxfordnet.ecadinfra.com/chains/main/blocks/head/header)         |
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |

--- a/website/versioned_docs/version-19.2.0/rpc_package.md
+++ b/website/versioned_docs/version-19.2.0/rpc_package.md
@@ -18,7 +18,7 @@ Methods in the RPC package map one-to-one to the corresponding Tezos RPC API end
 
 import { RpcClient } from '@taquito/rpc';
 
-const client = new RpcClient(' https://ghostnet.ecadinfra.com/', 'NetXLH1uAxK7CCh');
+const client = new RpcClient(' https://ghostnet.tezos.ecadinfra.com/', 'NetXLH1uAxK7CCh');
 ```
 
 The `RpcClient` constructor takes the URL of the node you want to use and the chain ID.

--- a/website/versioned_docs/version-19.2.0/sapling.md
+++ b/website/versioned_docs/version-19.2.0/sapling.md
@@ -53,7 +53,7 @@ import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 
@@ -86,7 +86,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -119,7 +119,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -156,7 +156,7 @@ Here is an example of how to prepare and inject a shielded transaction using Taq
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -228,7 +228,7 @@ Here is an example of how to prepare and inject a Sapling transaction using Taqu
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -286,7 +286,7 @@ Here is an example of how to prepare and inject an unshielded transaction using 
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -342,7 +342,7 @@ import { InMemoryViewingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 

--- a/website/versioned_docs/version-19.2.0/smartcontracts.md
+++ b/website/versioned_docs/version-19.2.0/smartcontracts.md
@@ -75,7 +75,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -90,7 +90,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -123,7 +123,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -167,7 +167,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -188,7 +188,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -230,7 +230,7 @@ values={[
 In the following example, a contract's `set_child_record` method will be called by passing the parameter in an object format. The `methodsObject` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -251,7 +251,7 @@ The preceding example returns an object giving indication on how to structure th
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -282,7 +282,7 @@ importKey(Tezos, secretKey)
 In the following example, a contract's `set_child_record` method will be called by passing the arguments using the flattened representation. The `methods` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -303,7 +303,7 @@ The preceding example returns an array which contains the different possible sig
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-19.2.0/storage_annotations.md
+++ b/website/versioned_docs/version-19.2.0/storage_annotations.md
@@ -36,7 +36,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -62,7 +62,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -111,7 +111,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -188,7 +188,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -215,7 +215,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({

--- a/website/versioned_docs/version-19.2.0/tezos_domains.md
+++ b/website/versioned_docs/version-19.2.0/tezos_domains.md
@@ -22,7 +22,7 @@ const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the domain name if found or the provided address
 const fetchTezosDomainFromAddress = async (address: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(domainContractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
@@ -53,7 +53,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the address if found or the provided domain name
 const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.records.get(stringToBytes(domainName));
@@ -82,7 +82,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // this function return the expiry date of a domain name
 const fetchExpiryDate = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const expiryDate = await storage.store.expiry_map.get(stringToBytes(domainName));

--- a/website/versioned_docs/version-19.2.0/timelock.md
+++ b/website/versioned_docs/version-19.2.0/timelock.md
@@ -148,7 +148,7 @@ Let's originate the contract with initial storage values `level` of 0, a stub ch
 // import { stringToBytes } from '@taquito/utils';
 // import { timelockCode, timelockStorage } from './timelock-flip-contract';
 
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const originate = await Tezos.contract.originate({ code: timelockCode, init: timelockStorage });
 await originate.confirmation()

--- a/website/versioned_docs/version-19.2.0/tutorial.md
+++ b/website/versioned_docs/version-19.2.0/tutorial.md
@@ -98,7 +98,7 @@ Now, open the file `index.ts` and replace the code with the following:
 ```ts
 import { TezosToolkit } from "@taquito/taquito";
 
-var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
 tezosToolkit.tz.getBalance("tz1YvE7Sfo92ueEPEdZceNWd5MWNeMNSt16L").then(balance => {
     console.log(balance.toNumber());
@@ -198,7 +198,7 @@ import { InMemorySigner } from "@taquito/signer";
 import { TezosToolkit } from "@taquito/taquito";
 
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     // WARNING: DO NOT DO THIS IN PRODUCTION, KEEP YOUR SECRETS SAFE
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
@@ -246,8 +246,8 @@ For the purpose of this section, I have created a new address and funded it on t
     docker run --pull always -it --entrypoint sh docker.io/tezos/tezos:latest
 
     # now you are inside the docker container
-    octez-client -E https://ghostnet.ecadinfra.com gen keys mysamplekey -s secp256k1
-    octez-client -E https://ghostnet.ecadinfra.com show address mysamplekey -S
+    octez-client -E https://ghostnet.tezos.ecadinfra.com gen keys mysamplekey -s secp256k1
+    octez-client -E https://ghostnet.tezos.ecadinfra.com show address mysamplekey -S
   ```
   The new address you just created has a balance of zero. For the testnet, You can go to [ghostnet faucet](https://faucet.ghostnet.teztnets.xyz/) and send some ꜩ to it for free. On mainnet, you need to buy actual Tez on an exchange.
 </details>
@@ -272,7 +272,7 @@ Open the file `index.ts` and change the `main` function to the following:
 
 ```ts
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
     tezosToolkit.setProvider({ signer });
@@ -431,7 +431,7 @@ import { BeaconWallet } from "@taquito/beacon-wallet";
 
 const App = () => {
   const [Tezos] = useState<TezosToolkit>(
-    new TezosToolkit("https://ghostnet.ecadinfra.com")
+    new TezosToolkit("https://ghostnet.tezos.ecadinfra.com")
   );
   const [wallet, setWallet] = useState<BeaconWallet | undefined>(undefined);
   const [userAddress, setUserAddress] = useState<string | undefined>(undefined);
@@ -485,7 +485,7 @@ const ConnectButton = ({
       await wallet!.requestPermissions({
         network: {
           type: NetworkType.GHOSTNET,
-          rpcUrl: "https://ghostnet.ecadinfra.com",
+          rpcUrl: "https://ghostnet.tezos.ecadinfra.com",
         },
       });
       const userAddress = await wallet!.getPKH();

--- a/website/versioned_docs/version-19.2.0/version.md
+++ b/website/versioned_docs/version-19.2.0/version.md
@@ -1116,7 +1116,7 @@ Note for the users of the lower level APIs: injecting more than one manager oper
 The `increase_paid_storage` operation allows increasing the paid storage of a smart contract by a specified bytes amount. The smart contract owner doesn't have to do it; any user can increase the storage. The operation is of interest for high-traffic dapps as it allows prepaying for storage and prevents transactions from failing because of an unpredictable storage burn.
 
 ```typescript
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const op = await Tezos.contract.increasePaidStorage({
     amount: 5,
@@ -2229,7 +2229,7 @@ In version 9.2.0-beta of Taquito, the ability to send more than one operation in
 The default streamer set on the `TezosToolkit` used a hardcoded polling interval of 20 seconds, and there was no easy way to change this. To reduce the probability of missing blocks, it is now possible to configure the interval as follow:
 
 ```ts
-const tezos = new TezosToolkit('https://mainnet.ecadinfra.com')
+const tezos = new TezosToolkit('https://mainnet.tezos.ecadinfra.com')
 tezos.setProvider({ config: { streamerPollingIntervalMilliseconds: 15000 } });
 
 const sub = tezos.stream.subscribeOperation(filter)

--- a/website/versioned_docs/version-19.2.0/wallet_API.md
+++ b/website/versioned_docs/version-19.2.0/wallet_API.md
@@ -42,7 +42,7 @@ To start, let's import the Tezos Toolkit from Taquito and create a new instance 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 ```
 
 This object exposes different methods we are going to use to set up our wallet. TZIP-10 has become the official standard of communication and interaction between wallets and dapps, so let's start with the `@taquito/beacon-wallet` package that implements this standard!
@@ -543,7 +543,7 @@ Now, we have everything we need to originate a new contract!
 Before doing so, we have to choose the network we want to originate it to:
 
 ```js
-Tezos.setProvider({ rpc: 'https://ghostnet.ecadinfra.com/' });
+Tezos.setProvider({ rpc: 'https://ghostnet.tezos.ecadinfra.com/' });
 ```
 
 Then, we can start the process. The Tezos singleton has a `wallet` property with an `originate` method. This is the one that must be called to originate the contract. This method takes an argument, an object with two properties: `code` that holds the parsed Michelson code to be originated and `storage` that has the initial storage. After passing this argument, you call the `send()` method to originate the contract.

--- a/website/versioned_docs/version-20.0.0/complex_parameters.md
+++ b/website/versioned_docs/version-20.0.0/complex_parameters.md
@@ -52,7 +52,7 @@ An annotation identifies every argument. Therefore we can ignore optional values
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
 // import { importKey } from '@taquito/signer';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 //%data
 const dataMap = new MichelsonMap();
@@ -129,7 +129,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -153,7 +153,7 @@ importKey(Tezos, secretKey)
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -184,7 +184,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-20.0.0/drain_account.md
+++ b/website/versioned_docs/version-20.0.0/drain_account.md
@@ -22,7 +22,7 @@ In the following example, we have not revealed the account that we want to empty
 :::
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 // import { getRevealFee } from "@taquito/taquito";
 
 Tezos.signer
@@ -87,7 +87,7 @@ The contract we originate is a `manager contract.` It has a `do` method taking a
 In the example, we estimate the transfer operation before doing it. The associated fees are deducted from the manager's address when draining the account. Thus, for the operation to be successful, the manager's address for that account must contain funds to cover the gas.
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 function transferImplicit(key, mutez) {
   return [

--- a/website/versioned_docs/version-20.0.0/estimate.md
+++ b/website/versioned_docs/version-20.0.0/estimate.md
@@ -43,7 +43,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -68,7 +68,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -109,7 +109,7 @@ The `contractCall()` member method can now be used to estimate contract calls as
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 Tezos.contract
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
   .then((contract) => {
@@ -137,7 +137,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
@@ -178,7 +178,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate
@@ -208,7 +208,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate

--- a/website/versioned_docs/version-20.0.0/inmemory_signer.md
+++ b/website/versioned_docs/version-20.0.0/inmemory_signer.md
@@ -41,7 +41,7 @@ The `fromSecretKey` method takes a secret that is base58 encoded as a parameter.
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb')
   .then((theSigner) => {
@@ -58,7 +58,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('spsk2Fiz7sGP5fNMJrokp6ynTa4bcFbsRhw58FHXbNf5ProDNFJ5Xq')
   .then((theSigner) => {
@@ -78,7 +78,7 @@ When required, Taquito offers the `b58cencode` function allowing to encode the s
 // import { b58cencode, prefix, Prefix } from '@taquito/utils';
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const b58encodedSecret = b58cencode(
   '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d',
@@ -119,7 +119,7 @@ Here are three examples with encrypted private keys where the passphrase used is
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'edesk1GXwWmGjXiLHBKxGBxwmNvG21vKBh6FBxc4CyJ8adQQE2avP5vBB57ZUZ93Anm7i4k8RmsHaPzVAvpnHkFF',
@@ -139,7 +139,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'spesk24UQkAiJk8X6AufNtRv1WWPp2BAssEgmijCTQPMgUXweSKPmLdbyAjPmCG1pR2dC9P5UZZVeZcb7zVodUHZ',
@@ -159,7 +159,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T',
@@ -188,7 +188,7 @@ With ed25519 default derivation path (Reminder Must be hardened with either h or
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   // ed25519 must have all hardened paths
 
@@ -212,7 +212,7 @@ With a non-default derivation path non-hardened with a tz2 address
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   const params = {
     mnemonic: 'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business',

--- a/website/versioned_docs/version-20.0.0/ledger_signer.md
+++ b/website/versioned_docs/version-20.0.0/ledger_signer.md
@@ -199,7 +199,7 @@ _Note that this example is not intended to be a complete example of paths scanni
 //import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';
 //import { TezosToolkit } from '@taquito/taquito';
 // import TransportWebHID from "@ledgerhq/hw-transport-webhid";
-//const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+//const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 TransportWebHID.create().then((transport) => {
   for (let index = 0, p = Promise.resolve(); index < 10; index++) {

--- a/website/versioned_docs/version-20.0.0/making_transfers.md
+++ b/website/versioned_docs/version-20.0.0/making_transfers.md
@@ -23,7 +23,7 @@ In the following example, we transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNj
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 render(`Fetching a private key...`);
 fetch('https://keygen.ecadinfra.com/ghostnet/', {

--- a/website/versioned_docs/version-20.0.0/maps_bigmaps.md
+++ b/website/versioned_docs/version-20.0.0/maps_bigmaps.md
@@ -903,7 +903,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')
@@ -933,7 +933,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')

--- a/website/versioned_docs/version-20.0.0/michelsonmap.md
+++ b/website/versioned_docs/version-20.0.0/michelsonmap.md
@@ -29,7 +29,7 @@ import { BigNumber } from 'bignumber.js';
 
 const contractAddress: string = 'KT1M5C76aSjpWXdoBvuzRdi3UJoC3jEzrSUW';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const contract = await Tezos.contract.at(contractAddress);
 const storage: MichelsonMap<string, BigNumber> = await contract.storage();

--- a/website/versioned_docs/version-20.0.0/originate.md
+++ b/website/versioned_docs/version-20.0.0/originate.md
@@ -35,7 +35,7 @@ This requires a signer to be configured, ie:
 ```
 import { importKey } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 
@@ -45,7 +45,7 @@ importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 const option = { name: "nameOfWallet", network: { type: 'ghostnet' }, enableMetrics: true};
 const wallet = new BeaconWallet(option);
 
@@ -93,7 +93,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -122,7 +122,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -164,7 +164,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -189,7 +189,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -225,7 +225,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -262,7 +262,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation

--- a/website/versioned_docs/version-20.0.0/quick_start.md
+++ b/website/versioned_docs/version-20.0.0/quick_start.md
@@ -57,7 +57,7 @@ Alternatively, you can use a `WalletProvider` to interact with a wallet. Please 
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.tz
   .getBalance('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')

--- a/website/versioned_docs/version-20.0.0/rpc_nodes.md
+++ b/website/versioned_docs/version-20.0.0/rpc_nodes.md
@@ -23,8 +23,8 @@ values={[
 
 | Provider         | Net          | URL                                      | Header                                                                          |
 |------------------|--------------|------------------------------------------|---------------------------------------------------------------------------------|
-| ECAD Labs        | Mainnet      | https://mainnet.ecadinfra.com            | [Check](https://mainnet.ecadinfra.com/chains/main/blocks/head/header)           |
-| ECAD Labs        | Ghostnet     | https://ghostnet.ecadinfra.com           | [Check](https://ghostnet.ecadinfra.com/chains/main/blocks/head/header)          |
+| ECAD Labs        | Mainnet      | https://mainnet.tezos.ecadinfra.com            | [Check](https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/header)           |
+| ECAD Labs        | Ghostnet     | https://ghostnet.tezos.ecadinfra.com           | [Check](https://ghostnet.tezos.ecadinfra.com/chains/main/blocks/head/header)          |
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |
 | Tezos Foundation | Mainnet      | https://rpc.tzbeta.net/                  | [Check](https://rpc.tzbeta.net/chains/main/blocks/head/header)                  |

--- a/website/versioned_docs/version-20.0.0/rpc_package.md
+++ b/website/versioned_docs/version-20.0.0/rpc_package.md
@@ -18,7 +18,7 @@ Methods in the RPC package map one-to-one to the corresponding Tezos RPC API end
 
 import { RpcClient } from '@taquito/rpc';
 
-const client = new RpcClient(' https://ghostnet.ecadinfra.com/', 'NetXLH1uAxK7CCh');
+const client = new RpcClient(' https://ghostnet.tezos.ecadinfra.com/', 'NetXLH1uAxK7CCh');
 ```
 
 The `RpcClient` constructor takes the URL of the node you want to use and the chain ID.

--- a/website/versioned_docs/version-20.0.0/sapling.md
+++ b/website/versioned_docs/version-20.0.0/sapling.md
@@ -53,7 +53,7 @@ import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 
@@ -86,7 +86,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -119,7 +119,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -156,7 +156,7 @@ Here is an example of how to prepare and inject a shielded transaction using Taq
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -228,7 +228,7 @@ Here is an example of how to prepare and inject a Sapling transaction using Taqu
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -286,7 +286,7 @@ Here is an example of how to prepare and inject an unshielded transaction using 
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -342,7 +342,7 @@ import { InMemoryViewingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 

--- a/website/versioned_docs/version-20.0.0/signing.md
+++ b/website/versioned_docs/version-20.0.0/signing.md
@@ -177,7 +177,7 @@ values={[
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
 // import { stringToBytes, num2PaddedHex } from '@taquito/utils';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 let magicByte = '0x80'
 let magicString = 'tezos signed offchain message'
@@ -205,7 +205,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
 // import { stringToBytes, num2PaddedHex } from '@taquito/utils';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 let magicByte = '0x80'
 let magicString = 'tezos signed offchain message'

--- a/website/versioned_docs/version-20.0.0/smartcontracts.md
+++ b/website/versioned_docs/version-20.0.0/smartcontracts.md
@@ -75,7 +75,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -90,7 +90,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -123,7 +123,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -167,7 +167,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -188,7 +188,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -230,7 +230,7 @@ values={[
 In the following example, a contract's `set_child_record` method will be called by passing the parameter in an object format. The `methodsObject` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -251,7 +251,7 @@ The preceding example returns an object giving indication on how to structure th
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -282,7 +282,7 @@ importKey(Tezos, secretKey)
 In the following example, a contract's `set_child_record` method will be called by passing the arguments using the flattened representation. The `methods` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -303,7 +303,7 @@ The preceding example returns an array which contains the different possible sig
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-20.0.0/storage_annotations.md
+++ b/website/versioned_docs/version-20.0.0/storage_annotations.md
@@ -36,7 +36,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -62,7 +62,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -111,7 +111,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -188,7 +188,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -215,7 +215,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({

--- a/website/versioned_docs/version-20.0.0/tezos_domains.md
+++ b/website/versioned_docs/version-20.0.0/tezos_domains.md
@@ -22,7 +22,7 @@ const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the domain name if found or the provided address
 const fetchTezosDomainFromAddress = async (address: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(domainContractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
@@ -53,7 +53,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the address if found or the provided domain name
 const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.records.get(stringToBytes(domainName));
@@ -82,7 +82,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // this function return the expiry date of a domain name
 const fetchExpiryDate = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const expiryDate = await storage.store.expiry_map.get(stringToBytes(domainName));

--- a/website/versioned_docs/version-20.0.0/timelock.md
+++ b/website/versioned_docs/version-20.0.0/timelock.md
@@ -148,7 +148,7 @@ Let's originate the contract with initial storage values `level` of 0, a stub ch
 // import { stringToBytes } from '@taquito/utils';
 // import { timelockCode, timelockStorage } from './timelock-flip-contract';
 
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const originate = await Tezos.contract.originate({ code: timelockCode, init: timelockStorage });
 await originate.confirmation()

--- a/website/versioned_docs/version-20.0.0/tutorial.md
+++ b/website/versioned_docs/version-20.0.0/tutorial.md
@@ -98,7 +98,7 @@ Now, open the file `index.ts` and replace the code with the following:
 ```ts
 import { TezosToolkit } from "@taquito/taquito";
 
-var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
 tezosToolkit.tz.getBalance("tz1YvE7Sfo92ueEPEdZceNWd5MWNeMNSt16L").then(balance => {
     console.log(balance.toNumber());
@@ -198,7 +198,7 @@ import { InMemorySigner } from "@taquito/signer";
 import { TezosToolkit } from "@taquito/taquito";
 
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     // WARNING: DO NOT DO THIS IN PRODUCTION, KEEP YOUR SECRETS SAFE
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
@@ -246,8 +246,8 @@ For the purpose of this section, I have created a new address and funded it on t
     docker run --pull always -it --entrypoint sh docker.io/tezos/tezos:latest
 
     # now you are inside the docker container
-    octez-client -E https://ghostnet.ecadinfra.com gen keys mysamplekey -s secp256k1
-    octez-client -E https://ghostnet.ecadinfra.com show address mysamplekey -S
+    octez-client -E https://ghostnet.tezos.ecadinfra.com gen keys mysamplekey -s secp256k1
+    octez-client -E https://ghostnet.tezos.ecadinfra.com show address mysamplekey -S
   ```
   The new address you just created has a balance of zero. For the testnet, You can go to [ghostnet faucet](https://faucet.ghostnet.teztnets.xyz/) and send some ꜩ to it for free. On mainnet, you need to buy actual Tez on an exchange.
 </details>
@@ -272,7 +272,7 @@ Open the file `index.ts` and change the `main` function to the following:
 
 ```ts
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
     tezosToolkit.setProvider({ signer });
@@ -431,7 +431,7 @@ import { BeaconWallet } from "@taquito/beacon-wallet";
 
 const App = () => {
   const [Tezos] = useState<TezosToolkit>(
-    new TezosToolkit("https://ghostnet.ecadinfra.com")
+    new TezosToolkit("https://ghostnet.tezos.ecadinfra.com")
   );
   const [wallet, setWallet] = useState<BeaconWallet | undefined>(undefined);
   const [userAddress, setUserAddress] = useState<string | undefined>(undefined);
@@ -485,7 +485,7 @@ const ConnectButton = ({
       await wallet!.requestPermissions({
         network: {
           type: NetworkType.GHOSTNET,
-          rpcUrl: "https://ghostnet.ecadinfra.com",
+          rpcUrl: "https://ghostnet.tezos.ecadinfra.com",
         },
       });
       const userAddress = await wallet!.getPKH();

--- a/website/versioned_docs/version-20.0.0/version.md
+++ b/website/versioned_docs/version-20.0.0/version.md
@@ -1217,7 +1217,7 @@ Note for the users of the lower level APIs: injecting more than one manager oper
 The `increase_paid_storage` operation allows increasing the paid storage of a smart contract by a specified bytes amount. The smart contract owner doesn't have to do it; any user can increase the storage. The operation is of interest for high-traffic dapps as it allows prepaying for storage and prevents transactions from failing because of an unpredictable storage burn.
 
 ```typescript
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const op = await Tezos.contract.increasePaidStorage({
     amount: 5,
@@ -2330,7 +2330,7 @@ In version 9.2.0-beta of Taquito, the ability to send more than one operation in
 The default streamer set on the `TezosToolkit` used a hardcoded polling interval of 20 seconds, and there was no easy way to change this. To reduce the probability of missing blocks, it is now possible to configure the interval as follow:
 
 ```ts
-const tezos = new TezosToolkit('https://mainnet.ecadinfra.com')
+const tezos = new TezosToolkit('https://mainnet.tezos.ecadinfra.com')
 tezos.setProvider({ config: { streamerPollingIntervalMilliseconds: 15000 } });
 
 const sub = tezos.stream.subscribeOperation(filter)

--- a/website/versioned_docs/version-20.0.0/wallet_API.md
+++ b/website/versioned_docs/version-20.0.0/wallet_API.md
@@ -42,7 +42,7 @@ To start, let's import the Tezos Toolkit from Taquito and create a new instance 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 ```
 
 This object exposes different methods we are going to use to set up our wallet. TZIP-10 has become the official standard of communication and interaction between wallets and dapps, so let's start with the `@taquito/beacon-wallet` package that implements this standard!
@@ -543,7 +543,7 @@ Now, we have everything we need to originate a new contract!
 Before doing so, we have to choose the network we want to originate it to:
 
 ```js
-Tezos.setProvider({ rpc: 'https://ghostnet.ecadinfra.com/' });
+Tezos.setProvider({ rpc: 'https://ghostnet.tezos.ecadinfra.com/' });
 ```
 
 Then, we can start the process. The Tezos singleton has a `wallet` property with an `originate` method. This is the one that must be called to originate the contract. This method takes an argument, an object with two properties: `code` that holds the parsed Michelson code to be originated and `storage` that has the initial storage. After passing this argument, you call the `send()` method to originate the contract.

--- a/website/versioned_docs/version-20.1.0/complex_parameters.md
+++ b/website/versioned_docs/version-20.1.0/complex_parameters.md
@@ -52,7 +52,7 @@ An annotation identifies every argument. Therefore we can ignore optional values
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
 // import { importKey } from '@taquito/signer';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 //%data
 const dataMap = new MichelsonMap();
@@ -129,7 +129,7 @@ The way to write the parameter when calling the function of a contract with Taqu
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -153,7 +153,7 @@ importKey(Tezos, secretKey)
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -184,7 +184,7 @@ The `address %address` and the `nat %ttl` of the `set_child_record` function are
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-20.1.0/drain_account.md
+++ b/website/versioned_docs/version-20.1.0/drain_account.md
@@ -22,7 +22,7 @@ In the following example, we have not revealed the account that we want to empty
 :::
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 // import { getRevealFee } from "@taquito/taquito";
 
 Tezos.signer
@@ -87,7 +87,7 @@ The contract we originate is a `manager contract.` It has a `do` method taking a
 In the example, we estimate the transfer operation before doing it. The associated fees are deducted from the manager's address when draining the account. Thus, for the operation to be successful, the manager's address for that account must contain funds to cover the gas.
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 function transferImplicit(key, mutez) {
   return [

--- a/website/versioned_docs/version-20.1.0/estimate.md
+++ b/website/versioned_docs/version-20.1.0/estimate.md
@@ -43,7 +43,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -68,7 +68,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const amount = 2;
 const address = 'tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY';
@@ -109,7 +109,7 @@ The `contractCall()` member method can now be used to estimate contract calls as
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 Tezos.contract
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
   .then((contract) => {
@@ -137,7 +137,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1BJadpDyLCACMH7Tt9xtpx4dQZVKw9cDF7')
@@ -178,7 +178,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate
@@ -208,7 +208,7 @@ Tezos.estimate
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 console.log(`Estimating the contract origination : `);
 Tezos.estimate

--- a/website/versioned_docs/version-20.1.0/inmemory_signer.md
+++ b/website/versioned_docs/version-20.1.0/inmemory_signer.md
@@ -41,7 +41,7 @@ The `fromSecretKey` method takes a secret that is base58 encoded as a parameter.
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGRZRnb')
   .then((theSigner) => {
@@ -58,7 +58,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey('spsk2Fiz7sGP5fNMJrokp6ynTa4bcFbsRhw58FHXbNf5ProDNFJ5Xq')
   .then((theSigner) => {
@@ -78,7 +78,7 @@ When required, Taquito offers the `b58cencode` function allowing to encode the s
 // import { b58cencode, prefix, Prefix } from '@taquito/utils';
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const b58encodedSecret = b58cencode(
   '7c842c15c8b0c8fd228e6cb5302a50201f41642dd36b699003fb3c857920bc9d',
@@ -119,7 +119,7 @@ Here are three examples with encrypted private keys where the passphrase used is
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'edesk1GXwWmGjXiLHBKxGBxwmNvG21vKBh6FBxc4CyJ8adQQE2avP5vBB57ZUZ93Anm7i4k8RmsHaPzVAvpnHkFF',
@@ -139,7 +139,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'spesk24UQkAiJk8X6AufNtRv1WWPp2BAssEgmijCTQPMgUXweSKPmLdbyAjPmCG1pR2dC9P5UZZVeZcb7zVodUHZ',
@@ -159,7 +159,7 @@ InMemorySigner.fromSecretKey(
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 InMemorySigner.fromSecretKey(
   'p2esk28hoUE2J88QNFj2aDX2pjzL7wcVh2g8tkEwtWWguby9M3FHUgSbzvF2Sd7wQ4Kd8crFwvto6gF3otcBuo4T',
@@ -188,7 +188,7 @@ With ed25519 default derivation path (Reminder Must be hardened with either h or
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   // ed25519 must have all hardened paths
 
@@ -212,7 +212,7 @@ With a non-default derivation path non-hardened with a tz2 address
 ```js live noInline
   // import { TezosToolkit } from '@taquito/taquito
   // import { InMemorySigner } from '@taquito/signer'
-  // const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+  // const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
   const params = {
     mnemonic: 'author crumble medal dose ribbon permit ankle sport final hood shadow vessel horn hawk enter zebra prefer devote captain during fly found despair business',

--- a/website/versioned_docs/version-20.1.0/ledger_signer.md
+++ b/website/versioned_docs/version-20.1.0/ledger_signer.md
@@ -199,7 +199,7 @@ _Note that this example is not intended to be a complete example of paths scanni
 //import { LedgerSigner, DerivationType, HDPathTemplate } from '@taquito/ledger-signer';
 //import { TezosToolkit } from '@taquito/taquito';
 // import TransportWebHID from "@ledgerhq/hw-transport-webhid";
-//const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+//const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 TransportWebHID.create().then((transport) => {
   for (let index = 0, p = Promise.resolve(); index < 10; index++) {

--- a/website/versioned_docs/version-20.1.0/making_transfers.md
+++ b/website/versioned_docs/version-20.1.0/making_transfers.md
@@ -23,7 +23,7 @@ In the following example, we transfer 0.5ꜩ from a `tz1aaYoabvj2DQtpHz74Z83fSNj
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 render(`Fetching a private key...`);
 fetch('https://keygen.ecadinfra.com/ghostnet/', {

--- a/website/versioned_docs/version-20.1.0/maps_bigmaps.md
+++ b/website/versioned_docs/version-20.1.0/maps_bigmaps.md
@@ -903,7 +903,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')
@@ -933,7 +933,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1LPdW47Aba3kVpNMpRt7sx5yM1M4A8XmAW')

--- a/website/versioned_docs/version-20.1.0/michelsonmap.md
+++ b/website/versioned_docs/version-20.1.0/michelsonmap.md
@@ -29,7 +29,7 @@ import { BigNumber } from 'bignumber.js';
 
 const contractAddress: string = 'KT1M5C76aSjpWXdoBvuzRdi3UJoC3jEzrSUW';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const contract = await Tezos.contract.at(contractAddress);
 const storage: MichelsonMap<string, BigNumber> = await contract.storage();

--- a/website/versioned_docs/version-20.1.0/originate.md
+++ b/website/versioned_docs/version-20.1.0/originate.md
@@ -35,7 +35,7 @@ This requires a signer to be configured, ie:
 ```
 import { importKey } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 
@@ -45,7 +45,7 @@ importKey(Tezos, "p2sk2obfVMEuPUnadAConLWk7Tf4Dt3n4svSgJwrgpamRqJXvaYcg1")
 ```
 import {  BeaconWallet } from '@taquito/beacon-wallet';
 import { TezosToolkit } from '@taquito/taquito';
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 const option = { name: "nameOfWallet", network: { type: 'ghostnet' }, enableMetrics: true};
 const wallet = new BeaconWallet(option);
 
@@ -93,7 +93,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -122,7 +122,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -164,7 +164,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -189,7 +189,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -225,7 +225,7 @@ values={[
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation
@@ -262,7 +262,7 @@ Tezos.contract
 
 ```js live noInline wallet
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 // const genericMultisigJSONfile = require('./generic.json')
 // generic.json is referring to Michelson source code in JSON representation

--- a/website/versioned_docs/version-20.1.0/quick_start.md
+++ b/website/versioned_docs/version-20.1.0/quick_start.md
@@ -57,7 +57,7 @@ Alternatively, you can use a `WalletProvider` to interact with a wallet. Please 
 
 ```js live noInline
 // import { TezosToolkit } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.tz
   .getBalance('tz1h3rQ8wBxFd8L9B3d7Jhaawu6Z568XU3xY')

--- a/website/versioned_docs/version-20.1.0/rpc_nodes.md
+++ b/website/versioned_docs/version-20.1.0/rpc_nodes.md
@@ -23,8 +23,8 @@ values={[
 
 | Provider         | Net          | URL                                      | Header                                                                          |
 |------------------|--------------|------------------------------------------|---------------------------------------------------------------------------------|
-| ECAD Labs        | Mainnet      | https://mainnet.ecadinfra.com            | [Check](https://mainnet.ecadinfra.com/chains/main/blocks/head/header)           |
-| ECAD Labs        | Ghostnet     | https://ghostnet.ecadinfra.com           | [Check](https://ghostnet.ecadinfra.com/chains/main/blocks/head/header)          |
+| ECAD Labs        | Mainnet      | https://mainnet.tezos.ecadinfra.com            | [Check](https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/header)           |
+| ECAD Labs        | Ghostnet     | https://ghostnet.tezos.ecadinfra.com           | [Check](https://ghostnet.tezos.ecadinfra.com/chains/main/blocks/head/header)          |
 | SmartPy          | Mainnet      | https://mainnet.smartpy.io               | [Check](https://mainnet.smartpy.io/chains/main/blocks/head/header)              |
 | SmartPy          | Ghostnet     | https://ghostnet.smartpy.io              | [Check](https://ghostnet.smartpy.io/chains/main/blocks/head/header)             |
 | Tezos Foundation | Mainnet      | https://rpc.tzbeta.net/                  | [Check](https://rpc.tzbeta.net/chains/main/blocks/head/header)                  |

--- a/website/versioned_docs/version-20.1.0/rpc_package.md
+++ b/website/versioned_docs/version-20.1.0/rpc_package.md
@@ -18,7 +18,7 @@ Methods in the RPC package map one-to-one to the corresponding Tezos RPC API end
 
 import { RpcClient } from '@taquito/rpc';
 
-const client = new RpcClient(' https://ghostnet.ecadinfra.com/', 'NetXLH1uAxK7CCh');
+const client = new RpcClient(' https://ghostnet.tezos.ecadinfra.com/', 'NetXLH1uAxK7CCh');
 ```
 
 The `RpcClient` constructor takes the URL of the node you want to use and the chain ID.

--- a/website/versioned_docs/version-20.1.0/sapling.md
+++ b/website/versioned_docs/version-20.1.0/sapling.md
@@ -53,7 +53,7 @@ import { TezosToolkit, RpcReadAdapter } from '@taquito/taquito';
 import { SaplingToolkit } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 
@@ -86,7 +86,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -119,7 +119,7 @@ const aliceSk = 'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW
 
 const inMemorySpendingKey = new InMemorySpendingKey(aliceSk);
 
-const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.ecadinfra.com/'));
+const readProvider = new RpcReadAdapter(new RpcClient('https://ghostnet.tezos.ecadinfra.com/'));
 
 const saplingToolkit = new SaplingToolkit(
     { saplingSigner: inMemorySpendingKey },
@@ -156,7 +156,7 @@ Here is an example of how to prepare and inject a shielded transaction using Taq
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -228,7 +228,7 @@ Here is an example of how to prepare and inject a Sapling transaction using Taqu
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -286,7 +286,7 @@ Here is an example of how to prepare and inject an unshielded transaction using 
 // import { RpcClient } from '@taquito/rpc';
 
 const saplingContractAddress = 'KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf'
-const rpcUrl = 'https://ghostnet.ecadinfra.com/';
+const rpcUrl = 'https://ghostnet.tezos.ecadinfra.com/';
 const readProvider = new RpcReadAdapter(new RpcClient(rpcUrl));
 // const Tezos = new TezosToolkit(rpcUrl);
 // Note: you need to set up your signer on the TezosToolkit as usual
@@ -342,7 +342,7 @@ import { InMemoryViewingKey } from '@taquito/sapling';
 import { RpcClient } from '@taquito/rpc';
 
 const readProvider = new RpcReadAdapter(new RpcClient('https://YOUR_PREFERRED_RPC_URL'));
-const tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 
 const saplingContract = await tezos.contract.at('KT1ToBD7bovonshNrxs3i4KMFuZ8PE2LUmQf');
 

--- a/website/versioned_docs/version-20.1.0/signing.md
+++ b/website/versioned_docs/version-20.1.0/signing.md
@@ -177,7 +177,7 @@ values={[
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
 // import { stringToBytes, num2PaddedHex } from '@taquito/utils';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 let magicByte = '0x80'
 let magicString = 'tezos signed offchain message'
@@ -205,7 +205,7 @@ InMemorySigner.fromSecretKey('edsk2rKA8YEExg9Zo2qNPiQnnYheF1DhqjLVmfKdxiFfu5GyGR
 // import { TezosToolkit } from '@taquito/taquito'
 // import { InMemorySigner } from '@taquito/signer'
 // import { stringToBytes, num2PaddedHex } from '@taquito/utils';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 let magicByte = '0x80'
 let magicString = 'tezos signed offchain message'

--- a/website/versioned_docs/version-20.1.0/smartcontracts.md
+++ b/website/versioned_docs/version-20.1.0/smartcontracts.md
@@ -75,7 +75,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -90,7 +90,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -123,7 +123,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -167,7 +167,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -188,7 +188,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .at('KT1KAUbe1gsdw5BeVQfgjh9xZFrHrKVs8ApD')
@@ -230,7 +230,7 @@ values={[
 In the following example, a contract's `set_child_record` method will be called by passing the parameter in an object format. The `methodsObject` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -251,7 +251,7 @@ The preceding example returns an object giving indication on how to structure th
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)
@@ -282,7 +282,7 @@ importKey(Tezos, secretKey)
 In the following example, a contract's `set_child_record` method will be called by passing the arguments using the flattened representation. The `methods` member of the `ContractAbstraction` class allows doing so. First, it is possible to obtain details about the signature of the `set_child_record` entry point by using the `getSignature` method as follow:
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .at('KT1B2exfRrGMjfZqWK1bDemr3nBFhHsUWQuN')
@@ -303,7 +303,7 @@ The preceding example returns an array which contains the different possible sig
 
 ```js live noInline
 // import { TezosToolkit, MichelsonMap } from '@taquito/taquito';
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com')
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com')
 // import { importKey } from '@taquito/signer';
 
 importKey(Tezos, secretKey)

--- a/website/versioned_docs/version-20.1.0/storage_annotations.md
+++ b/website/versioned_docs/version-20.1.0/storage_annotations.md
@@ -36,7 +36,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -62,7 +62,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -111,7 +111,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -137,7 +137,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({
@@ -188,7 +188,7 @@ values={[
 <TabItem value="contractAPI">
 
 ```js live noInline
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.contract
   .originate({
@@ -215,7 +215,7 @@ Tezos.contract
   <TabItem value="walletAPI">
 
 ```js live noInline wallet
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 Tezos.wallet
   .originate({

--- a/website/versioned_docs/version-20.1.0/tezos_domains.md
+++ b/website/versioned_docs/version-20.1.0/tezos_domains.md
@@ -22,7 +22,7 @@ const domainContractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the domain name if found or the provided address
 const fetchTezosDomainFromAddress = async (address: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(domainContractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.reverse_records.get(address);
@@ -53,7 +53,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // the function returns the address if found or the provided domain name
 const fetchAddressFromTezosDomain = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const domain = await storage.store.records.get(stringToBytes(domainName));
@@ -82,7 +82,7 @@ const contractAddress = "KT1GBZmSxmnKJXGMdMLbugPfLyUPmuLSMwKS";
 
 // this function return the expiry date of a domain name
 const fetchExpiryDate = async (domainName: string): Promise<string> => {
-    const Tezos = new TezosToolkit("https://mainnet.ecadinfra.com");
+    const Tezos = new TezosToolkit("https://mainnet.tezos.ecadinfra.com");
     const contract = await Tezos.wallet.at(contractAddress);
     const storage: any = await contract.storage();
     const expiryDate = await storage.store.expiry_map.get(stringToBytes(domainName));

--- a/website/versioned_docs/version-20.1.0/timelock.md
+++ b/website/versioned_docs/version-20.1.0/timelock.md
@@ -148,7 +148,7 @@ Let's originate the contract with initial storage values `level` of 0, a stub ch
 // import { stringToBytes } from '@taquito/utils';
 // import { timelockCode, timelockStorage } from './timelock-flip-contract';
 
-// const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+// const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const originate = await Tezos.contract.originate({ code: timelockCode, init: timelockStorage });
 await originate.confirmation()

--- a/website/versioned_docs/version-20.1.0/tutorial.md
+++ b/website/versioned_docs/version-20.1.0/tutorial.md
@@ -98,7 +98,7 @@ Now, open the file `index.ts` and replace the code with the following:
 ```ts
 import { TezosToolkit } from "@taquito/taquito";
 
-var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
 tezosToolkit.tz.getBalance("tz1YvE7Sfo92ueEPEdZceNWd5MWNeMNSt16L").then(balance => {
     console.log(balance.toNumber());
@@ -198,7 +198,7 @@ import { InMemorySigner } from "@taquito/signer";
 import { TezosToolkit } from "@taquito/taquito";
 
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     // WARNING: DO NOT DO THIS IN PRODUCTION, KEEP YOUR SECRETS SAFE
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
@@ -246,8 +246,8 @@ For the purpose of this section, I have created a new address and funded it on t
     docker run --pull always -it --entrypoint sh docker.io/tezos/tezos:latest
 
     # now you are inside the docker container
-    octez-client -E https://ghostnet.ecadinfra.com gen keys mysamplekey -s secp256k1
-    octez-client -E https://ghostnet.ecadinfra.com show address mysamplekey -S
+    octez-client -E https://ghostnet.tezos.ecadinfra.com gen keys mysamplekey -s secp256k1
+    octez-client -E https://ghostnet.tezos.ecadinfra.com show address mysamplekey -S
   ```
   The new address you just created has a balance of zero. For the testnet, You can go to [ghostnet faucet](https://faucet.ghostnet.teztnets.xyz/) and send some ꜩ to it for free. On mainnet, you need to buy actual Tez on an exchange.
 </details>
@@ -272,7 +272,7 @@ Open the file `index.ts` and change the `main` function to the following:
 
 ```ts
 async function main() {
-    var tezosToolkit = new TezosToolkit("https://ghostnet.ecadinfra.com");
+    var tezosToolkit = new TezosToolkit("https://ghostnet.tezos.ecadinfra.com");
 
     const signer = await InMemorySigner.fromSecretKey('spsk29SxqYRjnreqGzsYiAUEqxyhDwD8j2J57pJjaGgGtReZVD2UiD');
     tezosToolkit.setProvider({ signer });
@@ -431,7 +431,7 @@ import { BeaconWallet } from "@taquito/beacon-wallet";
 
 const App = () => {
   const [Tezos] = useState<TezosToolkit>(
-    new TezosToolkit("https://ghostnet.ecadinfra.com")
+    new TezosToolkit("https://ghostnet.tezos.ecadinfra.com")
   );
   const [wallet, setWallet] = useState<BeaconWallet | undefined>(undefined);
   const [userAddress, setUserAddress] = useState<string | undefined>(undefined);
@@ -485,7 +485,7 @@ const ConnectButton = ({
       await wallet!.requestPermissions({
         network: {
           type: NetworkType.GHOSTNET,
-          rpcUrl: "https://ghostnet.ecadinfra.com",
+          rpcUrl: "https://ghostnet.tezos.ecadinfra.com",
         },
       });
       const userAddress = await wallet!.getPKH();

--- a/website/versioned_docs/version-20.1.0/version.md
+++ b/website/versioned_docs/version-20.1.0/version.md
@@ -1249,7 +1249,7 @@ Note for the users of the lower level APIs: injecting more than one manager oper
 The `increase_paid_storage` operation allows increasing the paid storage of a smart contract by a specified bytes amount. The smart contract owner doesn't have to do it; any user can increase the storage. The operation is of interest for high-traffic dapps as it allows prepaying for storage and prevents transactions from failing because of an unpredictable storage burn.
 
 ```typescript
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com');
 
 const op = await Tezos.contract.increasePaidStorage({
     amount: 5,
@@ -2362,7 +2362,7 @@ In version 9.2.0-beta of Taquito, the ability to send more than one operation in
 The default streamer set on the `TezosToolkit` used a hardcoded polling interval of 20 seconds, and there was no easy way to change this. To reduce the probability of missing blocks, it is now possible to configure the interval as follow:
 
 ```ts
-const tezos = new TezosToolkit('https://mainnet.ecadinfra.com')
+const tezos = new TezosToolkit('https://mainnet.tezos.ecadinfra.com')
 tezos.setProvider({ config: { streamerPollingIntervalMilliseconds: 15000 } });
 
 const sub = tezos.stream.subscribeOperation(filter)

--- a/website/versioned_docs/version-20.1.0/wallet_API.md
+++ b/website/versioned_docs/version-20.1.0/wallet_API.md
@@ -42,7 +42,7 @@ To start, let's import the Tezos Toolkit from Taquito and create a new instance 
 ```js
 import { TezosToolkit } from '@taquito/taquito';
 
-const Tezos = new TezosToolkit('https://ghostnet.ecadinfra.com/');
+const Tezos = new TezosToolkit('https://ghostnet.tezos.ecadinfra.com/');
 ```
 
 This object exposes different methods we are going to use to set up our wallet. TZIP-10 has become the official standard of communication and interaction between wallets and dapps, so let's start with the `@taquito/beacon-wallet` package that implements this standard!
@@ -543,7 +543,7 @@ Now, we have everything we need to originate a new contract!
 Before doing so, we have to choose the network we want to originate it to:
 
 ```js
-Tezos.setProvider({ rpc: 'https://ghostnet.ecadinfra.com/' });
+Tezos.setProvider({ rpc: 'https://ghostnet.tezos.ecadinfra.com/' });
 ```
 
 Then, we can start the process. The Tezos singleton has a `wallet` property with an `originate` method. This is the one that must be called to originate the contract. This method takes an argument, an object with two properties: `code` that holds the parsed Michelson code to be originated and `storage` that has the initial storage. After passing this argument, you call the `send()` method to originate the contract.


### PR DESCRIPTION
Replaced all occurrences of deprecated ECAD Infra RPC addresses with the new format as outlined in issue #3089. Updated addresses for mainnet, ghostnet, parisnet, and quebecnet.

Old format: https://<network>.ecadinfra.com
New format: https://<network>.tezos.ecadinfra.com

This change ensures consistency with ECAD Infra's updated RPC address structure.

Closes #3089
