### PR TITLE
feat: replace bip39 with @scure/bip39

### DIFF
--- a/integration-tests/__tests__/sapling/sapling-batched-transactions.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-batched-transactions.spec.ts
@@ -1,9 +1,19 @@
-import { ContractAbstraction, ContractProvider, RpcReadAdapter } from '@taquito/taquito';
+import {
+  ContractAbstraction,
+  ContractProvider,
+  RpcReadAdapter,
+} from '@taquito/taquito';
 import { CONFIGS } from '../../config';
-import { InMemorySpendingKey, InMemoryViewingKey, SaplingToolkit, SaplingTransactionViewer } from '@taquito/sapling';
+import {
+  InMemorySpendingKey,
+  InMemoryViewingKey,
+  SaplingToolkit,
+  SaplingTransactionViewer,
+} from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
@@ -34,68 +44,84 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
   const memoSize = 4;
 
   describe(`Sapling transactions: ${rpc}`, () => {
-
     beforeAll(async () => {
       await setup();
 
       const saplingContractOrigination = await Tezos.contract.originate({
         code: singleSaplingStateContractJProtocol(4),
-        init: '{}'
+        init: '{}',
       });
       await saplingContractOrigination.confirmation();
       saplingContract = await saplingContractOrigination.contract();
 
-      const mnemonic1: string = bip39.generateMnemonic();
+      const mnemonic1: string = bip39.generateMnemonic(wordlist);
       inMemorySpendingKey1 = await InMemorySpendingKey.fromMnemonic(mnemonic1);
-      inMemoryViewingKey1 = await inMemorySpendingKey1.getSaplingViewingKeyProvider();
-      saplingToolkit1 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey1 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      inMemoryViewingKey1 =
+        await inMemorySpendingKey1.getSaplingViewingKeyProvider();
+      saplingToolkit1 = new SaplingToolkit(
+        { saplingSigner: inMemorySpendingKey1 },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       txViewer1 = await saplingToolkit1.getSaplingTransactionViewer();
       paymentAddress1Index0 = (await inMemoryViewingKey1.getAddress(0)).address;
 
-      const mnemonic2: string = bip39.generateMnemonic();
+      const mnemonic2: string = bip39.generateMnemonic(wordlist);
       inMemorySpendingKey2 = await InMemorySpendingKey.fromMnemonic(mnemonic2);
-      inMemoryViewingKey2 = await inMemorySpendingKey2.getSaplingViewingKeyProvider();
-      saplingToolkit2 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey2 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      inMemoryViewingKey2 =
+        await inMemorySpendingKey2.getSaplingViewingKeyProvider();
+      saplingToolkit2 = new SaplingToolkit(
+        { saplingSigner: inMemorySpendingKey2 },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       txViewer2 = await saplingToolkit2.getSaplingTransactionViewer();
       paymentAddress2Index0 = (await inMemoryViewingKey2.getAddress(0)).address;
       paymentAddress2Index5 = (await inMemoryViewingKey2.getAddress(5)).address;
       paymentAddress2Index8 = (await inMemoryViewingKey2.getAddress(8)).address;
 
-      inMemorySpendingKey3 = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
-      inMemoryViewingKey3 = await inMemorySpendingKey3.getSaplingViewingKeyProvider();
-      saplingToolkit3 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey3 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      inMemorySpendingKey3 = new InMemorySpendingKey(
+        'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L'
+      );
+      inMemoryViewingKey3 =
+        await inMemorySpendingKey3.getSaplingViewingKeyProvider();
+      saplingToolkit3 = new SaplingToolkit(
+        { saplingSigner: inMemorySpendingKey3 },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       txViewer3 = await saplingToolkit3.getSaplingTransactionViewer();
       paymentAddress3Index0 = (await inMemoryViewingKey3.getAddress(0)).address;
       paymentAddress3Index5 = (await inMemoryViewingKey3.getAddress(5)).address;
       paymentAddress3Index8 = (await inMemoryViewingKey3.getAddress(8)).address;
-
     });
 
     it('Prepare and inject 3 batched shielded transactions', async () => {
+      const shieldedTx = await saplingToolkit1.prepareShieldedTransaction([
+        {
+          to: paymentAddress1Index0,
+          amount: 1,
+          memo: 'T1',
+        },
+        {
+          to: paymentAddress2Index0,
+          amount: 2,
+          memo: 'T2',
+        },
+        {
+          to: paymentAddress3Index0,
+          amount: 3,
+          memo: 'T3',
+        },
+      ]);
 
-      const shieldedTx = await saplingToolkit1.prepareShieldedTransaction([{
-        to: paymentAddress1Index0,
-        amount: 1,
-        memo: 'T1'
-      },
-      {
-        to: paymentAddress2Index0,
-        amount: 2,
-        memo: 'T2'
-      },
-      {
-        to: paymentAddress3Index0,
-        amount: 3,
-        memo: 'T3'
-      }
-      ])
-
-      const op = await saplingContract.methods.default([shieldedTx]).send({ amount: 6 });
+      const op = await saplingContract.methods
+        .default([shieldedTx])
+        .send({ amount: 6 });
       await op.confirmation();
       expect(op.status).toEqual('applied');
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-
     });
 
     it('Verify balances after the shielded tx', async () => {
@@ -109,11 +135,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             value: new BigNumber(1000000),
             memo: 'T1',
             paymentAddress: paymentAddress1Index0,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
 
       const balance2 = await txViewer2.getBalance();
       const inputs2 = await txViewer2.getIncomingAndOutgoingTransactions();
@@ -125,11 +151,11 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             value: new BigNumber(2000000),
             memo: 'T2',
             paymentAddress: paymentAddress2Index0,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
 
       const balance3 = await txViewer3.getBalance();
       const inputs3 = await txViewer3.getIncomingAndOutgoingTransactions();
@@ -141,59 +167,58 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             value: new BigNumber(3000000),
             memo: 'T3',
             paymentAddress: paymentAddress3Index0,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
     });
 
     it('Prepare and inject batched sapling transactions', async () => {
-
-      const tx = await saplingToolkit1.prepareSaplingTransaction([{
-        to: paymentAddress2Index0,
-        amount: 10,
-        memo: 'tx1',
-        mutez: true
-      },
-      {
-        to: paymentAddress2Index5,
-        amount: 20,
-        memo: 'tx2',
-        mutez: true
-      },
-      {
-        to: paymentAddress2Index8,
-        amount: 30,
-        memo: 'tx3',
-        mutez: true
-      },
-      {
-        to: paymentAddress3Index0,
-        amount: 40,
-        memo: 'tx4',
-        mutez: true
-      },
-      {
-        to: paymentAddress3Index5,
-        amount: 50,
-        memo: 'tx5',
-        mutez: true
-      },
-      {
-        to: paymentAddress3Index8,
-        amount: 60,
-        memo: 'tx6',
-        mutez: true
-      }
-      ])
+      const tx = await saplingToolkit1.prepareSaplingTransaction([
+        {
+          to: paymentAddress2Index0,
+          amount: 10,
+          memo: 'tx1',
+          mutez: true,
+        },
+        {
+          to: paymentAddress2Index5,
+          amount: 20,
+          memo: 'tx2',
+          mutez: true,
+        },
+        {
+          to: paymentAddress2Index8,
+          amount: 30,
+          memo: 'tx3',
+          mutez: true,
+        },
+        {
+          to: paymentAddress3Index0,
+          amount: 40,
+          memo: 'tx4',
+          mutez: true,
+        },
+        {
+          to: paymentAddress3Index5,
+          amount: 50,
+          memo: 'tx5',
+          mutez: true,
+        },
+        {
+          to: paymentAddress3Index8,
+          amount: 60,
+          memo: 'tx6',
+          mutez: true,
+        },
+      ]);
 
       const op = await saplingContract.methods.default([tx]).send();
       await op.confirmation();
       expect(op.status).toEqual('applied');
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-
     });
 
     it('Verify balances after the sapling transactions', async () => {
@@ -202,127 +227,126 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       expect(balance1).toEqual(new BigNumber(999790));
       expect(inputs1).toEqual({
-        "incoming": [
+        incoming: [
           {
-            "value": new BigNumber("1000000"),
-            "memo": "T1",
-            "paymentAddress": paymentAddress1Index0,
-            "isSpent": true
+            value: new BigNumber('1000000'),
+            memo: 'T1',
+            paymentAddress: paymentAddress1Index0,
+            isSpent: true,
           },
           {
-            "value": new BigNumber("999790"),
-            "memo": "",
-            "paymentAddress": paymentAddress1Index0,
-            "isSpent": false
-          }
+            value: new BigNumber('999790'),
+            memo: '',
+            paymentAddress: paymentAddress1Index0,
+            isSpent: false,
+          },
         ],
-        "outgoing": [
+        outgoing: [
           {
-            "value": new BigNumber("10"),
-            "memo": "tx1",
-            "paymentAddress": paymentAddress2Index0
+            value: new BigNumber('10'),
+            memo: 'tx1',
+            paymentAddress: paymentAddress2Index0,
           },
           {
-            "value": new BigNumber("20"),
-            "memo": "tx2",
-            "paymentAddress": paymentAddress2Index5
+            value: new BigNumber('20'),
+            memo: 'tx2',
+            paymentAddress: paymentAddress2Index5,
           },
           {
-            "value": new BigNumber("30"),
-            "memo": "tx3",
-            "paymentAddress": paymentAddress2Index8
+            value: new BigNumber('30'),
+            memo: 'tx3',
+            paymentAddress: paymentAddress2Index8,
           },
           {
-            "value": new BigNumber("40"),
-            "memo": "tx4",
-            "paymentAddress": paymentAddress3Index0
+            value: new BigNumber('40'),
+            memo: 'tx4',
+            paymentAddress: paymentAddress3Index0,
           },
           {
-            "value": new BigNumber("50"),
-            "memo": "tx5",
-            "paymentAddress": paymentAddress3Index5
+            value: new BigNumber('50'),
+            memo: 'tx5',
+            paymentAddress: paymentAddress3Index5,
           },
           {
-            "value": new BigNumber("60"),
-            "memo": "tx6",
-            "paymentAddress": paymentAddress3Index8
+            value: new BigNumber('60'),
+            memo: 'tx6',
+            paymentAddress: paymentAddress3Index8,
           },
           {
-            "value": new BigNumber("999790"),
-            "memo": "",
-            "paymentAddress": paymentAddress1Index0
-          }
-        ]
-      })
+            value: new BigNumber('999790'),
+            memo: '',
+            paymentAddress: paymentAddress1Index0,
+          },
+        ],
+      });
 
       const balance2 = await txViewer2.getBalance();
       const inputs2 = await txViewer2.getIncomingAndOutgoingTransactions();
 
       expect(balance2).toEqual(new BigNumber(2000060));
       expect(inputs2).toEqual({
-        "incoming": [
+        incoming: [
           {
-            "value": new BigNumber("2000000"),
-            "memo": "T2",
-            "paymentAddress": paymentAddress2Index0,
-            "isSpent": false
+            value: new BigNumber('2000000'),
+            memo: 'T2',
+            paymentAddress: paymentAddress2Index0,
+            isSpent: false,
           },
           {
-            "value": new BigNumber("10"),
-            "memo": "tx1",
-            "paymentAddress": paymentAddress2Index0,
-            "isSpent": false
+            value: new BigNumber('10'),
+            memo: 'tx1',
+            paymentAddress: paymentAddress2Index0,
+            isSpent: false,
           },
           {
-            "value": new BigNumber("20"),
-            "memo": "tx2",
-            "paymentAddress": paymentAddress2Index5,
-            "isSpent": false
+            value: new BigNumber('20'),
+            memo: 'tx2',
+            paymentAddress: paymentAddress2Index5,
+            isSpent: false,
           },
           {
-            "value": new BigNumber("30"),
-            "memo": "tx3",
-            "paymentAddress": paymentAddress2Index8,
-            "isSpent": false
-          }
+            value: new BigNumber('30'),
+            memo: 'tx3',
+            paymentAddress: paymentAddress2Index8,
+            isSpent: false,
+          },
         ],
-        "outgoing": []
-      })
+        outgoing: [],
+      });
 
       const balance3 = await txViewer3.getBalance();
       const inputs3 = await txViewer3.getIncomingAndOutgoingTransactions();
 
       expect(balance3).toEqual(new BigNumber(3000150));
       expect(inputs3).toEqual({
-        "incoming": [
+        incoming: [
           {
-            "value": new BigNumber("3000000"),
-            "memo": "T3",
-            "paymentAddress": paymentAddress3Index0,
-            "isSpent": false
+            value: new BigNumber('3000000'),
+            memo: 'T3',
+            paymentAddress: paymentAddress3Index0,
+            isSpent: false,
           },
           {
-            "value": new BigNumber("40"),
-            "memo": "tx4",
-            "paymentAddress": paymentAddress3Index0,
-            "isSpent": false
+            value: new BigNumber('40'),
+            memo: 'tx4',
+            paymentAddress: paymentAddress3Index0,
+            isSpent: false,
           },
           {
-            "value": new BigNumber("50"),
-            "memo": "tx5",
-            "paymentAddress": paymentAddress3Index5,
-            "isSpent": false
+            value: new BigNumber('50'),
+            memo: 'tx5',
+            paymentAddress: paymentAddress3Index5,
+            isSpent: false,
           },
           {
-            "value": new BigNumber("60"),
-            "memo": "tx6",
-            "paymentAddress": paymentAddress3Index8,
-            "isSpent": false
-          }
+            value: new BigNumber('60'),
+            memo: 'tx6',
+            paymentAddress: paymentAddress3Index8,
+            isSpent: false,
+          },
         ],
-        "outgoing": []
-      })
+        outgoing: [],
+      });
     });
-
   });
 });

--- a/integration-tests/__tests__/sapling/sapling-transactions-contract-with-single-state.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-transactions-contract-with-single-state.spec.ts
@@ -1,116 +1,149 @@
-import { ContractAbstraction, ContractProvider, RpcReadAdapter } from '@taquito/taquito';
+import {
+  ContractAbstraction,
+  ContractProvider,
+  RpcReadAdapter,
+} from '@taquito/taquito';
 import { CONFIGS } from '../../config';
 import { InMemorySpendingKey, SaplingToolkit } from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
   const Tezos = lib;
   let saplingContract: ContractAbstraction<ContractProvider>;
   let bobInmemorySpendingKey: InMemorySpendingKey;
-  let bobPaymentAddress: string
+  let bobPaymentAddress: string;
   let aliceInMemorySpendingKey: InMemorySpendingKey;
   let alicePaymentAddress: string;
   const memoSize = 8;
 
   describe(`Test interaction with sapling contract having a single sapling state using: ${rpc}`, () => {
-
     beforeAll(async () => {
       await setup();
 
       // Deploy the sapling contract
       const saplingContractOrigination = await Tezos.contract.originate({
         code: singleSaplingStateContractJProtocol(),
-        init: '{}'
+        init: '{}',
       });
       await saplingContractOrigination.confirmation();
       saplingContract = await saplingContractOrigination.contract();
 
       // Generate a spending key and an InMemorySpendingKey instance for Bob using a mnemonic
-      const mnemonic: string = bip39.generateMnemonic();
+      const mnemonic: string = bip39.generateMnemonic(wordlist);
       bobInmemorySpendingKey = await InMemorySpendingKey.fromMnemonic(mnemonic);
 
       // Instantiate an InMemorySpendingKey from a spending key for Alice
-      aliceInMemorySpendingKey = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
-
+      aliceInMemorySpendingKey = new InMemorySpendingKey(
+        'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L'
+      );
     });
 
     it('Verify that the initial balance for Alice and Bob are 0 in the sapling contract', async () => {
-
-      const bobSaplingToolkit = new SaplingToolkit({ saplingSigner: bobInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
+      const bobSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: bobInmemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const bobTxViewer = await bobSaplingToolkit.getSaplingTransactionViewer();
       const bobInitialBalance = await bobTxViewer.getBalance();
 
       expect(bobInitialBalance).toEqual(new BigNumber(0));
 
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceInitialBalance = await aliceTxViewer.getBalance();
 
       expect(aliceInitialBalance).toEqual(new BigNumber(0));
-
     });
 
     it('Verify that Alice can shield tokens', async () => {
-
       const amountToAlice = 3;
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
-      const aliceInMemoryViewingKey = await aliceInMemorySpendingKey.getSaplingViewingKeyProvider();
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
+      const aliceInMemoryViewingKey =
+        await aliceInMemorySpendingKey.getSaplingViewingKeyProvider();
       // Fetch a payment address (zet) for Alice
-      alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress()).address;
+      alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress())
+        .address;
 
-      const shieldedTx = await aliceSaplingToolkit.prepareShieldedTransaction([{
-        to: alicePaymentAddress,
-        amount: amountToAlice,
-        memo: 'First Tx'
-      }])
+      const shieldedTx = await aliceSaplingToolkit.prepareShieldedTransaction([
+        {
+          to: alicePaymentAddress,
+          amount: amountToAlice,
+          memo: 'First Tx',
+        },
+      ]);
 
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       // The amount MUST be specified in the send method in order to transfer the 3 tez to the shielded pool
-      const op = await saplingContract.methods.default([shieldedTx]).send({ amount: amountToAlice });
+      const op = await saplingContract.methods
+        .default([shieldedTx])
+        .send({ amount: amountToAlice });
       await op.confirmation();
 
       expect(op.status).toEqual('applied');
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the shielded tx", async () => {
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
       // The returned balance is in MUTEZ
       expect(aliceBalance).toEqual(new BigNumber(3000000));
 
-      const inputsAlice = await aliceTxViewer.getIncomingAndOutgoingTransactions();
+      const inputsAlice =
+        await aliceTxViewer.getIncomingAndOutgoingTransactions();
       expect(inputsAlice).toEqual({
         incoming: [
           {
             value: new BigNumber(3000000),
             memo: 'First Tx',
             paymentAddress: alicePaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
     });
 
     it('Verify that Alice can do a shielded transaction to Bob', async () => {
       const amountToBob = 2;
       // Bob needs to give a payment address (zet) to Alice
-      const bobInMemoryViewingKey = await bobInmemorySpendingKey.getSaplingViewingKeyProvider();
+      const bobInMemoryViewingKey =
+        await bobInmemorySpendingKey.getSaplingViewingKeyProvider();
       bobPaymentAddress = (await bobInMemoryViewingKey.getAddress()).address;
 
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
-      const tx = await aliceSaplingToolkit.prepareSaplingTransaction([{
-        to: bobPaymentAddress,
-        amount: amountToBob,
-        memo: 'A gift'
-      }])
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
+      const tx = await aliceSaplingToolkit.prepareSaplingTransaction([
+        {
+          to: bobPaymentAddress,
+          amount: amountToBob,
+          memo: 'A gift',
+        },
+      ]);
 
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([tx]).send();
@@ -119,49 +152,60 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
       expect(op.status).toEqual('applied');
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the sapling tx", async () => {
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
       // The returned balance is in MUTEZ
       expect(aliceBalance).toEqual(new BigNumber(1000000));
 
-      const inputsAlice = await aliceTxViewer.getIncomingAndOutgoingTransactions();
+      const inputsAlice =
+        await aliceTxViewer.getIncomingAndOutgoingTransactions();
       expect(inputsAlice).toEqual({
         incoming: [
           {
             value: new BigNumber(3000000),
             memo: 'First Tx',
             paymentAddress: alicePaymentAddress,
-            isSpent: true
+            isSpent: true,
           },
-          { // This input is a payback for when Alice sent 2 tz to bob (3tz - 2tz = 1tz).
+          {
+            // This input is a payback for when Alice sent 2 tz to bob (3tz - 2tz = 1tz).
             // Alice consumed the 3tz input and received 1tz back.
             value: new BigNumber(1000000),
             memo: '',
             paymentAddress: alicePaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
         outgoing: [
           {
             value: new BigNumber(2000000),
             memo: 'A gift',
-            paymentAddress: bobPaymentAddress
+            paymentAddress: bobPaymentAddress,
           },
-          { // Here Alice sent 1tz back to her (matching the payback input above).
+          {
+            // Here Alice sent 1tz back to her (matching the payback input above).
             value: new BigNumber(1000000),
             memo: '',
-            paymentAddress: alicePaymentAddress
-          }
-        ]
-      })
+            paymentAddress: alicePaymentAddress,
+          },
+        ],
+      });
 
-      const bobSaplingToolkit = new SaplingToolkit({ saplingSigner: bobInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
+      const bobSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: bobInmemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const bobTxViewer = await bobSaplingToolkit.getSaplingTransactionViewer();
       const bobBalance = await bobTxViewer.getBalance();
 
@@ -175,27 +219,34 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
             value: new BigNumber(2000000),
             memo: 'A gift',
             paymentAddress: bobPaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
     });
 
     it('Verify that Alice can unshield tokens', async () => {
-
       const newAddress = await createAddress();
-      const opToFundNewAddress = await Tezos.contract.transfer({ to: await newAddress.signer.publicKeyHash(), amount: 2 });
+      const opToFundNewAddress = await Tezos.contract.transfer({
+        to: await newAddress.signer.publicKeyHash(),
+        amount: 2,
+      });
       await opToFundNewAddress.confirmation();
       const tezosAddress1 = await newAddress.signer.publicKeyHash();
 
       const amount = 1;
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const tezosInitialBalance = await Tezos.tz.getBalance(tezosAddress1);
-      const unshieldedTx = await aliceSaplingToolkit.prepareUnshieldedTransaction({
-        to: tezosAddress1,
-        amount
-      })
+      const unshieldedTx =
+        await aliceSaplingToolkit.prepareUnshieldedTransaction({
+          to: tezosAddress1,
+          amount,
+        });
 
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([unshieldedTx]).send();
@@ -206,59 +257,64 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       const tezosUpdatedBalance = await Tezos.tz.getBalance(tezosAddress1);
-      expect(tezosUpdatedBalance).toEqual(tezosInitialBalance.plus(new BigNumber(1000000)));
-
+      expect(tezosUpdatedBalance).toEqual(
+        tezosInitialBalance.plus(new BigNumber(1000000))
+      );
     });
 
     it("Verify that Alice's balance in the sapling pool is updated after the unshielded tx", async () => {
-      const aliceSaplingToolkit = new SaplingToolkit({ saplingSigner: aliceInMemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: aliceInMemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
       expect(aliceBalance).toEqual(new BigNumber(0));
 
-      const inputsAlice = await aliceTxViewer.getIncomingAndOutgoingTransactions();
+      const inputsAlice =
+        await aliceTxViewer.getIncomingAndOutgoingTransactions();
       expect(inputsAlice).toEqual({
         incoming: [
           {
             value: new BigNumber(3000000),
             memo: 'First Tx',
             paymentAddress: alicePaymentAddress,
-            isSpent: true
+            isSpent: true,
           },
           {
             value: new BigNumber(1000000),
             memo: '',
             paymentAddress: alicePaymentAddress,
-            isSpent: true
+            isSpent: true,
           },
           {
             value: new BigNumber(0),
             memo: '',
             paymentAddress: alicePaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
         outgoing: [
           {
             value: new BigNumber(2000000),
             memo: 'A gift',
-            paymentAddress: bobPaymentAddress
+            paymentAddress: bobPaymentAddress,
           },
           {
             value: new BigNumber(1000000),
             memo: '',
-            paymentAddress: alicePaymentAddress
+            paymentAddress: alicePaymentAddress,
           },
           {
             value: new BigNumber(0),
             memo: '',
-            paymentAddress: alicePaymentAddress
-          }
-        ]
-      })
-
+            paymentAddress: alicePaymentAddress,
+          },
+        ],
+      });
     });
-
   });
 });

--- a/integration-tests/__tests__/sapling/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-transactions-proof-using-proving-key.spec.ts
@@ -1,15 +1,24 @@
-import { ContractAbstraction, ContractProvider, RpcReadAdapter } from '@taquito/taquito';
+import {
+  ContractAbstraction,
+  ContractProvider,
+  RpcReadAdapter,
+} from '@taquito/taquito';
 import { CONFIGS } from '../../config';
-import { InMemorySpendingKey, SaplingToolkit, InMemoryProvingKey } from '@taquito/sapling';
+import {
+  InMemorySpendingKey,
+  SaplingToolkit,
+  InMemoryProvingKey,
+} from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
   let saplingContract: ContractAbstraction<ContractProvider>;
   let bobInmemorySpendingKey: InMemorySpendingKey;
-  let bobPaymentAddress: string
+  let bobPaymentAddress: string;
   let aliceInMemorySpendingKey: InMemorySpendingKey;
   let aliceInMemoryProvingKey: InMemoryProvingKey;
   let alicePaymentAddress: string;
@@ -17,99 +26,119 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
   const memoSize = 8;
 
   describe(`Test producing proofs with a proving key rather than a spending key: ${rpc}`, () => {
-
     beforeAll(async () => {
       await setup();
 
       // Deploy the sapling contract
       const saplingContractOrigination = await Tezos.contract.originate({
         code: singleSaplingStateContractJProtocol(),
-        init: '{}'
+        init: '{}',
       });
       await saplingContractOrigination.confirmation();
       saplingContract = await saplingContractOrigination.contract();
 
       // Generate a spending key and an InMemorySpendingKey instance for Bob using a mnemonic
-      const mnemonic: string = bip39.generateMnemonic();
+      const mnemonic: string = bip39.generateMnemonic(wordlist);
       bobInmemorySpendingKey = await InMemorySpendingKey.fromMnemonic(mnemonic);
 
       // Instantiate an InMemorySpendingKey from a spending key for Alice
-      aliceInMemorySpendingKey = new InMemorySpendingKey('sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L')
-      aliceInMemoryProvingKey = new InMemoryProvingKey('44259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed962717403f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb709');
-
+      aliceInMemorySpendingKey = new InMemorySpendingKey(
+        'sask27SLmU9herddHz4qFJBLMjWYMbJF8RtS579w9ej9mfCYK7VUdyCJPHK8AzW9zMsopGZEkYeNjAY7Zz1bkM7CGu8eKLzrjBLTMC5wWJDhxiK91ahA29rhDRsHdJDV2u2jFwb2MNUix8JW7sAkAqYVaJpCehTBPgRQ1KqKwqqUaNmuD8kazd4Q8MCWmgbWs21Yuomdqyi9FLigjRp7oY4m5adaVU19Nj1AHvsMY2tePeU2L'
+      );
+      aliceInMemoryProvingKey = new InMemoryProvingKey(
+        '44259fd700dc80120d3c9ca65d698f6064043b048b079caa4f198aed962717403f80bf8cb9a8da8deb290913e9302be00c56f4565d917a6170be1880f42bb709'
+      );
     });
 
     it('Verify that Alice can shield tokens', async () => {
-
       const amountToAlice = 3;
       const aliceSaplingToolkit = new SaplingToolkit(
-        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey },
+        {
+          saplingSigner: aliceInMemorySpendingKey,
+          saplingProver: aliceInMemoryProvingKey,
+        },
         { contractAddress: saplingContract.address, memoSize },
         new RpcReadAdapter(Tezos.rpc)
       );
-      const aliceInMemoryViewingKey = await aliceInMemorySpendingKey.getSaplingViewingKeyProvider();
+      const aliceInMemoryViewingKey =
+        await aliceInMemorySpendingKey.getSaplingViewingKeyProvider();
       // Fetch a payment address (zet) for Alice
-      alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress()).address;
+      alicePaymentAddress = (await aliceInMemoryViewingKey.getAddress())
+        .address;
 
-      const shieldedTx = await aliceSaplingToolkit.prepareShieldedTransaction([{
-        to: alicePaymentAddress,
-        amount: amountToAlice,
-        memo: 'First Tx'
-      }])
+      const shieldedTx = await aliceSaplingToolkit.prepareShieldedTransaction([
+        {
+          to: alicePaymentAddress,
+          amount: amountToAlice,
+          memo: 'First Tx',
+        },
+      ]);
 
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       // The amount MUST be specified in the send method in order to transfer the 3 tez to the shielded pool
-      const op = await saplingContract.methods.default([shieldedTx]).send({ amount: amountToAlice });
+      const op = await saplingContract.methods
+        .default([shieldedTx])
+        .send({ amount: amountToAlice });
       await op.confirmation();
 
       expect(op.status).toEqual('applied');
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the shielded tx", async () => {
       const aliceSaplingToolkit = new SaplingToolkit(
-        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey },
+        {
+          saplingSigner: aliceInMemorySpendingKey,
+          saplingProver: aliceInMemoryProvingKey,
+        },
         { contractAddress: saplingContract.address, memoSize },
         new RpcReadAdapter(Tezos.rpc)
       );
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
       // The returned balance is in MUTEZ
       expect(aliceBalance).toEqual(new BigNumber(3000000));
 
-      const inputsAlice = await aliceTxViewer.getIncomingAndOutgoingTransactions();
+      const inputsAlice =
+        await aliceTxViewer.getIncomingAndOutgoingTransactions();
       expect(inputsAlice).toEqual({
         incoming: [
           {
             value: new BigNumber(3000000),
             memo: 'First Tx',
             paymentAddress: alicePaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
     });
 
     it('Verify that Alice can do a shielded transaction to Bob', async () => {
       const amountToBob = 2;
       // Bob needs to give a payment address (zet) to Alice
-      const bobInMemoryViewingKey = await bobInmemorySpendingKey.getSaplingViewingKeyProvider();
+      const bobInMemoryViewingKey =
+        await bobInmemorySpendingKey.getSaplingViewingKeyProvider();
       bobPaymentAddress = (await bobInMemoryViewingKey.getAddress()).address;
 
       const aliceSaplingToolkit = new SaplingToolkit(
-        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey },
+        {
+          saplingSigner: aliceInMemorySpendingKey,
+          saplingProver: aliceInMemoryProvingKey,
+        },
         { contractAddress: saplingContract.address, memoSize },
         new RpcReadAdapter(Tezos.rpc)
       );
-      const tx = await aliceSaplingToolkit.prepareSaplingTransaction([{
-        to: bobPaymentAddress,
-        amount: amountToBob,
-        memo: 'A gift'
-      }])
+      const tx = await aliceSaplingToolkit.prepareSaplingTransaction([
+        {
+          to: bobPaymentAddress,
+          amount: amountToBob,
+          memo: 'A gift',
+        },
+      ]);
 
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([tx]).send();
@@ -118,53 +147,63 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       expect(op.status).toEqual('applied');
       expect(op.hash).toBeDefined();
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the sapling tx", async () => {
       const aliceSaplingToolkit = new SaplingToolkit(
-        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey },
+        {
+          saplingSigner: aliceInMemorySpendingKey,
+          saplingProver: aliceInMemoryProvingKey,
+        },
         { contractAddress: saplingContract.address, memoSize },
         new RpcReadAdapter(Tezos.rpc)
       );
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
       // The returned balance is in MUTEZ
       expect(aliceBalance).toEqual(new BigNumber(1000000));
 
-      const inputsAlice = await aliceTxViewer.getIncomingAndOutgoingTransactions();
+      const inputsAlice =
+        await aliceTxViewer.getIncomingAndOutgoingTransactions();
       expect(inputsAlice).toEqual({
         incoming: [
           {
             value: new BigNumber(3000000),
             memo: 'First Tx',
             paymentAddress: alicePaymentAddress,
-            isSpent: true
+            isSpent: true,
           },
-          { // This input is a payback for when Alice sent 2 tz to bob (3tz - 2tz = 1tz).
+          {
+            // This input is a payback for when Alice sent 2 tz to bob (3tz - 2tz = 1tz).
             // Alice consumed the 3tz input and received 1tz back.
             value: new BigNumber(1000000),
             memo: '',
             paymentAddress: alicePaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
         outgoing: [
           {
             value: new BigNumber(2000000),
             memo: 'A gift',
-            paymentAddress: bobPaymentAddress
+            paymentAddress: bobPaymentAddress,
           },
-          { // Here Alice sent 1tz back to her (matching the payback input above).
+          {
+            // Here Alice sent 1tz back to her (matching the payback input above).
             value: new BigNumber(1000000),
             memo: '',
-            paymentAddress: alicePaymentAddress
-          }
-        ]
-      })
+            paymentAddress: alicePaymentAddress,
+          },
+        ],
+      });
 
-      const bobSaplingToolkit = new SaplingToolkit({ saplingSigner: bobInmemorySpendingKey }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc))
+      const bobSaplingToolkit = new SaplingToolkit(
+        { saplingSigner: bobInmemorySpendingKey },
+        { contractAddress: saplingContract.address, memoSize },
+        new RpcReadAdapter(Tezos.rpc)
+      );
       const bobTxViewer = await bobSaplingToolkit.getSaplingTransactionViewer();
       const bobBalance = await bobTxViewer.getBalance();
 
@@ -178,27 +217,30 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
             value: new BigNumber(2000000),
             memo: 'A gift',
             paymentAddress: bobPaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
-        outgoing: []
-      })
+        outgoing: [],
+      });
     });
 
     it('Verify that Alice can unshield tokens', async () => {
-
       const amount = 1;
       const aliceSaplingToolkit = new SaplingToolkit(
-        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey },
+        {
+          saplingSigner: aliceInMemorySpendingKey,
+          saplingProver: aliceInMemoryProvingKey,
+        },
         { contractAddress: saplingContract.address, memoSize },
         new RpcReadAdapter(Tezos.rpc)
       );
       const tezosInitialBalance = await Tezos.tz.getBalance(tezosAddress);
 
-      const unshieldedTx = await aliceSaplingToolkit.prepareUnshieldedTransaction({
-        to: tezosAddress,
-        amount
-      })
+      const unshieldedTx =
+        await aliceSaplingToolkit.prepareUnshieldedTransaction({
+          to: tezosAddress,
+          amount,
+        });
 
       // Inject the sapling transaction using the ContractAbstraction by calling the default entrypoint
       const op = await saplingContract.methods.default([unshieldedTx]).send();
@@ -209,63 +251,67 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
       const tezosUpdatedBalance = await Tezos.tz.getBalance(tezosAddress);
-      expect(tezosUpdatedBalance).toEqual(tezosInitialBalance.plus(new BigNumber(1000000)));
-
+      expect(tezosUpdatedBalance).toEqual(
+        tezosInitialBalance.plus(new BigNumber(1000000))
+      );
     });
 
     it("Verify that Alice's balance in the sapling pool updated after the unshielded tx", async () => {
       const aliceSaplingToolkit = new SaplingToolkit(
-        { saplingSigner: aliceInMemorySpendingKey, saplingProver: aliceInMemoryProvingKey },
+        {
+          saplingSigner: aliceInMemorySpendingKey,
+          saplingProver: aliceInMemoryProvingKey,
+        },
         { contractAddress: saplingContract.address, memoSize },
         new RpcReadAdapter(Tezos.rpc)
       );
-      const aliceTxViewer = await aliceSaplingToolkit.getSaplingTransactionViewer();
+      const aliceTxViewer =
+        await aliceSaplingToolkit.getSaplingTransactionViewer();
       const aliceBalance = await aliceTxViewer.getBalance();
 
       expect(aliceBalance).toEqual(new BigNumber(0));
 
-      const inputsAlice = await aliceTxViewer.getIncomingAndOutgoingTransactions();
+      const inputsAlice =
+        await aliceTxViewer.getIncomingAndOutgoingTransactions();
       expect(inputsAlice).toEqual({
         incoming: [
           {
             value: new BigNumber(3000000),
             memo: 'First Tx',
             paymentAddress: alicePaymentAddress,
-            isSpent: true
+            isSpent: true,
           },
           {
             value: new BigNumber(1000000),
             memo: '',
             paymentAddress: alicePaymentAddress,
-            isSpent: true
+            isSpent: true,
           },
           {
             value: new BigNumber(0),
             memo: '',
             paymentAddress: alicePaymentAddress,
-            isSpent: false
-          }
+            isSpent: false,
+          },
         ],
         outgoing: [
           {
             value: new BigNumber(2000000),
             memo: 'A gift',
-            paymentAddress: bobPaymentAddress
+            paymentAddress: bobPaymentAddress,
           },
           {
             value: new BigNumber(1000000),
             memo: '',
-            paymentAddress: alicePaymentAddress
+            paymentAddress: alicePaymentAddress,
           },
           {
             value: new BigNumber(0),
             memo: '',
-            paymentAddress: alicePaymentAddress
-          }
-        ]
-      })
-
+            paymentAddress: alicePaymentAddress,
+          },
+        ],
+      });
     });
-
   });
 });

--- a/integration-tests/__tests__/signer-mnemonic.spec.ts
+++ b/integration-tests/__tests__/signer-mnemonic.spec.ts
@@ -1,20 +1,19 @@
 import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 import { CONFIGS } from '../config';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   let Funder: TezosToolkit;
   describe(`Create signer instances with fromMnemonic: ${rpc}`, () => {
     let mnemonic: string;
-    let Tez1: TezosToolkit,
-      Tez2: TezosToolkit,
-      Tez3: TezosToolkit;
+    let Tez1: TezosToolkit, Tez2: TezosToolkit, Tez3: TezosToolkit;
 
     let funderPKH: string;
 
     beforeAll(async () => {
-      mnemonic = Bip39.generateMnemonic();
+      mnemonic = bip39.generateMnemonic(wordlist);
       Funder = lib;
       await setup();
 
@@ -30,28 +29,44 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
         Tez1.setSignerProvider(signer1);
         const tez1Pkh = await Tez1.signer.publicKeyHash();
 
-
         Tez2 = new TezosToolkit(rpc);
-        const signer2 = InMemorySigner.fromMnemonic({ mnemonic, curve: 'secp256k1' });
+        const signer2 = InMemorySigner.fromMnemonic({
+          mnemonic,
+          curve: 'secp256k1',
+        });
         Tez2.setSignerProvider(signer2);
         const tez2Pkh = await Tez2.signer.publicKeyHash();
 
         Tez3 = new TezosToolkit(rpc);
-        const signer3 = InMemorySigner.fromMnemonic({ mnemonic, curve: 'p256' });
+        const signer3 = InMemorySigner.fromMnemonic({
+          mnemonic,
+          curve: 'p256',
+        });
         Tez3.setSignerProvider(signer3);
         const tez3Pkh = await Tez3.signer.publicKeyHash();
 
         // Fund all the signer accounts
-        const send1 = await Funder.contract.transfer({ to: tez1Pkh, amount: 2 });
+        const send1 = await Funder.contract.transfer({
+          to: tez1Pkh,
+          amount: 2,
+        });
         await send1.confirmation();
 
-        const send2 = await Funder.contract.transfer({ to: tez2Pkh, amount: 2 });
+        const send2 = await Funder.contract.transfer({
+          to: tez2Pkh,
+          amount: 2,
+        });
         await send2.confirmation();
 
-        const send3 = await Funder.contract.transfer({ to: tez3Pkh, amount: 2 });
+        const send3 = await Funder.contract.transfer({
+          to: tez3Pkh,
+          amount: 2,
+        });
         await send3.confirmation();
       } catch (e) {
-        console.log(`Error when trying to fund account: \n ${JSON.stringify(e)}`)
+        console.log(
+          `Error when trying to fund account: \n ${JSON.stringify(e)}`
+        );
       }
     });
 

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -18,6 +18,7 @@
     "@ledgerhq/hw-transport": "6.31.4",
     "@ledgerhq/hw-transport-node-hid": "6.29.5",
     "@ledgerhq/hw-transport-node-hid-noevents": "6.30.5",
+    "@scure/bip39": "^1.5.4",
     "@taquito/contracts-library": "^21.0.2",
     "@taquito/core": "^21.0.2",
     "@taquito/http-utils": "^21.0.2",
@@ -33,7 +34,6 @@
     "@taquito/tzip16": "^21.0.2",
     "@taquito/utils": "^21.0.2",
     "bignumber.js": "^9.1.2",
-    "bip39": "3.1.0",
     "blakejs": "^1.2.1"
   },
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -138,6 +138,7 @@
         "@ledgerhq/hw-transport": "6.31.4",
         "@ledgerhq/hw-transport-node-hid": "6.29.5",
         "@ledgerhq/hw-transport-node-hid-noevents": "6.30.5",
+        "@scure/bip39": "^1.5.4",
         "@taquito/contracts-library": "^21.0.2",
         "@taquito/core": "^21.0.2",
         "@taquito/http-utils": "^21.0.2",
@@ -153,7 +154,6 @@
         "@taquito/tzip16": "^21.0.2",
         "@taquito/utils": "^21.0.2",
         "bignumber.js": "^9.1.2",
-        "bip39": "3.1.0",
         "blakejs": "^1.2.1"
       },
       "devDependencies": {
@@ -5244,12 +5244,11 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -7093,6 +7092,26 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.4.tgz",
+      "integrity": "sha512-5Yy9czTO47mqz+/J8GM6GIId4umdCk1wc1q8rKERQulIoc8VP9pzDcghv10Tl2E7R96ZUx/PhND3ESYUQX8NuQ==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.4.tgz",
+      "integrity": "sha512-TFM4ni0vKvCfBpohoh+/lY05i9gRbSwXWngAsF4CABQxoaOHijxuaZ2R6cStDQ5CHtHO9aGJTr4ksVJASRRyMA==",
+      "dependencies": {
+        "@noble/hashes": "~1.7.1",
+        "@scure/base": "~1.2.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@shikijs/core": {
       "version": "1.12.0",
@@ -10049,15 +10068,6 @@
       "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/bl": {
@@ -28989,6 +28999,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@airgap/sapling-wasm": "0.0.9",
+        "@scure/bip39": "^1.5.4",
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/random": "^1.0.2",
         "@taquito/core": "^21.0.2",
@@ -28996,7 +29007,6 @@
         "@taquito/taquito": "^21.0.2",
         "@taquito/utils": "^21.0.2",
         "bignumber.js": "^9.1.2",
-        "bip39": "3.1.0",
         "blakejs": "^1.2.1",
         "node-fetch": "^2.7.0",
         "pbkdf2": "^3.1.2",
@@ -29058,6 +29068,7 @@
       "version": "21.0.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@scure/bip39": "^1.5.4",
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
         "@stablelib/hmac": "^1.0.1",
@@ -29068,7 +29079,6 @@
         "@taquito/taquito": "^21.0.2",
         "@taquito/utils": "^21.0.2",
         "@types/bn.js": "^5.1.5",
-        "bip39": "3.1.0",
         "elliptic": "^6.6.0",
         "pbkdf2": "^3.1.2",
         "typedarray-to-buffer": "^4.0.0"

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@airgap/sapling-wasm": "0.0.9",
+    "@scure/bip39": "^1.5.4",
     "@stablelib/nacl": "^1.0.4",
     "@stablelib/random": "^1.0.2",
     "@taquito/core": "^21.0.2",
@@ -73,7 +74,6 @@
     "@taquito/taquito": "^21.0.2",
     "@taquito/utils": "^21.0.2",
     "bignumber.js": "^9.1.2",
-    "bip39": "3.1.0",
     "blakejs": "^1.2.1",
     "node-fetch": "^2.7.0",
     "pbkdf2": "^3.1.2",

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -66,6 +66,7 @@
     ]
   },
   "dependencies": {
+    "@scure/bip39": "^1.5.4",
     "@stablelib/blake2b": "^1.0.1",
     "@stablelib/ed25519": "^1.0.3",
     "@stablelib/hmac": "^1.0.1",
@@ -76,7 +77,6 @@
     "@taquito/taquito": "^21.0.2",
     "@taquito/utils": "^21.0.2",
     "@types/bn.js": "^5.1.5",
-    "bip39": "3.1.0",
     "elliptic": "^6.6.0",
     "pbkdf2": "^3.1.2",
     "typedarray-to-buffer": "^4.0.0"

--- a/packages/taquito-signer/signature.json
+++ b/packages/taquito-signer/signature.json
@@ -113,18 +113,11 @@
           "name": "@taquito/signer",
           "version": "8.0.4-beta.0",
           "description": "Provide signing functionality to be with taquito",
-          "keywords": [
-            "tezos",
-            "blockchain",
-            "signer"
-          ],
+          "keywords": ["tezos", "blockchain", "signer"],
           "main": "dist/taquito-signer.umd.js",
           "module": "dist/taquito-signer.es5.js",
           "typings": "dist/types/taquito-signer.d.ts",
-          "files": [
-            "dist",
-            "signature.json"
-          ],
+          "files": ["dist", "signature.json"],
           "publishConfig": {
             "access": "public"
           },
@@ -148,10 +141,7 @@
             "start": "rollup -c rollup.config.ts -w"
           },
           "lint-staged": {
-            "{src,test}/**/*.ts": [
-              "prettier --write",
-              "tslint --fix"
-            ]
+            "{src,test}/**/*.ts": ["prettier --write", "tslint --fix"]
           },
           "jest": {
             "transform": {
@@ -159,27 +149,18 @@
             },
             "testEnvironment": "node",
             "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
-            "moduleFileExtensions": [
-              "ts",
-              "tsx",
-              "js"
-            ],
+            "moduleFileExtensions": ["ts", "tsx", "js"],
             "moduleNameMapper": {
               "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts"
             },
-            "coveragePathIgnorePatterns": [
-              "/node_modules/",
-              "/test/"
-            ],
-            "collectCoverageFrom": [
-              "src/**/*.{js,ts}"
-            ]
+            "coveragePathIgnorePatterns": ["/node_modules/", "/test/"],
+            "collectCoverageFrom": ["src/**/*.{js,ts}"]
           },
           "dependencies": {
+            "@scure/bip39": "^1.5.4",
             "@taquito/taquito": "^8.0.4-beta.0",
             "@taquito/utils": "^8.0.4-beta.0",
             "bignumber.js": "^9.0.1",
-            "bip39": "^3.0.2",
             "elliptic": "^6.5.3",
             "libsodium-wrappers": "^0.7.8",
             "pbkdf2": "^3.1.1",

--- a/packages/taquito-signer/src/taquito-signer.ts
+++ b/packages/taquito-signer/src/taquito-signer.ts
@@ -17,7 +17,8 @@ import toBuffer from 'typedarray-to-buffer';
 import { Tz1 } from './ed-key';
 import { Tz2, ECKey, Tz3 } from './ec-key';
 import pbkdf2 from 'pbkdf2';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import { Curves, generateSecretKey } from './helpers';
 import { InvalidMnemonicError, InvalidPassphraseError } from './errors';
 import { InvalidKeyError } from '@taquito/core';
@@ -45,10 +46,10 @@ export class InMemorySigner {
   private _key!: Tz1 | ECKey;
 
   static fromFundraiser(email: string, password: string, mnemonic: string) {
-    if (!Bip39.validateMnemonic(mnemonic)) {
+    if (!bip39.validateMnemonic(mnemonic, wordlist)) {
       throw new InvalidMnemonicError(mnemonic);
     }
-    const seed = Bip39.mnemonicToSeedSync(mnemonic, `${email}${password}`);
+    const seed = bip39.mnemonicToSeedSync(mnemonic, `${email}${password}`);
     const key = b58cencode(seed.slice(0, 32), prefix.edsk2);
     return new InMemorySigner(key);
   }
@@ -74,11 +75,11 @@ export class InMemorySigner {
     curve = 'ed25519',
   }: FromMnemonicParams) {
     // check if curve is defined if not default tz1
-    if (!Bip39.validateMnemonic(mnemonic)) {
+    if (!bip39.validateMnemonic(mnemonic, wordlist)) {
       // avoiding exposing mnemonic again in case of mistake making invalid
       throw new InvalidMnemonicError(mnemonic);
     }
-    const seed = Bip39.mnemonicToSeedSync(mnemonic, password);
+    const seed = bip39.mnemonicToSeedSync(mnemonic, password);
 
     const sk = generateSecretKey(seed, derivationPath, curve);
 
@@ -98,13 +99,21 @@ export class InMemorySigner {
 
     if (encrypted) {
       if (!passphrase) {
-        throw new InvalidPassphraseError('No passphrase provided to decrypt encrypted key');
+        throw new InvalidPassphraseError(
+          'No passphrase provided to decrypt encrypted key'
+        );
       }
 
       decrypt = (constructedKey: Uint8Array) => {
         const salt = toBuffer(constructedKey.slice(0, 8));
         const encryptedSk = constructedKey.slice(8);
-        const encryptionKey = pbkdf2.pbkdf2Sync(passphrase, salt, 32768, 32, 'sha512');
+        const encryptionKey = pbkdf2.pbkdf2Sync(
+          passphrase,
+          salt,
+          32768,
+          32,
+          'sha512'
+        );
 
         return openSecretBox(
           new Uint8Array(encryptionKey),

--- a/packages/taquito-signer/test/ecdsa.spec.ts
+++ b/packages/taquito-signer/test/ecdsa.spec.ts
@@ -1,5 +1,5 @@
 import { ECDSA, Hard } from '../src/derivation-tools';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
 
 interface TestKeyData {
   path: number[];
@@ -27,32 +27,38 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [],
-            chain: '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
+            chain:
+              '873dff81c02f525623fd1fe5167eac3a55a049de3d314bb42ee227ffed37d508',
             priv: 'e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35',
           },
           {
             path: [0 | Hard],
-            chain: '47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141',
+            chain:
+              '47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141',
             priv: 'edb2e14f9ee77d26dd93b4ecede8d16ed408ce149b6cd80b0715a2d911a0afea',
           },
           {
             path: [0 | Hard, 1],
-            chain: '2a7857631386ba23dacac34180dd1983734e444fdbf774041578e9b6adb37c19',
+            chain:
+              '2a7857631386ba23dacac34180dd1983734e444fdbf774041578e9b6adb37c19',
             priv: '3c6cb8d0f6a264c91ea8b5030fadaa8e538b020f0a387421a12de9319dc93368',
           },
           {
             path: [0 | Hard, 1, 2 | Hard],
-            chain: '04466b9cc8e161e966409ca52986c584f07e9dc81f735db683c3ff6ec7b1503f',
+            chain:
+              '04466b9cc8e161e966409ca52986c584f07e9dc81f735db683c3ff6ec7b1503f',
             priv: 'cbce0d719ecf7431d88e6a89fa1483e02e35092af60c042b1df2ff59fa424dca',
           },
           {
             path: [0 | Hard, 1, 2 | Hard, 2],
-            chain: 'cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd',
+            chain:
+              'cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd',
             priv: '0f479245fb19a38a1954c5c7c0ebab2f9bdfd96a17563ef28a6a4b1a2a764ef4',
           },
           {
             path: [0 | Hard, 1, 2 | Hard, 2, 1000000000],
-            chain: 'c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e',
+            chain:
+              'c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e',
             priv: '471b76e389e528d6de6d816857e012c5455051cad6660850e58372a6c3e6e7c8',
           },
         ],
@@ -62,32 +68,38 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [],
-            chain: '60499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd9689',
+            chain:
+              '60499f801b896d83179a4374aeb7822aaeaceaa0db1f85ee3e904c4defbd9689',
             priv: '4b03d6fc340455b363f51020ad3ecca4f0850280cf436c70c727923f6db46c3e',
           },
           {
             path: [0],
-            chain: 'f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c',
+            chain:
+              'f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c',
             priv: 'abe74a98f6c7eabee0428f53798f0ab8aa1bd37873999041703c742f15ac7e1e',
           },
           {
             path: [0, 2147483647 | Hard],
-            chain: 'be17a268474a6bb9c61e1d720cf6215e2a88c5406c4aee7b38547f585c9a37d9',
+            chain:
+              'be17a268474a6bb9c61e1d720cf6215e2a88c5406c4aee7b38547f585c9a37d9',
             priv: '877c779ad9687164e9c2f4f0f4ff0340814392330693ce95a58fe18fd52e6e93',
           },
           {
             path: [0, 2147483647 | Hard, 1],
-            chain: 'f366f48f1ea9f2d1d3fe958c95ca84ea18e4c4ddb9366c336c927eb246fb38cb',
+            chain:
+              'f366f48f1ea9f2d1d3fe958c95ca84ea18e4c4ddb9366c336c927eb246fb38cb',
             priv: '704addf544a06e5ee4bea37098463c23613da32020d604506da8c0518e1da4b7',
           },
           {
             path: [0, 2147483647 | Hard, 1, 2147483646 | Hard],
-            chain: '637807030d55d01f9a0cb3a7839515d796bd07706386a6eddf06cc29a65a0e29',
+            chain:
+              '637807030d55d01f9a0cb3a7839515d796bd07706386a6eddf06cc29a65a0e29',
             priv: 'f1c7c871a54a804afe328b4c83a1c33b8e5ff48f5087273f04efa83b247d6a2d',
           },
           {
             path: [0, 2147483647 | Hard, 1, 2147483646 | Hard, 2],
-            chain: '9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271',
+            chain:
+              '9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271',
             priv: 'bb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23',
           },
         ],
@@ -108,17 +120,20 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [738197632, 335544448 | Hard, 0, 0],
-            chain: '0524d4d89a04e06f0410003751306bbe7a1c4e80608433d12469fe6a92eecb43',
+            chain:
+              '0524d4d89a04e06f0410003751306bbe7a1c4e80608433d12469fe6a92eecb43',
             priv: 'f7dd8c0fb5023c6fce668c035560a40914abea017d83b792b15563d6feb1251b',
           },
           {
             path: [738197504, 335544320 | Hard, 16777216, 33554432],
-            chain: '336717d2389fd2886088c3dff5ceb66ef6064ad90e0a0d07a867064d1c074864',
+            chain:
+              '336717d2389fd2886088c3dff5ceb66ef6064ad90e0a0d07a867064d1c074864',
             priv: '32cc0b6f100f76d724738926fd406f9b476770ba970c369318943562e70011e6',
           },
           {
             path: [44 | Hard, 148 | Hard, 0, 0],
-            chain: '8fff97b457b717b0cad899d2818b5d43165f350f31c5d5598cc71bbde707d604',
+            chain:
+              '8fff97b457b717b0cad899d2818b5d43165f350f31c5d5598cc71bbde707d604',
             priv: '002e694a441a412fc0ca8c3a6dcc27a5da20f69341490bb27cddcd63db5b90ce',
           },
         ],
@@ -133,48 +148,57 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [],
-            chain: 'beeb672fe4621673f722f38529c07392fecaa61015c80c34f29ce8b41b3cb6ea',
+            chain:
+              'beeb672fe4621673f722f38529c07392fecaa61015c80c34f29ce8b41b3cb6ea',
             priv: '612091aaa12e22dd2abef664f8a01a82cae99ad7441b7ef8110424915c268bc2',
           },
           {
             path: [0 | Hard],
-            chain: '3460cea53e6a6bb5fb391eeef3237ffd8724bf0a40e94943c98b83825342ee11',
+            chain:
+              '3460cea53e6a6bb5fb391eeef3237ffd8724bf0a40e94943c98b83825342ee11',
             priv: '6939694369114c67917a182c59ddb8cafc3004e63ca5d3b84403ba8613debc0c',
           },
           {
             path: [0 | Hard, 1],
-            chain: '4187afff1aafa8445010097fb99d23aee9f599450c7bd140b6826ac22ba21d0c',
+            chain:
+              '4187afff1aafa8445010097fb99d23aee9f599450c7bd140b6826ac22ba21d0c',
             priv: '284e9d38d07d21e4e281b645089a94f4cf5a5a81369acf151a1c3a57f18b2129',
           },
           {
             path: [0 | Hard, 1, 2 | Hard],
-            chain: '98c7514f562e64e74170cc3cf304ee1ce54d6b6da4f880f313e8204c2a185318',
+            chain:
+              '98c7514f562e64e74170cc3cf304ee1ce54d6b6da4f880f313e8204c2a185318',
             priv: '694596e8a54f252c960eb771a3c41e7e32496d03b954aeb90f61635b8e092aa7',
           },
           {
             path: [0 | Hard, 1, 2 | Hard, 2],
-            chain: 'ba96f776a5c3907d7fd48bde5620ee374d4acfd540378476019eab70790c63a0',
+            chain:
+              'ba96f776a5c3907d7fd48bde5620ee374d4acfd540378476019eab70790c63a0',
             priv: '5996c37fd3dd2679039b23ed6f70b506c6b56b3cb5e424681fb0fa64caf82aaa',
           },
           {
             path: [0 | Hard, 1, 2 | Hard, 2, 1000000000],
-            chain: 'b9b7b82d326bb9cb5b5b121066feea4eb93d5241103c9e7a18aad40f1dde8059',
+            chain:
+              'b9b7b82d326bb9cb5b5b121066feea4eb93d5241103c9e7a18aad40f1dde8059',
             priv: '21c4f269ef0a5fd1badf47eeacebeeaa3de22eb8e5b0adcd0f27dd99d34d0119',
           },
           // derivation retry
           {
             path: [],
-            chain: 'beeb672fe4621673f722f38529c07392fecaa61015c80c34f29ce8b41b3cb6ea',
+            chain:
+              'beeb672fe4621673f722f38529c07392fecaa61015c80c34f29ce8b41b3cb6ea',
             priv: '612091aaa12e22dd2abef664f8a01a82cae99ad7441b7ef8110424915c268bc2',
           },
           {
             path: [28578 | Hard],
-            chain: 'e94c8ebe30c2250a14713212f6449b20f3329105ea15b652ca5bdfc68f6c65c2',
+            chain:
+              'e94c8ebe30c2250a14713212f6449b20f3329105ea15b652ca5bdfc68f6c65c2',
             priv: '06f0db126f023755d0b8d86d4591718a5210dd8d024e3e14b6159d63f53aa669',
           },
           {
             path: [28578 | Hard, 33941],
-            chain: '9e87fe95031f14736774cd82f25fd885065cb7c358c1edf813c72af535e83071',
+            chain:
+              '9e87fe95031f14736774cd82f25fd885065cb7c358c1edf813c72af535e83071',
             priv: '092154eed4af83e078ff9b84322015aefe5769e31270f62c3f66c33888335f3a',
           },
         ],
@@ -184,32 +208,38 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [],
-            chain: '96cd4465a9644e31528eda3592aa35eb39a9527769ce1855beafc1b81055e75d',
+            chain:
+              '96cd4465a9644e31528eda3592aa35eb39a9527769ce1855beafc1b81055e75d',
             priv: 'eaa31c2e46ca2962227cf21d73a7ef0ce8b31c756897521eb6c7b39796633357',
           },
           {
             path: [0],
-            chain: '84e9c258bb8557a40e0d041115b376dd55eda99c0042ce29e81ebe4efed9b86a',
+            chain:
+              '84e9c258bb8557a40e0d041115b376dd55eda99c0042ce29e81ebe4efed9b86a',
             priv: 'd7d065f63a62624888500cdb4f88b6d59c2927fee9e6d0cdff9cad555884df6e',
           },
           {
             path: [0, 2147483647 | Hard],
-            chain: 'f235b2bc5c04606ca9c30027a84f353acf4e4683edbd11f635d0dcc1cd106ea6',
+            chain:
+              'f235b2bc5c04606ca9c30027a84f353acf4e4683edbd11f635d0dcc1cd106ea6',
             priv: '96d2ec9316746a75e7793684ed01e3d51194d81a42a3276858a5b7376d4b94b9',
           },
           {
             path: [0, 2147483647 | Hard, 1],
-            chain: '7c0b833106235e452eba79d2bdd58d4086e663bc8cc55e9773d2b5eeda313f3b',
+            chain:
+              '7c0b833106235e452eba79d2bdd58d4086e663bc8cc55e9773d2b5eeda313f3b',
             priv: '974f9096ea6873a915910e82b29d7c338542ccde39d2064d1cc228f371542bbc',
           },
           {
             path: [0, 2147483647 | Hard, 1, 2147483646 | Hard],
-            chain: '5794e616eadaf33413aa309318a26ee0fd5163b70466de7a4512fd4b1a5c9e6a',
+            chain:
+              '5794e616eadaf33413aa309318a26ee0fd5163b70466de7a4512fd4b1a5c9e6a',
             priv: 'da29649bbfaff095cd43819eda9a7be74236539a29094cd8336b07ed8d4eff63',
           },
           {
             path: [0, 2147483647 | Hard, 1, 2147483646 | Hard, 2],
-            chain: '3bfb29ee8ac4484f09db09c2079b520ea5616df7820f071a20320366fbe226a7',
+            chain:
+              '3bfb29ee8ac4484f09db09c2079b520ea5616df7820f071a20320366fbe226a7',
             priv: 'bb0a77ba01cc31d77205d51d08bd313b979a71ef4de9b062f8958297e746bd67',
           },
         ],
@@ -220,7 +250,8 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [],
-            chain: '7762f9729fed06121fd13f326884c82f59aa95c57ac492ce8c9654e60efd130c',
+            chain:
+              '7762f9729fed06121fd13f326884c82f59aa95c57ac492ce8c9654e60efd130c',
             priv: '3b8c18469a4634517d6d0b65448f8e6c62091b45540a1743c5846be55d47d88f',
           },
         ],
@@ -241,17 +272,20 @@ const testData: CurveTestData[] = [
         keys: [
           {
             path: [738197632, 335544448 | Hard, 0, 0],
-            chain: 'cdc590746b238933166da99295ef0de9e048c9ef0717c269616613ac14e52934',
+            chain:
+              'cdc590746b238933166da99295ef0de9e048c9ef0717c269616613ac14e52934',
             priv: '64461c084badf0064b2cd6c9aacf010ec073e850170bae02643d1b7f9574baf7',
           },
           {
             path: [738197504, 335544320 | Hard, 16777216, 33554432],
-            chain: 'eb9bc0b0773fcbb10c4a3078c0a3bc2309ec0b4f28065d6224c5777b6b9e83cd',
+            chain:
+              'eb9bc0b0773fcbb10c4a3078c0a3bc2309ec0b4f28065d6224c5777b6b9e83cd',
             priv: '3cbf2b3d850e1a8f47b35271d0156ca482debef29bdfa5285386d47eefb87204',
           },
           {
             path: [44 | Hard, 148 | Hard, 0, 0],
-            chain: 'bba08de0a440987023821d4d82a39c46068e8c8ebe23be0e0329a7dc6467a30d',
+            chain:
+              'bba08de0a440987023821d4d82a39c46068e8c8ebe23be0e0329a7dc6467a30d',
             priv: '7b95d7cb3fc819eb4ac356644eb3467d465d5eb5f4703f39670a03139b6cdf56',
           },
         ],
@@ -265,16 +299,21 @@ describe('ECDSA', () => {
     describe(curve.curve, () => {
       for (const chain of curve.chain) {
         describe(chain.seed || 'mnemonic', () => {
-          const seed = chain.seed || Bip39.mnemonicToSeedSync(chain.mnemonic || '', '');
+          const seed =
+            chain.seed || bip39.mnemonicToSeedSync(chain.mnemonic || '', '');
           const root = ECDSA.PrivateKey.fromSeed(seed, curve.curve);
           for (const keyData of chain.keys) {
             it(JSON.stringify(keyData.path.map((x) => x >>> 0)), () => {
               const key = root.derivePath(keyData.path);
               if (keyData.chain) {
-                expect(Buffer.from(key.chainCode).toString('hex')).toBe(keyData.chain);
+                expect(Buffer.from(key.chainCode).toString('hex')).toBe(
+                  keyData.chain
+                );
               }
               if (keyData.priv) {
-                expect(Buffer.from(key.bytes()).toString('hex')).toBe(keyData.priv);
+                expect(Buffer.from(key.bytes()).toString('hex')).toBe(
+                  keyData.priv
+                );
               }
             });
           }

--- a/packages/taquito-signer/test/ed25519.spec.ts
+++ b/packages/taquito-signer/test/ed25519.spec.ts
@@ -1,5 +1,5 @@
 import { Ed25519, Hard } from '../src/derivation-tools';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
 import { InvalidSeedLengthError } from '../src/errors';
 
 interface TestKeyData {
@@ -20,32 +20,38 @@ const testData: TestChain[] = [
     keys: [
       {
         path: [],
-        chain: '90046a93de5380a72b5e45010748567d5ea02bbf6522f979e05c0d8d8ca9fffb',
+        chain:
+          '90046a93de5380a72b5e45010748567d5ea02bbf6522f979e05c0d8d8ca9fffb',
         priv: '2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7',
       },
       {
         path: [0 | Hard],
-        chain: '8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69',
+        chain:
+          '8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69',
         priv: '68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3',
       },
       {
         path: [0 | Hard, 1 | Hard],
-        chain: 'a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14',
+        chain:
+          'a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14',
         priv: 'b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2',
       },
       {
         path: [0 | Hard, 1 | Hard, 2 | Hard],
-        chain: '2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c',
+        chain:
+          '2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c',
         priv: '92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9',
       },
       {
         path: [0 | Hard, 1 | Hard, 2 | Hard, 2 | Hard],
-        chain: '8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc',
+        chain:
+          '8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc',
         priv: '30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662',
       },
       {
         path: [0 | Hard, 1 | Hard, 2 | Hard, 2 | Hard, 1000000000 | Hard],
-        chain: '68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230',
+        chain:
+          '68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230',
         priv: '8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793',
       },
     ],
@@ -55,32 +61,44 @@ const testData: TestChain[] = [
     keys: [
       {
         path: [],
-        chain: 'ef70a74db9c3a5af931b5fe73ed8e1a53464133654fd55e7a66f8570b8e33c3b',
+        chain:
+          'ef70a74db9c3a5af931b5fe73ed8e1a53464133654fd55e7a66f8570b8e33c3b',
         priv: '171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012',
       },
       {
         path: [0 | Hard],
-        chain: '0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d',
+        chain:
+          '0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d',
         priv: '1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635',
       },
       {
         path: [0 | Hard, 2147483647 | Hard],
-        chain: '138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f',
+        chain:
+          '138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f',
         priv: 'ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4',
       },
       {
         path: [0 | Hard, 2147483647 | Hard, 1 | Hard],
-        chain: '73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90',
+        chain:
+          '73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90',
         priv: '3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c',
       },
       {
         path: [0 | Hard, 2147483647 | Hard, 1 | Hard, 2147483646 | Hard],
-        chain: '0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a',
+        chain:
+          '0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a',
         priv: '5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72',
       },
       {
-        path: [0 | Hard, 2147483647 | Hard, 1 | Hard, 2147483646 | Hard, 2 | Hard],
-        chain: '5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4',
+        path: [
+          0 | Hard,
+          2147483647 | Hard,
+          1 | Hard,
+          2147483646 | Hard,
+          2 | Hard,
+        ],
+        chain:
+          '5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4',
         priv: '551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d',
       },
     ],
@@ -101,22 +119,31 @@ const testData: TestChain[] = [
     keys: [
       {
         path: [738197632 | Hard, 335544448 | Hard, 0 | Hard, 0 | Hard],
-        chain: 'b609a7af6a8ae5568bff26a3747aa0c4d8b383144db5c3da28650a37015f2503',
+        chain:
+          'b609a7af6a8ae5568bff26a3747aa0c4d8b383144db5c3da28650a37015f2503',
         priv: '9761691a62523b637c55aa267b3c4835b7cdd4bb704b399a0f7290ca570262cb',
       },
       {
-        path: [738197504 | Hard, 335544320 | Hard, 16777216 | Hard, 33554432 | Hard],
-        chain: '1a8e8df02b17fd4632529dab6443887359ecf94d547291535952b412cba88420',
+        path: [
+          738197504 | Hard,
+          335544320 | Hard,
+          16777216 | Hard,
+          33554432 | Hard,
+        ],
+        chain:
+          '1a8e8df02b17fd4632529dab6443887359ecf94d547291535952b412cba88420',
         priv: 'e36a66d67ea0d2dcf9af54bc4617c0fa0724b42acff17501ac9dd27588bbd7dd',
       },
       {
         path: [44 | Hard, 148 | Hard, 0 | Hard, 0 | Hard],
-        chain: 'ad38cb3640dd5a1e7540030761ec7ade17a8b38a203c37072647ec22eea7a3ba',
+        chain:
+          'ad38cb3640dd5a1e7540030761ec7ade17a8b38a203c37072647ec22eea7a3ba',
         priv: 'a044cf4dcc4c6206d64ea3a7dae79337afcd61808dc6239a22c1ba1f4618c055',
       },
       {
         path: [44 | Hard, 148 | Hard, 1 | Hard, 2 | Hard],
-        chain: 'fbc472b0a324f71f264c6b002524a93a690a3d9fd130c9ca949d0ccc1e37b07e',
+        chain:
+          'fbc472b0a324f71f264c6b002524a93a690a3d9fd130c9ca949d0ccc1e37b07e',
         priv: '889fc3bc31029c0f09eb6a24f1617af15b919dc9a6b3caac3c57383da094a157',
       },
     ],
@@ -128,13 +155,15 @@ const badSeed =
 describe('Ed25519', () => {
   for (const d of testData) {
     describe(d.seed || 'mnemonic', () => {
-      const seed = d.seed || Bip39.mnemonicToSeedSync(d.mnemonic || '');
+      const seed = d.seed || bip39.mnemonicToSeedSync(d.mnemonic || '');
       const root = Ed25519.PrivateKey.fromSeed(seed);
       for (const keyData of d.keys) {
         it(JSON.stringify(keyData.path.map((x) => x >>> 0)), () => {
           const key = root.derivePath(keyData.path);
           if (keyData.chain) {
-            expect(Buffer.from(key.chainCode).toString('hex')).toBe(keyData.chain);
+            expect(Buffer.from(key.chainCode).toString('hex')).toBe(
+              keyData.chain
+            );
           }
           if (keyData.priv) {
             expect(Buffer.from(key.seed()).toString('hex')).toBe(keyData.priv);
@@ -144,6 +173,8 @@ describe('Ed25519', () => {
     });
   }
   it('Should reject with bad seed', () => {
-    expect(() => Ed25519.PrivateKey.fromSeed(badSeed)).toThrowError(InvalidSeedLengthError);
+    expect(() => Ed25519.PrivateKey.fromSeed(badSeed)).toThrowError(
+      InvalidSeedLengthError
+    );
   });
 });


### PR DESCRIPTION
Part of https://github.com/ecadlabs/taquito/issues/2455.

Replace the `bip39` library with `@scure/bip39` which is an audited one.
Viem already made the switch to this library https://github.com/wevm/viem/blob/c52c8ed2a2e18d1e0d433fe87990bc5539d579be/src/package.json#L151.

## Release Note Draft Snippet

Replace the bip39 dependency with the audited @scure/bip39.
