### PR TITLE
Keepalive false for node v19+

### DIFF
--- a/packages/taquito-http-utils/package.json
+++ b/packages/taquito-http-utils/package.json
@@ -12,6 +12,10 @@
     "signature.json",
     "dist"
   ],
+  "browser": {
+    "http": false,
+    "https": false
+  },
   "author": "Simon Boissonneault-Robert <simon@ecadlabs.com>",
   "repository": {
     "type": "git",

--- a/packages/taquito-http-utils/rollup.config.ts
+++ b/packages/taquito-http-utils/rollup.config.ts
@@ -13,7 +13,8 @@ export default {
     { file: pkg.module, format: 'es', sourcemap: true },
   ],
   // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
-  external: [],
+  // Exclude nodejs http and https modules
+  external: [ "http", "https" ],
   watch: {
     include: 'src/**',
   },

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -10,12 +10,12 @@ let createAgent: ((url: string) => object) | undefined = undefined;
 const isNode = typeof process !== 'undefined' && !!process?.versions?.node;
 if (isNode) {
   fetch = require('node-fetch');
-  if (Number(process.versions.node.split('.')[0]) >= 20) {
-    // we need agent with keepalive false for node 20 and above
+  if (Number(process.versions.node.split('.')[0]) >= 19) {
+    // we need agent with keepalive false for node 19 and above
     createAgent = (url: string) => {
       return url.startsWith('https')
-        ? new require("https").Agent({ keepAlive: false })
-        : new require("http").Agent({ keepAlive: false });
+        ? new (require("https").Agent)({ keepAlive: false }) as import('https').Agent
+        : new (require("http").Agent)({ keepAlive: false }) as import('http').Agent;
     };
   }
 }
@@ -105,7 +105,7 @@ export class HttpBackend {
         headers,
         body: JSON.stringify(data),
         signal: controller.signal,
-        agent: isNode && createAgent ? createAgent(urlWithQuery) : undefined,
+        ...(isNode && createAgent ? { agent: createAgent(urlWithQuery) } : {}),
       });
 
       if (typeof response === 'undefined') {

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -12,10 +12,13 @@ if (isNode) {
   fetch = require('node-fetch');
   if (Number(process.versions.node.split('.')[0]) >= 19) {
     // we need agent with keepalive false for node 19 and above
+    const { Agent: HttpsAgent } = require('https') as { Agent: typeof import('https').Agent };
+    const { Agent: HttpAgent } = require('http') as { Agent: typeof import('http').Agent };
+    
     createAgent = (url: string) => {
       return url.startsWith('https')
-        ? new (require("https").Agent)({ keepAlive: false }) as import('https').Agent
-        : new (require("http").Agent)({ keepAlive: false }) as import('http').Agent;
+        ? new HttpsAgent({ keepAlive: false })
+        : new HttpAgent({ keepAlive: false });
     };
   }
 }

--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -105,7 +105,7 @@ export class HttpBackend {
         headers,
         body: JSON.stringify(data),
         signal: controller.signal,
-        agent: isNode ? createAgent?(urlWithQuery): undefined
+        agent: isNode && createAgent ? createAgent(urlWithQuery) : undefined,
       });
 
       if (typeof response === 'undefined') {


### PR DESCRIPTION
Fixes the issue mentioned in #2973.

It was supposedly resolved by #2986, but in Node.js v20 and later, `fetch` requires an explicit HTTP/HTTPS agent with `keepAlive: false`—setting `keepalive: false` alone is not sufficient/effective.
