### PR TITLE
update tokenId type to BigInt in TZIP12 implementation and docs

### DIFF
--- a/docs/tzip12.md
+++ b/docs/tzip12.md
@@ -94,7 +94,7 @@ values={[
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.contract.at(contractAddress, compose(tzip12, tzip16))
 .then(contract => {
@@ -118,7 +118,7 @@ Tezos.contract.at(contractAddress, compose(tzip12, tzip16))
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.wallet.at(contractAddress, compose(tzip12, tzip16))
 .then(wallet => {
@@ -151,7 +151,7 @@ values={[
 Tezos.addExtension(new Tzip16Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.contract.at(contractAddress, tzip16)
 .then(contract => {
@@ -180,7 +180,7 @@ Tezos.contract.at(contractAddress, tzip16)
 Tezos.addExtension(new Tzip16Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.wallet.at(contractAddress, tzip16)
 .then(wallet => {
@@ -259,7 +259,7 @@ values={[
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.contract.at(contractAddress, tzip12)
 .then(contract => {
@@ -282,7 +282,7 @@ Tezos.contract.at(contractAddress, tzip12)
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.wallet.at(contractAddress, tzip12)
 .then(wallet => {

--- a/integration-tests/__tests__/contract/extensions.spec.ts
+++ b/integration-tests/__tests__/contract/extensions.spec.ts
@@ -57,7 +57,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBigMapContract, knownTzip1216Contract
             const contract = await Tezos.contract.at(knownTzip1216Contract, compose(tzip16, tzip12));
             const metadata = await contract.tzip16().getMetadata();
             expect(metadata.metadata.name).toEqual('Test Taquito FA2 token_metadata view');
-            const tokenMetadata1 = await contract.tzip12().getTokenMetadata(1);
+            const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigInt(1));
             expect(tokenMetadata1.name).toEqual('AliceToken');
 
             // assert the script is loaded from the contractsLibrary instead of the RPC

--- a/integration-tests/__tests__/tzip-metadata/tzip12-token-metadata.spec.ts
+++ b/integration-tests/__tests__/tzip-metadata/tzip12-token-metadata.spec.ts
@@ -131,7 +131,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			expect(isTzip12Contract).toEqual(true);
 
 			// Fetch token metadata
-			const tokenMetadata1 = await contract.tzip12().getTokenMetadata(1);
+			const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigInt(1));
 			expect(tokenMetadata1).toEqual({
 				token_id: 1,
 				decimals: 6,
@@ -139,7 +139,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 				symbol: 'wTK'
 			});
 
-			const tokenMetadata2 = await contract.tzip12().getTokenMetadata(2);
+			const tokenMetadata2 = await contract.tzip12().getTokenMetadata(BigInt(2));
 			expect(tokenMetadata2).toEqual({
 				token_id: 2,
 				name: 'AliceToken',
@@ -148,7 +148,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			});
 
 			try {
-				await contract.tzip12().getTokenMetadata(3);
+				await contract.tzip12().getTokenMetadata(BigInt(3));
 			} catch (err) {
 				expect(err).toBeInstanceOf(TokenIdNotFound);
 			}
@@ -253,7 +253,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			expect(isTzip12Contract).toEqual(true);
 
 			// Fetch token metadata (view result contains a URI for this token)
-			const tokenMetadata0 = await contract.tzip12().getTokenMetadata(0);
+			const tokenMetadata0 = await contract.tzip12().getTokenMetadata(BigInt(0));
 			expect(tokenMetadata0).toEqual({
 				token_id: 0,
 				decimals: 3,
@@ -261,7 +261,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 				symbol: 'XTZ2'
 			});
 
-			const tokenMetadata1 = await contract.tzip12().getTokenMetadata(1);
+			const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigInt(1));
 			expect(tokenMetadata1).toEqual({
 				token_id: 1,
 				name: 'AliceToken',
@@ -271,13 +271,13 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 			});
 
 			try {
-				await contract.tzip12().getTokenMetadata(2);
+				await contract.tzip12().getTokenMetadata(BigInt(2));
 			} catch (err) {
 				expect(err).toBeInstanceOf(InvalidTokenMetadata);
 			}
 
 			try {
-				await contract.tzip12().getTokenMetadata(3);
+				await contract.tzip12().getTokenMetadata(BigInt(3));
 			} catch (err) {
 				expect(err).toBeInstanceOf(ViewSimulationError);
 			}

--- a/integration-tests/__tests__/wallet/extensions.spec.ts
+++ b/integration-tests/__tests__/wallet/extensions.spec.ts
@@ -57,7 +57,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBigMapContract, knownTzip1216Contract
             const contract = await Tezos.wallet.at(knownTzip1216Contract, compose(tzip16, tzip12));
             const metadata = await contract.tzip16().getMetadata();
             expect(metadata.metadata.name).toEqual('Test Taquito FA2 token_metadata view');
-            const tokenMetadata1 = await contract.tzip12().getTokenMetadata(1);
+            const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigInt(1));
             expect(tokenMetadata1.name).toEqual('AliceToken');
 
             // assert the script is loaded from the contractsLibrary instead of the RPC

--- a/packages/taquito-tzip12/README.md
+++ b/packages/taquito-tzip12/README.md
@@ -39,13 +39,13 @@ Tezos.addExtension(new Tzip12Module());
 const contract = await Tezos.contract.at("contractAddress", tzip12)
 
 // get the token metadata
-await contract.tzip12().getTokenMetadata(1);
+await contract.tzip12().getTokenMetadata(BigInt(1));
 ```
 
-The `getTokenMetadata` method takes a number as a parameter that represents the token_id and returns an object matching this interface:
+The `getTokenMetadata` method takes a BigInt as a parameter that represents the token_id and returns an object matching this interface:
 ```
 interface TokenMetadata {
-    token_id: number,
+    token_id: BigInt,
     decimals: number
     name?: string,
     symbol?: string,

--- a/packages/taquito-tzip12/src/errors.ts
+++ b/packages/taquito-tzip12/src/errors.ts
@@ -17,7 +17,7 @@ export class TokenMetadataNotFound extends TaquitoError {
  *  @description Error that indicates the token ID not being found
  */
 export class TokenIdNotFound extends TaquitoError {
-  constructor(public readonly tokenId: number) {
+  constructor(public readonly tokenId: BigInt) {
     super(`Could not find token metadata for the token ID: ${tokenId}`);
     this.name = 'TokenIdNotFound';
   }

--- a/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
+++ b/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
@@ -25,7 +25,7 @@ const tokenMetadataBigMapType = {
 };
 
 export interface TokenMetadata {
-  token_id: number;
+  token_id: BigInt;
   decimals: number;
   name?: string;
   symbol?: string;
@@ -82,12 +82,12 @@ export class Tzip12ContractAbstraction {
    * @returns An object of type `TokenMetadata`
    * @throws {@link TokenIdNotFound, TokenMetadataNotFound, InvalidTokenMetadata}
    */
-  async getTokenMetadata(tokenId: number) {
+  async getTokenMetadata(tokenId: BigInt) {
     const tokenMetadata = await this.retrieveTokenMetadataFromView(tokenId);
     return !tokenMetadata ? this.retrieveTokenMetadataFromBigMap(tokenId) : tokenMetadata;
   }
 
-  private async retrieveTokenMetadataFromView(tokenId: number) {
+  private async retrieveTokenMetadataFromView(tokenId: BigInt) {
     if (await this.getContractMetadata()) {
       const views = await this._tzip16ContractAbstraction.metadataViews();
       if (views && this.hasTokenMetadataView(views)) {
@@ -107,7 +107,7 @@ export class Tzip12ContractAbstraction {
 
   private async executeTokenMetadataView(
     tokenMetadataView: View,
-    tokenId: number
+    tokenId: BigInt
   ): Promise<TokenMetadata> {
     const tokenMetadata = await tokenMetadataView.executeView(tokenId);
     const tokenMap = Object.values(tokenMetadata)[1];
@@ -147,7 +147,7 @@ export class Tzip12ContractAbstraction {
   }
 
   private formatMetadataToken(
-    tokenId: number,
+    tokenId: BigInt,
     metadataTokenMap: MichelsonMap<string, string>,
     metadataFromUri?: any
   ): TokenMetadata {
@@ -180,7 +180,7 @@ export class Tzip12ContractAbstraction {
     return tokenMetadataDecoded as TokenMetadata;
   }
 
-  private async retrieveTokenMetadataFromBigMap(tokenId: number) {
+  private async retrieveTokenMetadataFromBigMap(tokenId: BigInt) {
     const bigmapTokenMetadataId = await this.findTokenMetadataBigMap();
     let pairNatMap;
     try {

--- a/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
@@ -140,9 +140,9 @@ describe('Tzip12 contract abstraction test', () => {
       '1': tokenMap,
     });
 
-    const tokenMetadata = await tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, 0);
+    const tokenMetadata = await tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, BigInt(0));
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito',
       symbol: 'XTZ',
       decimals: 3,
@@ -154,7 +154,7 @@ describe('Tzip12 contract abstraction test', () => {
       throw new ViewSimulationError('view simulation failed', 'test');
     });
 
-    expect(tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, 0)).rejects.toEqual(
+    expect(tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, BigInt(0))).rejects.toEqual(
       new ViewSimulationError('view simulation failed', 'test')
     );
   });
@@ -165,7 +165,7 @@ describe('Tzip12 contract abstraction test', () => {
       '1': 'I am not a map',
     });
 
-    expect(tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, 0)).rejects.toEqual(
+    expect(tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, BigInt(0))).rejects.toEqual(
       new TokenMetadataNotFound(mockContractAbstraction.address)
     );
   });
@@ -173,7 +173,7 @@ describe('Tzip12 contract abstraction test', () => {
   it('Test 4 for executeTokenMetadataView(): should throw TokenMetadataNotFound if the type of the view result is wrong', async () => {
     mockMichelsonStorageView.executeView.mockResolvedValue('wrong type');
 
-    expect(tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, 0)).rejects.toEqual(
+    expect(tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, BigInt(0))).rejects.toEqual(
       new TokenMetadataNotFound(mockContractAbstraction.address)
     );
   });
@@ -199,9 +199,9 @@ describe('Tzip12 contract abstraction test', () => {
       token_info: tokenMap,
     });
 
-    const tokenMetadata = await tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, 0);
+    const tokenMetadata = await tzip12Abs['executeTokenMetadataView'](mockMichelsonStorageView, BigInt(0));
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito test',
       decimals: 3,
       symbol: 'XTZ!',
@@ -262,7 +262,7 @@ describe('Tzip12 contract abstraction test', () => {
 
     const tokenMetadata = await tzip12Abs['retrieveTokenMetadataFromView'](0);
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito',
       symbol: 'XTZ',
       decimals: 3,
@@ -302,7 +302,7 @@ describe('Tzip12 contract abstraction test', () => {
 
     const tokenMetadata = await tzip12Abs['retrieveTokenMetadataFromBigMap'](0);
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito',
       symbol: 'XTZ',
       decimals: 3,
@@ -324,14 +324,14 @@ describe('Tzip12 contract abstraction test', () => {
       throw new Error();
     });
 
-    expect(tzip12Abs['retrieveTokenMetadataFromBigMap'](0)).rejects.toEqual(new TokenIdNotFound(0));
+    expect(tzip12Abs['retrieveTokenMetadataFromBigMap'](BigInt(0))).rejects.toEqual(new TokenIdNotFound(BigInt(0)));
   });
 
   it('Test 4 for retrieveTokenMetadataFromBigMap(): Should throw TokenIdNotFound', async () => {
     mockSchema.FindFirstInTopLevelPair.mockReturnValue({ int: '20350' });
     mockRpcContractProvider.getBigMapKeyByID.mockResolvedValue('I am not a pair');
 
-    expect(tzip12Abs['retrieveTokenMetadataFromBigMap'](0)).rejects.toEqual(new TokenIdNotFound(0));
+    expect(tzip12Abs['retrieveTokenMetadataFromBigMap'](BigInt(0))).rejects.toEqual(new TokenIdNotFound(BigInt(0)));
   });
 
   it('Test 1 for getTokenMetadata(): Should succeed to fetch the token metadata', async () => {
@@ -353,7 +353,7 @@ describe('Tzip12 contract abstraction test', () => {
 
     const tokenMetadata = await tzip12Abs.getTokenMetadata(0);
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito',
       symbol: 'XTZ',
       decimals: 3,
@@ -382,7 +382,7 @@ describe('Tzip12 contract abstraction test', () => {
 
     const tokenMetadata = await tzip12Abs.getTokenMetadata(0);
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito test',
       symbol: 'XTZ',
       decimals: 3,
@@ -422,7 +422,7 @@ describe('Tzip12 contract abstraction test', () => {
 
     const tokenMetadata = await tzip12Abs.getTokenMetadata(0);
     expect(tokenMetadata).toEqual({
-      token_id: 0,
+      token_id: BigInt(0),
       name: 'Taquito test',
       symbol: 'XTZ',
       decimals: 3,
@@ -446,7 +446,7 @@ describe('Tzip12 contract abstraction test', () => {
     });
 
     try {
-      await tzip12Abs.getTokenMetadata(0);
+      await tzip12Abs.getTokenMetadata(BigInt(0));
     } catch (err) {
       expect(err).toBeInstanceOf(InvalidTokenMetadata);
     }

--- a/website/versioned_docs/version-23.0.0/tzip12.md
+++ b/website/versioned_docs/version-23.0.0/tzip12.md
@@ -94,7 +94,7 @@ values={[
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.contract.at(contractAddress, compose(tzip12, tzip16))
 .then(contract => {
@@ -118,7 +118,7 @@ Tezos.contract.at(contractAddress, compose(tzip12, tzip16))
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.wallet.at(contractAddress, compose(tzip12, tzip16))
 .then(wallet => {
@@ -151,7 +151,7 @@ values={[
 Tezos.addExtension(new Tzip16Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.contract.at(contractAddress, tzip16)
 .then(contract => {
@@ -180,7 +180,7 @@ Tezos.contract.at(contractAddress, tzip16)
 Tezos.addExtension(new Tzip16Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.wallet.at(contractAddress, tzip16)
 .then(wallet => {
@@ -259,7 +259,7 @@ values={[
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.contract.at(contractAddress, tzip12)
 .then(contract => {
@@ -282,7 +282,7 @@ Tezos.contract.at(contractAddress, tzip12)
 Tezos.addExtension(new Tzip12Module());
 
 const contractAddress = "KT1NMtSQq484bDYSFvNrBjfkGtpug2Fm1rrr";
-const tokenId = 1;
+const tokenId = BigInt(1);
 
 Tezos.wallet.at(contractAddress, tzip12)
 .then(wallet => {


### PR DESCRIPTION
Closes #979 

Updates getting token metadata to use BigInt for Token ID rather than number to correspond with the `nat` value from TZIP-12