### PR TITLE
docs: make sapling category not a sub-category

### DIFF
--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -147,15 +147,15 @@ const sidebars = {
         'contracts-library',
         'timelock',
         'taquito_utils',
+        {
+          type: 'category',
+          label: 'Sapling',
+          collapsed: false,
+          collapsible: false,
+          className: 'sidebarSubcategory',
+          items: ['sapling', 'sapling_in_memory_spending_key', 'sapling_in_memory_viewing_key'],
+        },
       ],
-    },
-    {
-      type: 'category',
-      label: 'Sapling',
-      collapsed: false,
-      collapsible: false,
-      className: 'sidebarHeader',
-      items: ['sapling', 'sapling_in_memory_spending_key', 'sapling_in_memory_viewing_key'],
     },
     {
       type: 'category',

--- a/website/src/css/custom.scss
+++ b/website/src/css/custom.scss
@@ -638,6 +638,37 @@ aside {
   .theme-doc-sidebar-item-category {
     padding-bottom: 10px;
   }
+
+  // Subcategory styling for nested categories
+  .sidebarSubcategory {
+    .theme-doc-sidebar-item-category-level-2 > a {
+      font-family: Source Sans Pro;
+      font-style: normal;
+      font-weight: 500;
+      font-size: 14px;
+      line-height: 20px;
+      letter-spacing: 0.2px;
+      text-transform: none;
+      color: var(--sidebar-text-color);
+      opacity: 0.8;
+      border-left: 2px solid var(--brown-primary);
+    }
+
+    .menu__list-item {
+      margin-left: 16px;
+    }
+
+    .menu__link {
+      font-size: 14px !important;
+      color: var(--sidebar-text-color) !important;
+      opacity: 0.9;
+    }
+
+    .menu__link--active {
+      background: var(--sidebar-link-bg) !important;
+      border-radius: 16px !important;
+    }
+  }
 }
 
 .table-of-contents__link--active {

--- a/website/versioned_sidebars/version-20.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-20.0.0-sidebars.json
@@ -128,18 +128,19 @@
         "michelson_encoder",
         "contracts-library",
         "timelock",
-        "taquito_utils"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Sapling",
-      "collapsed": false,
-      "collapsible": false,
-      "items": [
-        "sapling",
-        "sapling_in_memory_spending_key",
-        "sapling_in_memory_viewing_key"
+        "taquito_utils",
+        {
+          "type": "category",
+          "label": "Sapling",
+          "collapsed": false,
+          "collapsible": false,
+          "className": "sidebarSubcategory",
+          "items": [
+            "sapling",
+            "sapling_in_memory_spending_key",
+            "sapling_in_memory_viewing_key"
+          ]
+        }
       ]
     },
     {

--- a/website/versioned_sidebars/version-20.1.0-sidebars.json
+++ b/website/versioned_sidebars/version-20.1.0-sidebars.json
@@ -129,18 +129,19 @@
         "michel_codec",
         "contracts-library",
         "timelock",
-        "taquito_utils"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Sapling",
-      "collapsed": false,
-      "collapsible": false,
-      "items": [
-        "sapling",
-        "sapling_in_memory_spending_key",
-        "sapling_in_memory_viewing_key"
+        "taquito_utils",
+        {
+          "type": "category",
+          "label": "Sapling",
+          "collapsed": false,
+          "collapsible": false,
+          "className": "sidebarSubcategory",
+          "items": [
+            "sapling",
+            "sapling_in_memory_spending_key",
+            "sapling_in_memory_viewing_key"
+          ]
+        }
       ]
     },
     {

--- a/website/versioned_sidebars/version-21.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-21.0.0-sidebars.json
@@ -130,18 +130,19 @@
         "michel_codec",
         "contracts-library",
         "timelock",
-        "taquito_utils"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Sapling",
-      "collapsed": false,
-      "collapsible": false,
-      "items": [
-        "sapling",
-        "sapling_in_memory_spending_key",
-        "sapling_in_memory_viewing_key"
+        "taquito_utils",
+        {
+          "type": "category",
+          "label": "Sapling",
+          "collapsed": false,
+          "collapsible": false,
+          "className": "sidebarSubcategory",
+          "items": [
+            "sapling",
+            "sapling_in_memory_spending_key",
+            "sapling_in_memory_viewing_key"
+          ]
+        }
       ]
     },
     {

--- a/website/versioned_sidebars/version-22.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-22.0.0-sidebars.json
@@ -130,18 +130,19 @@
         "michel_codec",
         "contracts-library",
         "timelock",
-        "taquito_utils"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Sapling",
-      "collapsed": false,
-      "collapsible": false,
-      "items": [
-        "sapling",
-        "sapling_in_memory_spending_key",
-        "sapling_in_memory_viewing_key"
+        "taquito_utils",
+        {
+          "type": "category",
+          "label": "Sapling",
+          "collapsed": false,
+          "collapsible": false,
+          "className": "sidebarSubcategory",
+          "items": [
+            "sapling",
+            "sapling_in_memory_spending_key",
+            "sapling_in_memory_viewing_key"
+          ]
+        }
       ]
     },
     {

--- a/website/versioned_sidebars/version-23.0.0-sidebars.json
+++ b/website/versioned_sidebars/version-23.0.0-sidebars.json
@@ -130,18 +130,19 @@
         "michel_codec",
         "contracts-library",
         "timelock",
-        "taquito_utils"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Sapling",
-      "collapsed": false,
-      "collapsible": false,
-      "items": [
-        "sapling",
-        "sapling_in_memory_spending_key",
-        "sapling_in_memory_viewing_key"
+        "taquito_utils",
+        {
+          "type": "category",
+          "label": "Sapling",
+          "collapsed": false,
+          "collapsible": false,
+          "className": "sidebarSubcategory",
+          "items": [
+            "sapling",
+            "sapling_in_memory_spending_key",
+            "sapling_in_memory_viewing_key"
+          ]
+        }
       ]
     },
     {


### PR DESCRIPTION
Before, the sapling category was indented under the "packages" category and looked a little odd. This PR makes it no longer a sub-category, and instead its own category.

https://c39c2e88.taquito-584.pages.dev/

<img width="421" height="517" alt="image" src="https://github.com/user-attachments/assets/18b5d432-f59a-4258-9348-96e467ee68e9" />
