### PR TITLE
docs fix(header.astro): changing doc version loses current page context

### DIFF
--- a/website/src/components/Header.astro
+++ b/website/src/components/Header.astro
@@ -10,6 +10,10 @@ const versionMatch = pathname.match(/\/docs\/([^/]+)/);
 const currentVersion = versionMatch?.[1] && VERSIONS.includes(versionMatch[1] as typeof VERSIONS[number])
   ? versionMatch[1]
   : DEFAULT_VERSION;
+
+// Extract the current page slug (everything after /docs/{version}/)
+const pageSlugMatch = pathname.match(/\/docs\/[^/]+\/(.+)/);
+const currentPageSlug = pageSlugMatch?.[1] || "quick_start";
 ---
 
 <header
@@ -54,7 +58,7 @@ const currentVersion = versionMatch?.[1] && VERSIONS.includes(versionMatch[1] as
         >
           {VERSIONS.map((version) => (
             <a
-              href={`/docs/${version}/quick_start`}
+              href={`/docs/${version}/${currentPageSlug}`}
               class:list={[
                 "block px-4 py-2 text-sm hover:bg-primary/10 transition-colors",
                 version === currentVersion ? "text-primary font-medium bg-primary/5" : "text-gray-700"
@@ -157,7 +161,7 @@ const currentVersion = versionMatch?.[1] && VERSIONS.includes(versionMatch[1] as
         >
           {VERSIONS.map((version) => (
             <a
-              href={`/docs/${version}/quick_start`}
+              href={`/docs/${version}/${currentPageSlug}`}
               class:list={[
                 "block px-6 py-2 text-sm hover:bg-primary/10 transition-colors",
                 version === currentVersion ? "text-primary font-medium bg-primary/5" : "text-gray-700"


### PR DESCRIPTION
Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [ ] Your code builds cleanly without any errors or warnings
- [ ] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [ ] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [ ] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [ ] You have added a concise description on your changes
## Release Note Draft Snippet

__If relevant, please write a summary of your change that will be suitable for
inclusion in the Release Notes for the next Taquito release.__
