### PR TITLE
fix: update hardcoded version links to use default version

### DIFF
--- a/website/src/components/home/DeveloperExperience.astro
+++ b/website/src/components/home/DeveloperExperience.astro
@@ -1,5 +1,6 @@
 ---
 import { Briefcase, Bug, Boxes, FileText } from "@lucide/astro";
+import { DEFAULT_VERSION } from "../../pages/api/search/[version].json.ts";
 
 const items = [
   {
@@ -48,7 +49,7 @@ const items = [
           What makes Taquito so amazing?
         </h3>
         <a
-          href="/docs/23.0.0/quick_start"
+          href={`/docs/${DEFAULT_VERSION}/quick_start`}
           class="bg-primary text-white hover:text-gray-300 transition-colors duration-150 px-4 py-2 rounded-full text-lg"
           >Get Started</a
         >

--- a/website/src/components/home/Hero.astro
+++ b/website/src/components/home/Hero.astro
@@ -1,5 +1,5 @@
 ---
-
+import { DEFAULT_VERSION } from "../../pages/api/search/[version].json.ts";
 ---
 
 <section class="bg-background-primary py-20 px-8">
@@ -12,7 +12,7 @@
       blockchain apps faster and easier
     </p>
     <a
-      href="/docs/23.0.0/quick_start"
+      href={`/docs/${DEFAULT_VERSION}/quick_start`}
       class="bg-primary text-white hover:text-gray-300 transition-colors duration-150 px-5 py-2.5 rounded-full text-lg"
       >Get Started</a
     >

--- a/website/src/components/home/Problems.astro
+++ b/website/src/components/home/Problems.astro
@@ -1,5 +1,6 @@
 ---
 import happyTaco from "../../images/happy_taco.svg";
+import { DEFAULT_VERSION } from "../../pages/api/search/[version].json.ts";
 
 const items = [
   "Tired of figuring out what is needed to make that RPC work?",
@@ -37,7 +38,7 @@ const items = [
         <div class="flex flex-col items-start gap-2">
           <p>Ready to start?</p>
           <a
-            href="/docs/23.0.0/quick_start"
+            href={`/docs/${DEFAULT_VERSION}/quick_start`}
             class="bg-primary text-white hover:text-gray-300 transition-colors duration-150 px-5 py-2.5 text-lg rounded-full"
             >Get Started</a
           >

--- a/website/src/components/home/Start.astro
+++ b/website/src/components/home/Start.astro
@@ -1,5 +1,6 @@
 ---
 import { Binary, Download, PlugZap } from "@lucide/astro";
+import { DEFAULT_VERSION } from "../../pages/api/search/[version].json.ts";
 ---
 
 <section class="bg-background-secondary">
@@ -9,7 +10,7 @@ import { Binary, Download, PlugZap } from "@lucide/astro";
       Just a few simple steps and you are set to start building your own app.
     </h3>
     <a
-      href="/docs/23.0.0/quick_start"
+      href={`/docs/${DEFAULT_VERSION}/quick_start`}
       class="bg-primary text-white hover:text-gray-300 transition-colors duration-150 px-4 py-2 rounded-full text-lg"
       >Get Started</a
     >
@@ -81,7 +82,7 @@ import { Binary, Download, PlugZap } from "@lucide/astro";
         <div class="absolute bottom-0 right-4 3xl:right-1/5 md:right-24">
             <p class="text-lg text-black mb-4">Ready to start?</p>
             <a
-            href="/docs/23.0.0/quick_start"
+            href={`/docs/${DEFAULT_VERSION}/quick_start`}
             class="bg-primary text-white hover:text-gray-300 transition-colors duration-150 px-6 py-2.5 rounded-full text-lg"
             >Get Started</a>
         </div>


### PR DESCRIPTION
Previously, certain links on the Taquito site would direct to 23.0.0 no matter what. These have been updated to use the default version variable. 