### PR TITLE
docs: add security comments for zero nonce in encrypted key decryption

### DIFF
--- a/packages/taquito-sapling/src/sapling-keys/helpers.ts
+++ b/packages/taquito-sapling/src/sapling-keys/helpers.ts
@@ -30,9 +30,11 @@ export function decryptKey(spendingKey: string, password?: string) {
     const encryptedSk = toBuffer(keyArr.slice(8));
 
     const encryptionKey = pbkdf2.pbkdf2Sync(password, salt, 32768, 32, 'sha512');
+    // Zero nonce is safe: fresh random salt per encryption produces unique PBKDF2-derived key.
+    // See: https://gitlab.com/tezos/tezos/-/blob/master/src/lib_signer_backends/encrypted.ml
     const decrypted = openSecretBox(
       new Uint8Array(encryptionKey),
-      new Uint8Array(24),
+      new Uint8Array(24), // zero nonce - uniqueness provided by per-encryption derived key
       new Uint8Array(encryptedSk)
     );
     if (!decrypted) {

--- a/packages/taquito-signer/src/in-memory-signer.ts
+++ b/packages/taquito-signer/src/in-memory-signer.ts
@@ -137,9 +137,13 @@ export class InMemorySigner implements Signer {
         const encryptedSk = data.slice(8);
         const encryptionKey = pbkdf2.pbkdf2Sync(passphrase, salt, 32768, 32, 'sha512');
 
+        // Zero nonce is safe here: Tezos encrypted key format uses a fresh random salt per
+        // encryption, producing a unique PBKDF2-derived key each time. The (key, nonce) pair
+        // never repeats, satisfying NaCl secretbox requirements. This matches octez-client.
+        // See: https://gitlab.com/tezos/tezos/-/blob/master/src/lib_signer_backends/encrypted.ml
         const res = openSecretBox(
           new Uint8Array(encryptionKey),
-          new Uint8Array(24),
+          new Uint8Array(24), // zero nonce - uniqueness provided by per-encryption derived key
           new Uint8Array(encryptedSk)
         );
         if (!res) {


### PR DESCRIPTION
Adds comments explaining why zero nonce is safe in `openSecretBox` calls. prevents false positives in security audits.