### PR TITLE
Fix fetch failing in certain environments when native fetch is available

### DIFF
--- a/packages/taquito-http-utils/src/taquito-http-utils.ts
+++ b/packages/taquito-http-utils/src/taquito-http-utils.ts
@@ -5,25 +5,30 @@
 
 let fetch = globalThis?.fetch;
 let createAgent: ((url: string) => { keepAlive?: boolean; [key: string]: any }) | undefined;
-// Will only use browser fetch if we are in a browser environment,
-// default to the more stable node-fetch otherwise
-const isNode = typeof process !== 'undefined' && !!process?.versions?.node;
-if (isNode) {
-  // Handle both ESM and CJS default export patterns for webpack compatibility
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const nodeFetch = require('node-fetch');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const https = require('https');
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const http = require('http');
-  fetch = nodeFetch.default || nodeFetch;
-  if (Number(process.versions.node.split('.')[0]) >= 19) {
-    // we need agent with keepalive false for node 19 and above
-    createAgent = (url: string) => {
-      return url.startsWith('https')
-        ? new https.Agent({ keepAlive: false })
-        : new http.Agent({ keepAlive: false });
-    };
+let isNode = false;
+
+// Prefer native fetch when available (browser, Electron renderer, Node 18+)
+// Only fall back to node-fetch when native fetch is not available
+if (typeof fetch !== 'function') {
+  const hasNodeProcess = typeof process !== 'undefined' && !!process?.versions?.node;
+  if (hasNodeProcess) {
+    // Handle both ESM and CJS default export patterns for webpack compatibility
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nodeFetch = require('node-fetch');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const https = require('https');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const http = require('http');
+    fetch = nodeFetch.default || nodeFetch;
+    isNode = true;
+    if (Number(process.versions.node.split('.')[0]) >= 19) {
+      // we need agent with keepalive false for node 19 and above
+      createAgent = (url: string) => {
+        return url.startsWith('https')
+          ? new https.Agent({ keepAlive: false })
+          : new http.Agent({ keepAlive: false });
+      };
+    }
   }
 }
 


### PR DESCRIPTION
Previously we were accidentially overwriting the built-in fetch module in some situations with a problematic and not  working version. We now do a better check for if built-in fetch is available before attempting to use node-fetch 
instead.

fix #3301

Thank you for your contribution to Taquito.

Before submitting this PR, please make sure:

- [x] Your code builds cleanly without any errors or warnings
- [x] You have run the linter against the changes
- [ ] You have added unit tests (if relevant/appropriate)
- [ ] You have added integration tests (if relevant/appropriate)
- [ ] All public methods or types have TypeDoc coverage with a complete description, and ideally an @example
- [ ] You have added or updated corresponding documentation
- [x] If relevant, you have written a first draft summary describing the change for inclusion in Release Notes. 

In this PR, please also make sure: 

- [x] You have linked this PR to the issue by putting `closes #TICKETNUMBER` in the description box (when applicable)
- [x] You have added a concise description on your changes
## Release Note Draft Snippet

Fix fetch failing in certain environments when native fetch is available
