### PR TITLE
test(scripts): keygen TTFB load test

### DIFF
--- a/.github/workflows/keygen-load-test.yml
+++ b/.github/workflows/keygen-load-test.yml
@@ -1,6 +1,7 @@
 name: Keygen TTFB Load Test
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       duration:

--- a/.github/workflows/keygen-load-test.yml
+++ b/.github/workflows/keygen-load-test.yml
@@ -1,0 +1,75 @@
+name: Keygen TTFB Load Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: 'Test duration in seconds'
+        default: '300'
+        required: false
+      concurrency:
+        description: 'Concurrent requests per batch'
+        default: '20'
+        required: false
+      ttfb_threshold_ms:
+        description: 'Fail if any TTFB exceeds this (ms)'
+        default: '5000'
+        required: false
+      compare:
+        description: 'Compare CF-proxied vs direct (true/false)'
+        default: 'false'
+        required: false
+  schedule:
+    # Run nightly at 02:00 UTC
+    - cron: '0 2 * * *'
+
+jobs:
+  keygen-load-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/Jod
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run keygen TTFB load test
+        id: load-test
+        run: |
+          set +e
+          node -r ts-node/register scripts/keygen-load-test.ts \
+            | tee /tmp/keygen-load-test-output.txt
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          set -e
+        env:
+          TAQUITO_KEYGEN_AUTH_HEADER: ${{ secrets.TAQUITO_KEYGEN_AUTH_HEADER }}
+          KEYGEN_URL: https://keygen.ecadinfra.com/ghostnet
+          KEYGEN_DIRECT_URL: https://keygen-direct.ecadinfra.com/ghostnet
+          KEYGEN_TEST_DURATION: ${{ github.event.inputs.duration || '300' }}
+          KEYGEN_CONCURRENCY: ${{ github.event.inputs.concurrency || '20' }}
+          KEYGEN_TTFB_THRESHOLD_MS: ${{ github.event.inputs.ttfb_threshold_ms || '5000' }}
+          KEYGEN_COMPARE: ${{ github.event.inputs.compare || 'false' }}
+
+      - name: Write step summary
+        if: always()
+        run: |
+          echo '## Keygen TTFB Load Test Results' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          cat /tmp/keygen-load-test-output.txt >> "$GITHUB_STEP_SUMMARY" || true
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload output artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: keygen-load-test-output
+          path: /tmp/keygen-load-test-output.txt
+          retention-days: 30
+
+      - name: Fail on threshold breach
+        if: steps.load-test.outputs.exit_code != '0'
+        run: exit 1

--- a/.github/workflows/keygen-load-test.yml
+++ b/.github/workflows/keygen-load-test.yml
@@ -48,7 +48,7 @@ jobs:
           set -e
         env:
           TAQUITO_KEYGEN_AUTH_HEADER: ${{ secrets.TAQUITO_KEYGEN_AUTH_HEADER }}
-          KEYGEN_URL: https://keygen.ecadinfra.com/ghostnet
+          KEYGEN_URL: http://keygen-direct.ecadinfra.com/ghostnet
           KEYGEN_DIRECT_URL: https://keygen-direct.ecadinfra.com/ghostnet
           KEYGEN_TEST_DURATION: ${{ github.event.inputs.duration || '300' }}
           KEYGEN_CONCURRENCY: ${{ github.event.inputs.concurrency || '20' }}

--- a/.github/workflows/keygen-load-test.yml
+++ b/.github/workflows/keygen-load-test.yml
@@ -48,7 +48,7 @@ jobs:
           set -e
         env:
           TAQUITO_KEYGEN_AUTH_HEADER: ${{ secrets.TAQUITO_KEYGEN_AUTH_HEADER }}
-          KEYGEN_URL: http://keygen-direct.ecadinfra.com/ghostnet
+          KEYGEN_URL: https://keygen.ecadinfra.com/ghostnet
           KEYGEN_DIRECT_URL: https://keygen-direct.ecadinfra.com/ghostnet
           KEYGEN_TEST_DURATION: ${{ github.event.inputs.duration || '300' }}
           KEYGEN_CONCURRENCY: ${{ github.event.inputs.concurrency || '20' }}

--- a/scripts/keygen-load-test.ts
+++ b/scripts/keygen-load-test.ts
@@ -5,7 +5,12 @@
  * for KEYGEN_TEST_DURATION seconds (default 300) and reports TTFB statistics.
  *
  * Usage:
- *   KEYGEN_TOKEN=<token> node -r ts-node/register scripts/keygen-load-test.ts
+ *   TAQUITO_KEYGEN_AUTH_HEADER="Authorization: Bearer <token>" \
+ *     node -r ts-node/register scripts/keygen-load-test.ts
+ *
+ * Auth (pick one — TAQUITO_KEYGEN_AUTH_HEADER takes precedence):
+ *   TAQUITO_KEYGEN_AUTH_HEADER  — full header string, e.g. "Authorization: Bearer taquito-example"
+ *   KEYGEN_TOKEN                — bare bearer token (TAQUITO_KEYGEN_AUTH_HEADER preferred in CI)
  *
  * Optional env vars:
  *   KEYGEN_URL                 — target URL (default: https://keygen.ecadinfra.com/ghostnet)
@@ -23,12 +28,21 @@ import { URL } from 'url';
 const KEYGEN_URL = process.env.KEYGEN_URL ?? 'https://keygen.ecadinfra.com/ghostnet';
 const KEYGEN_DIRECT_URL =
   process.env.KEYGEN_DIRECT_URL ?? 'https://keygen-direct.ecadinfra.com/ghostnet';
-const KEYGEN_TOKEN = process.env.KEYGEN_TOKEN ?? '';
 const DURATION_MS = parseInt(process.env.KEYGEN_TEST_DURATION ?? '300', 10) * 1000;
 const CONCURRENCY = parseInt(process.env.KEYGEN_CONCURRENCY ?? '20', 10);
 const TTFB_THRESHOLD_MS = parseInt(process.env.KEYGEN_TTFB_THRESHOLD_MS ?? '5000', 10);
 const COMPARE = process.env.KEYGEN_COMPARE === 'true';
 const REQUEST_TIMEOUT_MS = 60_000;
+
+// Resolve auth header — prefer the full-header form used by existing keygen infra scripts
+function resolveAuthHeader(): string {
+  const full = process.env.TAQUITO_KEYGEN_AUTH_HEADER;
+  if (full) return full;
+  const token = process.env.KEYGEN_TOKEN;
+  if (token) return `Authorization: Bearer ${token}`;
+  return '';
+}
+const AUTH_HEADER = resolveAuthHeader();
 
 interface RequestResult {
   probeNumber: number;
@@ -39,13 +53,17 @@ interface RequestResult {
   error?: string;
 }
 
-function makeRequest(url: string, token: string, probeNumber: number): Promise<RequestResult> {
+function makeRequest(url: string, probeNumber: number): Promise<RequestResult> {
   return new Promise((resolve) => {
     const parsed = new URL(url);
     const isHttps = parsed.protocol === 'https:';
     const lib = isHttps ? https : http;
 
     const body = '{}';
+    // AUTH_HEADER is "Authorization: Bearer <token>" — split on first ": " for the headers map
+    const [authName, ...authValueParts] = AUTH_HEADER.split(': ');
+    const authValue = authValueParts.join(': ');
+
     const options: https.RequestOptions = {
       hostname: parsed.hostname,
       port: parsed.port || (isHttps ? 443 : 80),
@@ -54,7 +72,7 @@ function makeRequest(url: string, token: string, probeNumber: number): Promise<R
       headers: {
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(body),
-        Authorization: `Bearer ${token}`,
+        [authName]: authValue,
       },
     };
 
@@ -185,7 +203,7 @@ async function runTest(url: string, label: string): Promise<RequestResult[]> {
     const promises: Promise<RequestResult>[] = [];
     for (let i = 0; i < CONCURRENCY; i++) {
       probeNumber++;
-      promises.push(makeRequest(url, KEYGEN_TOKEN, probeNumber));
+      promises.push(makeRequest(url, probeNumber));
     }
 
     const results = await Promise.all(promises);
@@ -217,8 +235,10 @@ async function runTest(url: string, label: string): Promise<RequestResult[]> {
 }
 
 async function main(): Promise<void> {
-  if (!KEYGEN_TOKEN) {
-    console.error('Error: KEYGEN_TOKEN environment variable is required.');
+  if (!AUTH_HEADER) {
+    console.error(
+      'Error: set TAQUITO_KEYGEN_AUTH_HEADER="Authorization: Bearer <token>" or KEYGEN_TOKEN=<token>'
+    );
     process.exit(1);
   }
 

--- a/scripts/keygen-load-test.ts
+++ b/scripts/keygen-load-test.ts
@@ -1,0 +1,287 @@
+/**
+ * Keygen service TTFB load test
+ *
+ * Fires KEYGEN_CONCURRENCY (default 20) concurrent POST requests to KEYGEN_URL
+ * for KEYGEN_TEST_DURATION seconds (default 300) and reports TTFB statistics.
+ *
+ * Usage:
+ *   KEYGEN_TOKEN=<token> node -r ts-node/register scripts/keygen-load-test.ts
+ *
+ * Optional env vars:
+ *   KEYGEN_URL                 — target URL (default: https://keygen.ecadinfra.com/ghostnet)
+ *   KEYGEN_DIRECT_URL          — bypass URL for side-by-side comparison
+ *   KEYGEN_TEST_DURATION       — test duration in seconds (default: 300)
+ *   KEYGEN_CONCURRENCY         — concurrent requests per batch (default: 20)
+ *   KEYGEN_TTFB_THRESHOLD_MS   — fail if any TTFB exceeds this (default: 5000)
+ *   KEYGEN_COMPARE             — set to "true" to run both proxied + direct and compare
+ */
+
+import * as https from 'https';
+import * as http from 'http';
+import { URL } from 'url';
+
+const KEYGEN_URL = process.env.KEYGEN_URL ?? 'https://keygen.ecadinfra.com/ghostnet';
+const KEYGEN_DIRECT_URL =
+  process.env.KEYGEN_DIRECT_URL ?? 'https://keygen-direct.ecadinfra.com/ghostnet';
+const KEYGEN_TOKEN = process.env.KEYGEN_TOKEN ?? '';
+const DURATION_MS = parseInt(process.env.KEYGEN_TEST_DURATION ?? '300', 10) * 1000;
+const CONCURRENCY = parseInt(process.env.KEYGEN_CONCURRENCY ?? '20', 10);
+const TTFB_THRESHOLD_MS = parseInt(process.env.KEYGEN_TTFB_THRESHOLD_MS ?? '5000', 10);
+const COMPARE = process.env.KEYGEN_COMPARE === 'true';
+const REQUEST_TIMEOUT_MS = 60_000;
+
+interface RequestResult {
+  probeNumber: number;
+  timestamp: string;
+  statusCode: number;
+  ttfbMs: number;
+  totalMs: number;
+  error?: string;
+}
+
+function makeRequest(url: string, token: string, probeNumber: number): Promise<RequestResult> {
+  return new Promise((resolve) => {
+    const parsed = new URL(url);
+    const isHttps = parsed.protocol === 'https:';
+    const lib = isHttps ? https : http;
+
+    const body = '{}';
+    const options: https.RequestOptions = {
+      hostname: parsed.hostname,
+      port: parsed.port || (isHttps ? 443 : 80),
+      path: parsed.pathname + parsed.search,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        Authorization: `Bearer ${token}`,
+      },
+    };
+
+    const startTime = Date.now();
+    let ttfbMs = -1;
+    const timestamp = new Date().toISOString();
+    let settled = false;
+
+    const settle = (result: RequestResult) => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+
+    const req = lib.request(options, (res) => {
+      ttfbMs = Date.now() - startTime;
+
+      res.on('data', () => {
+        // drain response body
+      });
+
+      res.on('end', () => {
+        settle({
+          probeNumber,
+          timestamp,
+          statusCode: res.statusCode ?? 0,
+          ttfbMs,
+          totalMs: Date.now() - startTime,
+        });
+      });
+
+      res.on('error', (err) => {
+        settle({
+          probeNumber,
+          timestamp,
+          statusCode: res.statusCode ?? 0,
+          ttfbMs: ttfbMs >= 0 ? ttfbMs : Date.now() - startTime,
+          totalMs: Date.now() - startTime,
+          error: err.message,
+        });
+      });
+    });
+
+    req.on('error', (err) => {
+      settle({
+        probeNumber,
+        timestamp,
+        statusCode: 0,
+        ttfbMs: Date.now() - startTime,
+        totalMs: Date.now() - startTime,
+        error: err.message,
+      });
+    });
+
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Request timeout (${REQUEST_TIMEOUT_MS}ms)`));
+    });
+
+    req.write(body);
+    req.end();
+  });
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.ceil(sorted.length * p) - 1;
+  return sorted[Math.max(0, idx)];
+}
+
+function printSummary(label: string, results: RequestResult[]): void {
+  if (results.length === 0) {
+    console.log(`\n[${label}] No results collected.`);
+    return;
+  }
+
+  const ttfbs = results.map((r) => r.ttfbMs).sort((a, b) => a - b);
+  const avg = ttfbs.reduce((a, b) => a + b, 0) / ttfbs.length;
+  const max = ttfbs[ttfbs.length - 1];
+  const p95 = percentile(ttfbs, 0.95);
+
+  const over1s = results.filter((r) => r.ttfbMs > 1_000).length;
+  const over5s = results.filter((r) => r.ttfbMs > 5_000).length;
+  const over19s = results.filter((r) => r.ttfbMs > 19_000).length;
+  const errored = results.filter((r) => r.error !== undefined).length;
+
+  const statusBreakdown: Record<number, number> = {};
+  for (const r of results) {
+    statusBreakdown[r.statusCode] = (statusBreakdown[r.statusCode] ?? 0) + 1;
+  }
+  const statusStr = Object.entries(statusBreakdown)
+    .sort(([a], [b]) => Number(a) - Number(b))
+    .map(([code, count]) => `HTTP ${code}: ${count}`)
+    .join(', ');
+
+  const pct = (n: number) => `${n} (${((n / results.length) * 100).toFixed(1)}%)`;
+
+  console.log(`\n${'='.repeat(50)}`);
+  console.log(`  Summary: ${label}`);
+  console.log('='.repeat(50));
+  console.log(`  Total requests:   ${results.length}`);
+  console.log(`  Avg TTFB:         ${avg.toFixed(0)} ms`);
+  console.log(`  Max TTFB:         ${max} ms`);
+  console.log(`  p95 TTFB:         ${p95} ms`);
+  console.log(`  TTFB > 1s:        ${pct(over1s)}`);
+  console.log(`  TTFB > 5s:        ${pct(over5s)}`);
+  console.log(`  TTFB > 19s:       ${pct(over19s)}`);
+  console.log(`  Errors:           ${pct(errored)}`);
+  console.log(`  Status codes:     ${statusStr}`);
+}
+
+async function runTest(url: string, label: string): Promise<RequestResult[]> {
+  const allResults: RequestResult[] = [];
+  const endTime = Date.now() + DURATION_MS;
+  let probeNumber = 0;
+  let batchNumber = 0;
+
+  console.log(`\n[${label}] Starting load test`);
+  console.log(`  URL:         ${url}`);
+  console.log(`  Duration:    ${DURATION_MS / 1000}s`);
+  console.log(`  Concurrency: ${CONCURRENCY}`);
+  console.log(`  Threshold:   TTFB > ${TTFB_THRESHOLD_MS}ms causes non-zero exit`);
+
+  while (Date.now() < endTime) {
+    batchNumber++;
+    const batchFirstProbe = probeNumber + 1;
+
+    const promises: Promise<RequestResult>[] = [];
+    for (let i = 0; i < CONCURRENCY; i++) {
+      probeNumber++;
+      promises.push(makeRequest(url, KEYGEN_TOKEN, probeNumber));
+    }
+
+    const results = await Promise.all(promises);
+    allResults.push(...results);
+
+    const batchTtfbs = results.map((r) => r.ttfbMs);
+    const batchAvg = batchTtfbs.reduce((a, b) => a + b, 0) / batchTtfbs.length;
+    const batchMax = Math.max(...batchTtfbs);
+    const batchErrors = results.filter((r) => r.error).length;
+    const errorNote = batchErrors > 0 ? ` | errors=${batchErrors}` : '';
+
+    console.log(
+      `  batch ${String(batchNumber).padStart(3)} | probes ${batchFirstProbe}-${probeNumber}` +
+        ` | avg=${batchAvg.toFixed(0)}ms max=${batchMax}ms${errorNote}`
+    );
+
+    for (const r of results) {
+      if (r.error) {
+        console.log(`    [ERR] probe #${r.probeNumber} @ ${r.timestamp}: ${r.error}`);
+      } else if (r.ttfbMs > TTFB_THRESHOLD_MS) {
+        console.log(
+          `    [SLOW] probe #${r.probeNumber} @ ${r.timestamp}: TTFB=${r.ttfbMs}ms (HTTP ${r.statusCode})`
+        );
+      }
+    }
+  }
+
+  return allResults;
+}
+
+async function main(): Promise<void> {
+  if (!KEYGEN_TOKEN) {
+    console.error('Error: KEYGEN_TOKEN environment variable is required.');
+    process.exit(1);
+  }
+
+  console.log('Keygen TTFB Load Test');
+  console.log('=====================');
+
+  let exitCode = 0;
+
+  if (COMPARE) {
+    const proxiedResults = await runTest(KEYGEN_URL, 'CF-Proxied');
+    const directResults = await runTest(KEYGEN_DIRECT_URL, 'Direct (no CF)');
+
+    printSummary('CF-Proxied', proxiedResults);
+    printSummary('Direct (no CF)', directResults);
+
+    if (proxiedResults.length > 0 && directResults.length > 0) {
+      const proxiedP95 = percentile(
+        proxiedResults.map((r) => r.ttfbMs).sort((a, b) => a - b),
+        0.95
+      );
+      const directP95 = percentile(
+        directResults.map((r) => r.ttfbMs).sort((a, b) => a - b),
+        0.95
+      );
+      console.log(`\n${'='.repeat(50)}`);
+      console.log('  Side-by-side p95 TTFB Comparison');
+      console.log('='.repeat(50));
+      console.log(`  CF-Proxied:    ${proxiedP95} ms`);
+      console.log(`  Direct:        ${directP95} ms`);
+      console.log(`  Delta (CF-Direct): ${proxiedP95 - directP95} ms`);
+    }
+
+    const allMax = Math.max(
+      ...proxiedResults.map((r) => r.ttfbMs),
+      ...directResults.map((r) => r.ttfbMs)
+    );
+    if (allMax > TTFB_THRESHOLD_MS) {
+      console.error(
+        `\nFAIL: Max TTFB ${allMax}ms exceeds threshold ${TTFB_THRESHOLD_MS}ms`
+      );
+      exitCode = 1;
+    }
+  } else {
+    const results = await runTest(KEYGEN_URL, 'Keygen');
+    printSummary('Keygen', results);
+
+    const maxTtfb = results.length > 0 ? Math.max(...results.map((r) => r.ttfbMs)) : 0;
+    if (maxTtfb > TTFB_THRESHOLD_MS) {
+      console.error(
+        `\nFAIL: Max TTFB ${maxTtfb}ms exceeds threshold ${TTFB_THRESHOLD_MS}ms`
+      );
+      exitCode = 1;
+    }
+  }
+
+  if (exitCode === 0) {
+    console.log('\nPASS: All TTFBs within threshold.');
+  }
+
+  process.exit(exitCode);
+}
+
+main().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/scripts/keygen-load-test.ts
+++ b/scripts/keygen-load-test.ts
@@ -59,7 +59,6 @@ function makeRequest(url: string, probeNumber: number): Promise<RequestResult> {
     const isHttps = parsed.protocol === 'https:';
     const lib = isHttps ? https : http;
 
-    const body = '{}';
     // AUTH_HEADER is "Authorization: Bearer <token>" — split on first ": " for the headers map
     const [authName, ...authValueParts] = AUTH_HEADER.split(': ');
     const authValue = authValueParts.join(': ');
@@ -68,10 +67,8 @@ function makeRequest(url: string, probeNumber: number): Promise<RequestResult> {
       hostname: parsed.hostname,
       port: parsed.port || (isHttps ? 443 : 80),
       path: parsed.pathname + parsed.search,
-      method: 'POST',
+      method: 'GET',
       headers: {
-        'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(body),
         [authName]: authValue,
       },
     };
@@ -132,7 +129,6 @@ function makeRequest(url: string, probeNumber: number): Promise<RequestResult> {
       req.destroy(new Error(`Request timeout (${REQUEST_TIMEOUT_MS}ms)`));
     });
 
-    req.write(body);
     req.end();
   });
 }

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "outDir": "../dist/scripts",
+    "rootDir": "."
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["../node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/keygen-load-test.ts` — a standalone Node.js/TypeScript load test that stress-tests the keygen service for TTFB regressions
- Fires 20 concurrent POST requests continuously for 5 minutes, recording timestamp, probe number, HTTP status, TTFB, and total time per request
- Prints a summary at the end: total requests, avg/max/p95 TTFB, counts for TTFB >1s / >5s / >19s, and response code breakdown
- Exits non-zero if any TTFB exceeds the configurable threshold (default 5 s)
- Supports `KEYGEN_COMPARE=true` to run against both `keygen.ecadinfra.com` (CF-proxied) and `keygen-direct.ecadinfra.com` (no CF proxy) and print a side-by-side p95 TTFB delta

## Motivation

We're seeing ~20 s TTFB intermittently from GitHub Actions runners in IAD/ARN colos, attributed to the Cloudflare proxy layer before Traefik. This script reproduces the load pattern and provides a threshold-based exit code usable in CI.

## Configuration

| Env var | Default | Description |
|---|---|---|
| `KEYGEN_TOKEN` | _(required)_ | Bearer token |
| `KEYGEN_URL` | `https://keygen.ecadinfra.com/ghostnet` | Target endpoint |
| `KEYGEN_DIRECT_URL` | `https://keygen-direct.ecadinfra.com/ghostnet` | Bypass endpoint |
| `KEYGEN_TEST_DURATION` | `300` | Duration in seconds |
| `KEYGEN_CONCURRENCY` | `20` | Concurrent requests per batch |
| `KEYGEN_TTFB_THRESHOLD_MS` | `5000` | Fail threshold in ms |
| `KEYGEN_COMPARE` | `false` | Run both endpoints for comparison |

## Usage

\`\`\`bash
KEYGEN_TOKEN=xxx node -r ts-node/register scripts/keygen-load-test.ts

# Compare CF-proxied vs direct
KEYGEN_TOKEN=xxx KEYGEN_COMPARE=true node -r ts-node/register scripts/keygen-load-test.ts
\`\`\`

## Test plan

- [ ] Run against ghostnet with a valid token and verify summary is printed
- [ ] Verify non-zero exit when TTFB exceeds KEYGEN_TTFB_THRESHOLD_MS
- [ ] Run with KEYGEN_COMPARE=true and verify side-by-side delta is printed
- [ ] Optionally wire into a GitHub Actions workflow triggered manually