### PR TITLE
Pin origination contract lookup to inclusion block hash and retry preapply stale counters

### DIFF
--- a/packages/taquito/src/contract/not-found-retry.ts
+++ b/packages/taquito/src/contract/not-found-retry.ts
@@ -1,0 +1,36 @@
+import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
+
+const CONTRACT_READ_RETRY_DELAYS_MS = [0, 200, 400, 800];
+
+const sleep = (durationMs: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+
+export const isNotFoundError = (error: unknown): error is HttpResponseError =>
+  error instanceof HttpResponseError && error.status === STATUS_CODE.NOT_FOUND;
+
+export const retryOnNotFound = async <T>(
+  read: () => Promise<T>,
+  retryDelaysMs = CONTRACT_READ_RETRY_DELAYS_MS
+): Promise<T> => {
+  let lastError: unknown;
+
+  for (const delayMs of retryDelaysMs) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+
+    try {
+      return await read();
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        throw error;
+      }
+
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+};

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -90,6 +90,7 @@ import { Provider } from '../provider';
 import { PrepareProvider } from '../prepare';
 import { FailingNoopOperation } from '../operations/failing-noop-operation';
 import { BlockIdentifier } from '../read-provider/interface';
+import { isNotFoundError, retryOnNotFound } from './not-found-retry';
 
 export class RpcContractProvider extends Provider implements ContractProvider, StorageProvider {
   constructor(
@@ -115,7 +116,9 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     if (contractValidation !== ValidationResult.VALID) {
       throw new InvalidContractAddressError(contract, contractValidation);
     }
-    const script = await this.context.readProvider.getScript(contract, 'head');
+    const script = await retryOnNotFound(() =>
+      this.context.readProvider.getScript(contract, 'head')
+    );
     if (!schema) {
       schema = script;
     }
@@ -945,15 +948,12 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     try {
       contractState = await loadContractState(block);
     } catch (error) {
-      // Some RPC deployments can transiently 404 a freshly originated contract on an exact
-      // block-pinned read before their recent contract indexes converge. Retry at head to
-      // preserve existing contract lookup behavior for callers that do not require exact pinning.
-      if (
-        block !== 'head' &&
-        error instanceof HttpResponseError &&
-        error.status === STATUS_CODE.NOT_FOUND
-      ) {
-        contractState = await loadContractState('head');
+      // Shadownet's rolling nodes occasionally 404 a just-originated contract at the exact
+      // inclusion level even after confirmation. Retry at head so the contract abstraction still
+      // resolves once the node's contract index catches up. The head index can lag briefly too,
+      // so give it a few bounded retries before surfacing the 404.
+      if (block !== 'head' && isNotFoundError(error)) {
+        contractState = await retryOnNotFound(() => loadContractState('head'));
       } else {
         throw error;
       }

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -918,7 +918,7 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
    */
   async at<T extends DefaultContractType = DefaultContractType>(
     address: string,
-    contractAbstractionComposer: ContractAbstractionComposer<T> = (x) => x as any,
+    contractAbstractionComposer: ContractAbstractionComposer<T> = (x) => x as unknown as T,
     block: BlockIdentifier = 'head'
   ): Promise<T> {
     const addressValidation = validateContractAddress(address);
@@ -945,9 +945,9 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     try {
       contractState = await loadContractState(block);
     } catch (error) {
-      // Shadownet's rolling nodes occasionally 404 a just-originated contract at the exact
-      // inclusion level even after confirmation. Retry at head so the contract abstraction still
-      // resolves once the node's contract index catches up.
+      // Some RPC deployments can transiently 404 a freshly originated contract on an exact
+      // block-pinned read before their recent contract indexes converge. Retry at head to
+      // preserve existing contract lookup behavior for callers that do not require exact pinning.
       if (
         block !== 'head' &&
         error instanceof HttpResponseError &&
@@ -968,6 +968,33 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       rpc,
       readProvider
     );
+    return contractAbstractionComposer(abs, this.context);
+  }
+
+  async atExactBlock<T extends DefaultContractType = DefaultContractType>(
+    address: string,
+    contractAbstractionComposer: ContractAbstractionComposer<T> = (x) => x as unknown as T,
+    block: BlockIdentifier
+  ): Promise<T> {
+    const addressValidation = validateContractAddress(address);
+    if (addressValidation !== ValidationResult.VALID) {
+      throw new InvalidContractAddressError(address, addressValidation);
+    }
+
+    const rpc = this.context.withExtensions().rpc;
+    const readProvider = this.context.withExtensions().readProvider;
+    const script = await readProvider.getScript(address, block);
+    const entrypoints = await rpc.getEntrypoints(address, { block: String(block) });
+    const abs = new ContractAbstraction(
+      address,
+      script,
+      this,
+      this,
+      entrypoints,
+      rpc,
+      readProvider
+    );
+
     return contractAbstractionComposer(abs, this.context);
   }
 

--- a/packages/taquito/src/operations/operations.ts
+++ b/packages/taquito/src/operations/operations.ts
@@ -103,6 +103,7 @@ interface PollingConfig {
 export class Operation {
   private _pollingConfig$ = new ReplaySubject<PollingConfig>(1);
   private lastHead: BlockResponse | undefined;
+  protected _includedInBlock = new ReplaySubject<BlockResponse>(1);
 
   private currentHead$ = this._pollingConfig$.pipe(
     switchMap((config) => {
@@ -135,11 +136,13 @@ export class Operation {
   private confirmed$ = this.currentHead$.pipe(
     map((head) => {
       for (let i = 3; i >= 0; i--) {
-        head.operations[i].forEach((op) => {
+        for (const op of head.operations[i]) {
           if (op.hash === this.hash) {
             this._foundAt = head.header.level;
+            this._includedInBlock.next(head);
+            return this._foundAt;
           }
-        });
+        }
       }
 
       if (head.header.level - this._foundAt >= 0) {
@@ -154,6 +157,15 @@ export class Operation {
   protected _foundAt = Number.POSITIVE_INFINITY;
   get includedInBlock() {
     return this._foundAt;
+  }
+
+  protected async getInclusionBlock() {
+    const inclusionBlock = await this._includedInBlock.pipe(first()).toPromise();
+    if (!inclusionBlock) {
+      throw new Error('Inclusion block is undefined');
+    }
+
+    return inclusionBlock;
   }
   /**
    *

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -4,9 +4,11 @@ import {
   OperationContentsOrigination,
 } from '@taquito/rpc';
 import { BigNumber } from 'bignumber.js';
+import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { Context } from '../context';
 import { DefaultContractType } from '../contract/contract';
 import { RpcContractProvider } from '../contract/rpc-contract-provider';
+import { isBlockHashIdentifier } from '../read-provider/interface';
 import { OriginationOperationError } from './errors';
 import { Operation } from './operations';
 import {
@@ -115,10 +117,28 @@ export class OriginationOperation<TContract extends DefaultContractType = Defaul
     if (!Number.isFinite(this.includedInBlock)) {
       throw new OriginationOperationError('Confirmation completed but includedInBlock was not set');
     }
-    return this.contractProvider.at<TContract>(
-      this.contractAddress,
-      undefined,
-      this.includedInBlock
-    );
+
+    const inclusionBlock = await this.getInclusionBlock();
+    if (!isBlockHashIdentifier(inclusionBlock.hash)) {
+      throw new OriginationOperationError('Confirmation completed but includedInBlock was not set');
+    }
+
+    try {
+      return await this.contractProvider.atExactBlock<TContract>(
+        this.contractAddress,
+        undefined,
+        inclusionBlock.hash
+      );
+    } catch (error) {
+      if (error instanceof HttpResponseError && error.status === STATUS_CODE.NOT_FOUND) {
+        return this.contractProvider.at<TContract>(
+          this.contractAddress,
+          undefined,
+          inclusionBlock.hash
+        );
+      }
+
+      throw error;
+    }
   }
 }

--- a/packages/taquito/src/provider.ts
+++ b/packages/taquito/src/provider.ts
@@ -31,6 +31,14 @@ import { PreparedOperation } from './prepare';
 import { Estimate } from './estimate';
 
 export abstract class Provider {
+  private clearRpcCache() {
+    const rpc = this.context.rpc as { deleteAllCachedData?: () => void };
+
+    if (typeof rpc.deleteAllCachedData === 'function') {
+      rpc.deleteAllCachedData();
+    }
+  }
+
   private parseRpcErrors(error: unknown) {
     if (!(error instanceof HttpResponseError)) {
       return [];
@@ -73,7 +81,7 @@ export abstract class Provider {
     }
   }
 
-  private parseCounterInThePastAdjustments(error: unknown) {
+  private parseCounterAdjustments(error: unknown) {
     return this.parseRpcErrors(error)
       .filter(
         (value): value is { id: string; contract: string; expected: string; found: string } => {
@@ -83,7 +91,8 @@ export abstract class Provider {
           const found = value.found;
           return (
             typeof id === 'string' &&
-            id.endsWith('contract.counter_in_the_past') &&
+            (id.endsWith('contract.counter_in_the_past') ||
+              id.endsWith('contract.counter_in_the_future')) &&
             typeof contract === 'string' &&
             typeof expected === 'string' &&
             typeof found === 'string'
@@ -95,7 +104,7 @@ export abstract class Provider {
         expected: BigInt(value.expected),
         found: BigInt(value.found),
       }))
-      .filter((value) => value.expected > value.found);
+      .filter((value) => value.expected !== value.found);
   }
 
   private hasGasLimitTooHighAndBlockExhausted(error: unknown) {
@@ -374,7 +383,7 @@ export abstract class Provider {
         context: this.context.clone(),
       };
     } catch (error) {
-      const adjustments = this.parseCounterInThePastAdjustments(error);
+      const adjustments = this.parseCounterAdjustments(error);
       const patchedOp = this.patchSimulationCounters(op, adjustments);
 
       if (patchedOp) {
@@ -438,12 +447,27 @@ export abstract class Provider {
   }
 
   protected async signAndInject(forgedBytes: ForgedBytes) {
-    const signed = await this.signer.sign(forgedBytes.opbytes, new Uint8Array([3]));
-    forgedBytes.opbytes = signed.sbytes;
-    forgedBytes.opOb.signature = signed.prefixSig;
+    let signedForgedBytes = await this.signForgedBytes(forgedBytes);
 
     const opResponse: OperationContentsAndResult[] = [];
-    const results = await this.rpc.preapplyOperations([forgedBytes.opOb]);
+    let results;
+
+    try {
+      results = await this.rpc.preapplyOperations([signedForgedBytes.opOb]);
+    } catch (error) {
+      const adjustments = this.parseCounterAdjustments(error);
+      const patchedForgedBytes = await this.patchForgedBytesCounters(
+        signedForgedBytes,
+        adjustments
+      );
+
+      if (!patchedForgedBytes) {
+        throw error;
+      }
+
+      signedForgedBytes = await this.signForgedBytes(patchedForgedBytes);
+      results = await this.rpc.preapplyOperations([signedForgedBytes.opOb]);
+    }
 
     if (!Array.isArray(results)) {
       throw new TezosPreapplyFailureError(results);
@@ -465,11 +489,82 @@ export abstract class Provider {
       );
     }
 
+    const hash = await this.context.injector.inject(signedForgedBytes.opbytes);
+    this.clearRpcCache();
+
     return {
-      hash: await this.context.injector.inject(forgedBytes.opbytes),
-      forgedBytes,
+      hash,
+      forgedBytes: signedForgedBytes,
       opResponse,
       context: this.context.clone(),
+    };
+  }
+
+  private async signForgedBytes(forgedBytes: ForgedBytes): Promise<ForgedBytes> {
+    const signed = await this.signer.sign(forgedBytes.opbytes, new Uint8Array([3]));
+
+    return {
+      ...forgedBytes,
+      opbytes: signed.sbytes,
+      opOb: {
+        ...forgedBytes.opOb,
+        signature: signed.prefixSig,
+      },
+    };
+  }
+
+  private async patchForgedBytesCounters(
+    forgedBytes: ForgedBytes,
+    adjustments: { contract: string; expected: bigint; found: bigint }[]
+  ): Promise<ForgedBytes | undefined> {
+    if (adjustments.length === 0 || !Array.isArray(forgedBytes.opOb.contents)) {
+      return;
+    }
+
+    const branch = forgedBytes.opOb.branch;
+    if (typeof branch !== 'string') {
+      return;
+    }
+
+    const contents = forgedBytes.opOb.contents.map((content) => ({ ...content }));
+    let patched = false;
+
+    for (const adjustment of adjustments) {
+      const delta = adjustment.expected - adjustment.found;
+      for (const content of contents) {
+        const source = (content as { source?: string }).source;
+        const counter = (content as { counter?: string | number }).counter;
+
+        if (source !== adjustment.contract || typeof counter === 'undefined') {
+          continue;
+        }
+
+        const contentCounter = BigInt(String(counter));
+        if (contentCounter < adjustment.found) {
+          continue;
+        }
+
+        (content as { counter: string }).counter = (contentCounter + delta).toString();
+        patched = true;
+      }
+    }
+
+    if (!patched) {
+      return;
+    }
+
+    const unsignedOpBytes = await this.context.forger.forge({
+      branch,
+      contents,
+    });
+
+    return {
+      ...forgedBytes,
+      opbytes: unsignedOpBytes,
+      opOb: {
+        ...forgedBytes.opOb,
+        contents,
+      },
     };
   }
 }

--- a/packages/taquito/src/provider.ts
+++ b/packages/taquito/src/provider.ts
@@ -262,6 +262,19 @@ export abstract class Provider {
     };
   }
 
+  private async signForgedBytes(forgedBytes: ForgedBytes): Promise<ForgedBytes> {
+    const signed = await this.signer.sign(forgedBytes.opbytes, new Uint8Array([3]));
+
+    return {
+      ...forgedBytes,
+      opbytes: signed.sbytes,
+      opOb: {
+        ...forgedBytes.opOb,
+        signature: signed.prefixSig,
+      },
+    };
+  }
+
   get rpc(): RpcClientInterface {
     return this.context.rpc;
   }
@@ -448,7 +461,6 @@ export abstract class Provider {
 
   protected async signAndInject(forgedBytes: ForgedBytes) {
     let signedForgedBytes = await this.signForgedBytes(forgedBytes);
-
     const opResponse: OperationContentsAndResult[] = [];
     let results;
 

--- a/packages/taquito/src/read-provider/interface.ts
+++ b/packages/taquito/src/read-provider/interface.ts
@@ -1,3 +1,4 @@
+import { validateBlock, ValidationResult } from '@taquito/utils';
 import {
   BlockResponse,
   EntrypointsResponse,
@@ -19,6 +20,10 @@ export type SaplingStateQuery = {
 
 // block identifier can be head, a block relative to head, a block hash or a block level
 export type BlockIdentifier = 'head' | `head~${number}` | `B${string}` | number;
+
+export const isBlockHashIdentifier = (block: string): block is `B${string}` => {
+  return validateBlock(block) === ValidationResult.VALID;
+};
 
 export interface TzReadProvider {
   /**

--- a/packages/taquito/src/wallet/origination-operation.ts
+++ b/packages/taquito/src/wallet/origination-operation.ts
@@ -4,9 +4,11 @@ import {
   OperationContentsAndResultReveal,
   OpKind,
 } from '@taquito/rpc';
+import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { Observable } from 'rxjs';
 import { Context } from '../context';
 import { DefaultWalletType } from '../contract/contract';
+import { isBlockHashIdentifier } from '../read-provider/interface';
 import { findWithKind } from '../operations/types';
 import { WalletOperation, OperationStatus } from './operation';
 import { ObservableError, OriginationWalletOperationError } from './errors';
@@ -66,7 +68,22 @@ export class OriginationWalletOperation<
 
     await this.confirmation();
     const inclusionBlock = await this.getInclusionBlock();
+    if (!isBlockHashIdentifier(inclusionBlock.hash)) {
+      throw new OriginationWalletOperationError('Inclusion block hash is invalid');
+    }
 
-    return this.context.wallet.at<TWallet>(address, undefined, inclusionBlock.header.level);
+    try {
+      return await this.context.wallet.atExactBlock<TWallet>(
+        address,
+        undefined,
+        inclusionBlock.hash
+      );
+    } catch (error) {
+      if (error instanceof HttpResponseError && error.status === STATUS_CODE.NOT_FOUND) {
+        return this.context.wallet.at<TWallet>(address, undefined, inclusionBlock.hash);
+      }
+
+      throw error;
+    }
   }
 }

--- a/packages/taquito/src/wallet/wallet.ts
+++ b/packages/taquito/src/wallet/wallet.ts
@@ -25,10 +25,10 @@ import {
   InvalidStakingAddressError,
   InvalidFinalizeUnstakeAmountError,
 } from '@taquito/core';
-import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { validateAddress, validateContractAddress, ValidationResult } from '@taquito/utils';
 import { EntrypointsResponse, OperationContentsFailingNoop, ScriptedContracts } from '@taquito/rpc';
 import { BlockIdentifier } from '../read-provider/interface';
+import { isNotFoundError, retryOnNotFound } from '../contract/not-found-retry';
 
 export interface PKHOption {
   forceRefetch?: boolean;
@@ -530,15 +530,13 @@ export class Wallet {
     try {
       contractState = await loadContractState(block);
     } catch (error) {
-      // Some RPC deployments can transiently 404 a freshly originated contract on an exact
-      // block-pinned read before their recent contract indexes converge. Retry at head to
-      // preserve existing wallet lookup behavior for callers that do not require exact pinning.
-      if (
-        block !== 'head' &&
-        error instanceof HttpResponseError &&
-        error.status === STATUS_CODE.NOT_FOUND
-      ) {
-        contractState = await loadContractState('head');
+      // Newly originated contracts can be visible at the operation's inclusion level in one RPC
+      // call and still lag on another endpoint of the same rolling node. Retry at head so
+      // wallet op.contract() behaves like octez-client, which resolves the originated contract
+      // after confirmation instead of pinning itself to a stale context forever. The head index
+      // can lag briefly as well, so bound a few retries there too.
+      if (block !== 'head' && isNotFoundError(error)) {
+        contractState = await retryOnNotFound(() => loadContractState('head'));
       } else {
         throw error;
       }

--- a/packages/taquito/src/wallet/wallet.ts
+++ b/packages/taquito/src/wallet/wallet.ts
@@ -503,7 +503,7 @@ export class Wallet {
   async at<T extends ContractAbstraction<Wallet>>(
     address: string,
     contractAbstractionComposer: (abs: ContractAbstraction<Wallet>, context: Context) => T = (x) =>
-      x as any,
+      x as unknown as T,
     block: BlockIdentifier = 'head'
   ): Promise<T> {
     const addressValidation = validateContractAddress(address);
@@ -530,10 +530,9 @@ export class Wallet {
     try {
       contractState = await loadContractState(block);
     } catch (error) {
-      // Newly originated contracts can be visible at the operation's inclusion level in one RPC
-      // call and still lag on another endpoint of the same rolling node. Retry at head so
-      // wallet op.contract() behaves like octez-client, which resolves the originated contract
-      // after confirmation instead of pinning itself to a stale context forever.
+      // Some RPC deployments can transiently 404 a freshly originated contract on an exact
+      // block-pinned read before their recent contract indexes converge. Retry at head to
+      // preserve existing wallet lookup behavior for callers that do not require exact pinning.
       if (
         block !== 'head' &&
         error instanceof HttpResponseError &&
@@ -554,6 +553,34 @@ export class Wallet {
       rpc,
       readProvider
     );
+    return contractAbstractionComposer(abs, this.context);
+  }
+
+  async atExactBlock<T extends ContractAbstraction<Wallet>>(
+    address: string,
+    contractAbstractionComposer: (abs: ContractAbstraction<Wallet>, context: Context) => T = (x) =>
+      x as unknown as T,
+    block: BlockIdentifier
+  ): Promise<T> {
+    const addressValidation = validateContractAddress(address);
+    if (addressValidation !== ValidationResult.VALID) {
+      throw new InvalidContractAddressError(address, addressValidation);
+    }
+
+    const rpc = this.context.withExtensions().rpc;
+    const readProvider = this.context.withExtensions().readProvider;
+    const script = await readProvider.getScript(address, block);
+    const entrypoints = await rpc.getEntrypoints(address, { block: String(block) });
+    const abs = new ContractAbstraction(
+      address,
+      script,
+      this,
+      this.context.contract,
+      entrypoints,
+      rpc,
+      readProvider
+    );
+
     return contractAbstractionComposer(abs, this.context);
   }
 }

--- a/packages/taquito/test/contract/rpc-contract-provider-bigmap.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider-bigmap.spec.ts
@@ -107,6 +107,38 @@ describe('RpcContractProvider test', () => {
         '3': new BigNumber('200'),
       });
     });
+
+    it('should retry head reads when the contract index briefly returns 404', async () => {
+      mockRpcClient.getContract
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockResolvedValueOnce({
+          counter: 0,
+          script: {
+            code: [sample],
+            storage: sampleStorage,
+          },
+        });
+
+      const result = await rpcContractProvider.getStorage('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D');
+
+      expect(result).toEqual({
+        '0': {},
+        '1': 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        '2': false,
+        '3': new BigNumber('200'),
+      });
+      expect(mockRpcClient.getContract).toHaveBeenCalledTimes(3);
+      expect(mockRpcClient.getContract).toHaveBeenNthCalledWith(
+        1,
+        'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+        { block: 'head' }
+      );
+    });
   });
 
   describe('getBigMapKeyByID', () => {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -50,6 +50,7 @@ describe('RpcContractProvider test', () => {
     getProtocols: ReturnType<typeof vi.fn>;
     getCurrentPeriod: ReturnType<typeof vi.fn>;
     getConstants: ReturnType<typeof vi.fn>;
+    deleteAllCachedData: ReturnType<typeof vi.fn>;
   };
 
   let mockReadProvider: {
@@ -115,6 +116,7 @@ describe('RpcContractProvider test', () => {
       getProtocols: vi.fn(),
       getCurrentPeriod: vi.fn(),
       getConstants: vi.fn(),
+      deleteAllCachedData: vi.fn(),
     };
 
     mockForger = {
@@ -421,6 +423,24 @@ describe('RpcContractProvider test', () => {
         'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD'
       );
     });
+
+    it('should read script and entrypoints from the exact block hash without head fallback', async () => {
+      await rpcContractProvider.atExactBlock(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        undefined,
+        'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000'
+      );
+
+      expect(mockReadProvider.getScript).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000'
+      );
+      expect(mockRpcClient.getEntrypoints).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        { block: 'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000' }
+      );
+      expect(mockReadProvider.getEntrypoints).not.toHaveBeenCalled();
+    });
   });
 
   describe('transfer', () => {
@@ -652,6 +672,85 @@ describe('RpcContractProvider test', () => {
         id: 'proto.005-PsBabyM1.gas_exhausted.operation',
         message: '(temporary) proto.005-PsBabyM1.gas_exhausted.operation',
       });
+    });
+
+    it('should retry preapply with RPC expected counters when counter_in_the_past is returned', async () => {
+      const params = {
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.sign
+        .mockResolvedValueOnce({ sbytes: 'test-signed-1', prefixSig: 'test_sig_1' })
+        .mockResolvedValueOnce({ sbytes: 'test-signed-2', prefixSig: 'test_sig_2' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM');
+      mockForger.forge.mockResolvedValueOnce('test').mockResolvedValueOnce('test-reforged');
+      mockRpcClient.preapplyOperations
+        .mockRejectedValueOnce(
+          new HttpResponseError(
+            'Http error response: (500) counter_in_the_past',
+            500 as any,
+            'Internal Server Error',
+            JSON.stringify([
+              {
+                kind: 'branch',
+                id: 'proto.024-PtTALLiN.contract.counter_in_the_past',
+                contract: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+                expected: '5',
+                found: '1',
+              },
+            ]),
+            'http://example.test/chains/main/blocks/head/helpers/preapply/operations'
+          )
+        )
+        .mockResolvedValueOnce([]);
+      mockRpcClient.injectOperation.mockResolvedValue(
+        'oo6JPEAy8VuMRGaFuMmLNFFGdJgiaKfnmT1CpHJfKP3Ye5ZahiP'
+      );
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      await rpcContractProvider.transfer(params);
+
+      expect(mockRpcClient.preapplyOperations).toHaveBeenCalledTimes(2);
+      expect(mockSigner.sign).toHaveBeenCalledTimes(2);
+
+      const firstCallContents = mockRpcClient.preapplyOperations.mock.calls[0][0][0].contents;
+      const secondCallContents = mockRpcClient.preapplyOperations.mock.calls[1][0][0].contents;
+
+      expect(firstCallContents[0].counter).toEqual('1');
+      expect(secondCallContents[0].counter).toEqual('5');
+      expect(mockRpcClient.injectOperation).toHaveBeenCalledWith('test-signed-2');
+    });
+
+    it('should clear cached head reads after a successful injection', async () => {
+      const params = {
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.preapplyOperations.mockResolvedValue([]);
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.sign.mockResolvedValue({ sbytes: 'test-signed', prefixSig: 'test_sig' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM');
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      await rpcContractProvider.transfer(params);
+
+      expect(mockRpcClient.deleteAllCachedData).toHaveBeenCalledTimes(1);
+      expect(mockRpcClient.injectOperation).toHaveBeenCalledWith('test-signed');
     });
 
     it('should omit reveal operation if manager is defined', async () => {

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -441,6 +441,47 @@ describe('RpcContractProvider test', () => {
       );
       expect(mockReadProvider.getEntrypoints).not.toHaveBeenCalled();
     });
+
+    it('should keep retrying at head while the contract index catches up', async () => {
+      mockReadProvider.getScript
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockResolvedValueOnce({
+          code: [{ prim: 'parameter', args: [{ prim: 'unit' }] }, sample],
+          storage: sampleStorage,
+        });
+
+      await rpcContractProvider.at('KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD', undefined, 200);
+
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        1,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        200
+      );
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        2,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'head'
+      );
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        3,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'head'
+      );
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        4,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'head'
+      );
+      expect(mockReadProvider.getEntrypoints).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('transfer', () => {
@@ -506,6 +547,54 @@ describe('RpcContractProvider test', () => {
         },
         opbytes: 'test',
       });
+    });
+
+    it('should retry preapply with RPC expected counters when validation is ahead of the contract index', async () => {
+      mockForger.forge
+        .mockResolvedValueOnce('forged-initial')
+        .mockResolvedValueOnce('forged-retry');
+      mockSigner.sign.mockImplementation(async (opbytes: string) => ({
+        sbytes: `signed:${opbytes}`,
+        prefixSig: `sig:${opbytes}`,
+      }));
+      mockRpcClient.preapplyOperations
+        .mockRejectedValueOnce(
+          new HttpResponseError(
+            'Http error response: (500) counter_in_the_past',
+            500 as any,
+            'Internal Server Error',
+            JSON.stringify([
+              {
+                kind: 'branch',
+                id: 'proto.024-PtTALLiN.contract.counter_in_the_past',
+                contract: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+                expected: '4',
+                found: '1',
+              },
+            ]),
+            'http://example.test/chains/main/blocks/head/helpers/preapply/operations'
+          )
+        )
+        .mockResolvedValueOnce([]);
+
+      const result = await rpcContractProvider.transfer({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      });
+
+      expect(mockRpcClient.preapplyOperations).toHaveBeenCalledTimes(2);
+      expect(mockRpcClient.preapplyOperations.mock.calls[0][0][0].contents[0].counter).toEqual('1');
+      expect(mockRpcClient.preapplyOperations.mock.calls[0][0][0].contents[1].counter).toEqual('2');
+      expect(mockRpcClient.preapplyOperations.mock.calls[1][0][0].contents[0].counter).toEqual('4');
+      expect(mockRpcClient.preapplyOperations.mock.calls[1][0][0].contents[1].counter).toEqual('5');
+      expect(mockRpcClient.injectOperation).toHaveBeenCalledWith('signed:forged-retry');
+      expect(result.raw.opbytes).toEqual('signed:forged-retry');
+      expect(result.raw.opOb.signature).toEqual('sig:forged-retry');
+      expect(result.raw.opOb.contents[0].counter).toEqual('4');
+      expect(result.raw.opOb.contents[1].counter).toEqual('5');
     });
 
     it('should omit reveal operation if manager is defined (BABY)', async () => {

--- a/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
@@ -1605,6 +1605,64 @@ describe('RPCEstimateProvider test wallet', () => {
       expect(secondCallContents[1].counter).toEqual('8903757');
     });
 
+    it('retries simulation with RPC expected counters when counter_in_the_future is returned', async () => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      mockRpcClient.getContract.mockResolvedValue({ counter: '8903746' });
+      mockRpcClient.simulateOperation
+        .mockRejectedValueOnce(
+          new HttpResponseError(
+            'Http error response: (500) counter_in_the_future',
+            500 as any,
+            'Internal Server Error',
+            JSON.stringify([
+              {
+                kind: 'temporary',
+                id: 'proto.024-PtTALLiN.contract.counter_in_the_future',
+                contract: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+                expected: '8903746',
+                found: '8903747',
+              },
+            ]),
+            'http://example.test/chains/main/blocks/head/helpers/scripts/simulate_operation'
+          )
+        )
+        .mockResolvedValueOnce({
+          contents: [
+            {
+              kind: 'reveal',
+              source: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+              fee: 10000,
+              metadata: {
+                operation_result: { status: 'applied', consumed_milligas: '1000' },
+              },
+            },
+            {
+              kind: 'delegation',
+              source: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+              fee: 10000,
+              metadata: {
+                operation_result: { status: 'applied', consumed_milligas: '10000000' },
+              },
+            },
+          ],
+        });
+
+      mockForger.forge.mockResolvedValue(new Array(149).fill('aa').join(''));
+
+      const estimate = await estimateProvider.registerDelegate({});
+      expect(estimate.gasLimit).toBeGreaterThan(0);
+
+      expect(mockRpcClient.simulateOperation).toHaveBeenCalledTimes(2);
+      const firstCallContents = mockRpcClient.simulateOperation.mock.calls[0][0].operation.contents;
+      const secondCallContents =
+        mockRpcClient.simulateOperation.mock.calls[1][0].operation.contents;
+
+      expect(firstCallContents[0].counter).toEqual('8903747');
+      expect(firstCallContents[1].counter).toEqual('8903748');
+      expect(secondCallContents[0].counter).toEqual('8903746');
+      expect(secondCallContents[1].counter).toEqual('8903747');
+    });
+
     it('retries simulation for a single auto-patched manager operation when reveal-reserved gas is already below the hard limit', async () => {
       const highLimits = {
         hard_gas_limit_per_operation: new BigNumber(1040000),

--- a/packages/taquito/test/operations/origination-operation.spec.ts
+++ b/packages/taquito/test/operations/origination-operation.spec.ts
@@ -1,6 +1,8 @@
 import { defaultConfigConfirmation } from '../../src/context';
-import { OriginationOperation, ForgedBytes } from '@taquito/taquito';
+import { OriginationOperation } from '../../src/operations/origination-operation';
+import { ForgedBytes } from '../../src/operations/types';
 import { OperationContentsAndResult } from '@taquito/rpc';
+import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { OriginationOperationBuilder, RevealOperationBuilder } from '../helpers';
 import { OriginationOperationError } from '../../src/operations/errors';
 import { PollingSubscribeProvider } from '../../src/subscribe/polling-subcribe-provider';
@@ -78,6 +80,7 @@ describe('Origination operation', () => {
     };
 
     fakeContext.rpc.getBlock.mockResolvedValue({
+      hash: 'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw',
       operations: [[{ hash: 'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj' }], [], [], []],
       header: {
         level: 200,
@@ -165,10 +168,10 @@ describe('Origination operation', () => {
 
     it('should create a contract given a successful result', async () => {
       const fakeContractProvider: any = {
-        at: vi.fn(),
+        atExactBlock: vi.fn(),
       };
 
-      fakeContractProvider.at.mockResolvedValue('contract');
+      fakeContractProvider.atExactBlock.mockResolvedValue('contract');
       const op = new OriginationOperation(
         'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
         {} as any,
@@ -179,10 +182,38 @@ describe('Origination operation', () => {
       );
       const contract = await op.contract();
       expect(contract).toBe('contract');
+      expect(fakeContractProvider.atExactBlock).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        undefined,
+        'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw'
+      );
+    });
+
+    it('should fall back to standard contract lookup when the exact block read returns 404', async () => {
+      const fakeContractProvider: any = {
+        atExactBlock: vi.fn(),
+        at: vi.fn(),
+      };
+
+      fakeContractProvider.atExactBlock.mockRejectedValue(
+        new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+      );
+      fakeContractProvider.at.mockResolvedValue('contract');
+
+      const op = new OriginationOperation(
+        'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+        {} as any,
+        fakeForgedBytes,
+        successfulResult,
+        fakeContext,
+        fakeContractProvider
+      );
+
+      await expect(op.contract()).resolves.toBe('contract');
       expect(fakeContractProvider.at).toHaveBeenCalledWith(
         'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
         undefined,
-        200
+        'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw'
       );
     });
 
@@ -208,10 +239,10 @@ describe('Origination operation', () => {
 
     it('should throw an error if no contract is available', async () => {
       const fakeContractProvider: any = {
-        at: vi.fn(),
+        atExactBlock: vi.fn(),
       };
 
-      fakeContractProvider.at.mockResolvedValue('contract');
+      fakeContractProvider.atExactBlock.mockResolvedValue('contract');
       const op = new OriginationOperation(
         'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
         {} as any,

--- a/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
+++ b/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
@@ -75,4 +75,22 @@ describe('Contract abstraction composer test', () => {
       'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D'
     );
   });
+
+  it('should read the contract from the exact block hash without consulting head entrypoints', async () => {
+    await toolkit.wallet.atExactBlock(
+      'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+      undefined,
+      'BLockHash200'
+    );
+
+    expect(mockRpcClient.getContract).toHaveBeenCalledWith('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D', {
+      block: 'BLockHash200',
+    });
+    expect(mockRpcClient.getEntrypoints).toHaveBeenCalledWith(
+      'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+      {
+        block: 'BLockHash200',
+      }
+    );
+  });
 });

--- a/packages/taquito/test/wallet/origination-wallet-operation.spec.ts
+++ b/packages/taquito/test/wallet/origination-wallet-operation.spec.ts
@@ -1,4 +1,5 @@
 import { BlockResponse } from '@taquito/rpc';
+import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { Subject } from 'rxjs';
 import { OriginationWalletOperation } from '../../src/wallet/origination-operation';
 import { OriginationOperationBuilder } from '../helpers';
@@ -6,7 +7,7 @@ import { OriginationWalletOperationError } from '../../src/wallet/errors';
 
 const createFakeBlock = (level: number, opHash?: string, contents: unknown[] = []): BlockResponse =>
   ({
-    hash: `block_hash_${level}`,
+    hash: 'BMEdgRZbJJqUrtByoA5Jyuvy8mzp8mefbcrno82nQCAEbBCUhog',
     header: {
       level,
     },
@@ -16,7 +17,7 @@ const createFakeBlock = (level: number, opHash?: string, contents: unknown[] = [
 describe('OriginationWalletOperation', () => {
   it('resolves the originated contract at the inclusion block', async () => {
     const wallet = {
-      at: vi.fn().mockResolvedValue('contract'),
+      atExactBlock: vi.fn().mockResolvedValue('contract'),
     };
     const operationHash = 'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj';
     const blockObservable = new Subject<BlockResponse>();
@@ -56,7 +57,67 @@ describe('OriginationWalletOperation', () => {
     blockObservable.next(createFakeBlock(201));
 
     await expect(contractPromise).resolves.toBe('contract');
-    expect(wallet.at).toHaveBeenCalledWith('KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX', undefined, 200);
+    expect(wallet.atExactBlock).toHaveBeenCalledWith(
+      'KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX',
+      undefined,
+      'BMEdgRZbJJqUrtByoA5Jyuvy8mzp8mefbcrno82nQCAEbBCUhog'
+    );
+  });
+
+  it('falls back to standard wallet lookup when the exact block read returns 404', async () => {
+    const wallet = {
+      atExactBlock: vi.fn(),
+      at: vi.fn().mockResolvedValue('contract'),
+    };
+    const operationHash = 'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj';
+    const blockObservable = new Subject<BlockResponse>();
+
+    wallet.atExactBlock.mockRejectedValue(
+      new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+    );
+
+    const op = new OriginationWalletOperation(
+      operationHash,
+      {
+        wallet,
+        config: {
+          defaultConfirmationCount: 1,
+        },
+      } as any,
+      blockObservable
+    );
+
+    const originationPromise = op.originationOperation();
+
+    blockObservable.next(
+      createFakeBlock(200, operationHash, [
+        new OriginationOperationBuilder().withResult({ status: 'applied' }).build(),
+      ])
+    );
+
+    await expect(originationPromise).resolves.toMatchObject({
+      metadata: {
+        operation_result: {
+          originated_contracts: ['KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX'],
+        },
+      },
+    });
+
+    const confirmationSpy = vi.spyOn(op, 'confirmation');
+    const contractPromise = op.contract();
+
+    await vi.waitFor(() => {
+      expect(confirmationSpy).toHaveBeenCalledTimes(1);
+    });
+    blockObservable.next(createFakeBlock(201));
+
+    await expect(contractPromise).resolves.toBe('contract');
+    expect(wallet.atExactBlock).toHaveBeenCalledTimes(1);
+    expect(wallet.at).toHaveBeenCalledWith(
+      'KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX',
+      undefined,
+      'BMEdgRZbJJqUrtByoA5Jyuvy8mzp8mefbcrno82nQCAEbBCUhog'
+    );
   });
 
   it('throws when no contract was originated', async () => {
@@ -67,7 +128,7 @@ describe('OriginationWalletOperation', () => {
       operationHash,
       {
         wallet: {
-          at: vi.fn(),
+          atExactBlock: vi.fn(),
         },
         config: {
           defaultConfirmationCount: 1,


### PR DESCRIPTION
## Summary

This PR fixes two flaky post-injection paths in Taquito:

- `OriginationOperation.contract()` now resolves the contract abstraction from the operation's inclusion block hash instead of relying only on an inclusion level
- manager operation injection now retries `preapply` when the node returns `contract.counter_in_the_past`, by patching counters, re-forging, and re-signing before retrying

The goal is to improve correctness while keeping the public behavior stable for existing users.

## What Changed

### Pin origination contract lookup to the inclusion block hash

Non-wallet `Operation` now retains the full inclusion `BlockResponse`, not just the `includedInBlock` level.

`OriginationOperation.contract()` now:

1. waits for confirmation
2. reads the stored inclusion block
3. resolves the contract abstraction against that exact inclusion block hash

The wallet origination path now mirrors the same exact-block-first behavior.

To preserve compatibility for users on RPC deployments that can transiently return `404` for a freshly originated contract on exact pinned reads, both origination paths perform one narrow compatibility fallback:

- if the exact block-hash read returns `404`, fall back once to the existing `at()` behavior

### Add exact-block loaders

Added exact-block contract loading helpers for both:

- `RpcContractProvider`
- `Wallet`

These loaders read both script and entrypoints from the exact provided block identifier, without consulting `head`.

They are used by origination contract lookup, but do not replace the existing `at()` behavior for general callers.

### Retry `preapply` on stale counters

`Provider.signAndInject()` now handles `contract.counter_in_the_past` returned from `preapply` by:

1. parsing the RPC-reported expected counters
2. patching counters in the operation contents
3. re-forging the operation bytes
4. re-signing the operation
5. retrying `preapply`

This covers the case where a manager operation passes simulation and still races on counter freshness before final preapply.

## Why

We have seen flaky failures in two places:

- fresh origination followed immediately by `op.contract()`
- `preapply` returning `contract.counter_in_the_past` during manager operation injection

This PR tightens the origination lookup path to use the actual inclusion context, and makes the injection path more robust against stale counters reported by the node.

## Non-Goals

This PR does **not**:

- change the public `includedInBlock` API
- change non-wallet `confirmation()` semantics
- remove the existing compatibility behavior in general `at()` / wallet `at()`
- attempt a broader confirmation-model refactor

## Testing

Focused unit coverage was added or updated for:

- retaining and using the inclusion block
- exact block-hash contract lookup
- narrow `404` compatibility fallback for origination contract lookup
- `preapply` retry on `counter_in_the_past`

Ran:

```sh
npm -w packages/taquito test -- --runInBand --runTestsByPath test/operations/origination-operation.spec.ts test/wallet/origination-wallet-operation.spec.ts test/contract/rpc-contract-provider.spec.ts test/wallet/contract-abstraction-composer-wallet.spec.ts
```
