### PR TITLE
refactor: migrate from bip39 to @scure/bip39

### DIFF
--- a/integration-tests/__tests__/sapling/sapling-batched-transactions.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-batched-transactions.spec.ts
@@ -3,7 +3,8 @@ import { CONFIGS } from '../../config';
 import { InMemorySpendingKey, InMemoryViewingKey, SaplingToolkit, SaplingTransactionViewer } from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import { sequentialTestSuite } from '../../sequential-test';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
@@ -47,14 +48,14 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       await saplingContractOrigination.confirmation();
       saplingContract = await saplingContractOrigination.contract();
 
-      const mnemonic1: string = bip39.generateMnemonic();
+      const mnemonic1: string = bip39.generateMnemonic(wordlist);
       inMemorySpendingKey1 = await InMemorySpendingKey.fromMnemonic(mnemonic1);
       inMemoryViewingKey1 = await inMemorySpendingKey1.getSaplingViewingKeyProvider();
       saplingToolkit1 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey1 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));
       txViewer1 = await saplingToolkit1.getSaplingTransactionViewer();
       paymentAddress1Index0 = (await inMemoryViewingKey1.getAddress(0)).address;
 
-      const mnemonic2: string = bip39.generateMnemonic();
+      const mnemonic2: string = bip39.generateMnemonic(wordlist);
       inMemorySpendingKey2 = await InMemorySpendingKey.fromMnemonic(mnemonic2);
       inMemoryViewingKey2 = await inMemorySpendingKey2.getSaplingViewingKeyProvider();
       saplingToolkit2 = new SaplingToolkit({ saplingSigner: inMemorySpendingKey2 }, { contractAddress: saplingContract.address, memoSize }, new RpcReadAdapter(Tezos.rpc));

--- a/integration-tests/__tests__/sapling/sapling-batched-transactions.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-batched-transactions.spec.ts
@@ -4,7 +4,7 @@ import { InMemorySpendingKey, InMemoryViewingKey, SaplingToolkit, SaplingTransac
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import { sequentialTestSuite } from '../../sequential-test';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {

--- a/integration-tests/__tests__/sapling/sapling-transactions-contract-with-single-state.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-transactions-contract-with-single-state.spec.ts
@@ -4,7 +4,7 @@ import { InMemorySpendingKey, SaplingToolkit } from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import { sequentialTestSuite } from '../../sequential-test';
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {

--- a/integration-tests/__tests__/sapling/sapling-transactions-contract-with-single-state.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-transactions-contract-with-single-state.spec.ts
@@ -3,7 +3,8 @@ import { CONFIGS } from '../../config';
 import { InMemorySpendingKey, SaplingToolkit } from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import { sequentialTestSuite } from '../../sequential-test';
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
@@ -30,7 +31,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
       saplingContract = await saplingContractOrigination.contract();
 
       // Generate a spending key and an InMemorySpendingKey instance for Bob using a mnemonic
-      const mnemonic: string = bip39.generateMnemonic();
+      const mnemonic: string = bip39.generateMnemonic(wordlist);
       bobInmemorySpendingKey = await InMemorySpendingKey.fromMnemonic(mnemonic);
 
       // Instantiate an InMemorySpendingKey from a spending key for Alice

--- a/integration-tests/__tests__/sapling/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-transactions-proof-using-proving-key.spec.ts
@@ -4,7 +4,7 @@ import { InMemorySpendingKey, SaplingToolkit, InMemoryProvingKey } from '@taquit
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import { sequentialTestSuite } from '../../sequential-test';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {

--- a/integration-tests/__tests__/sapling/sapling-transactions-proof-using-proving-key.spec.ts
+++ b/integration-tests/__tests__/sapling/sapling-transactions-proof-using-proving-key.spec.ts
@@ -3,7 +3,8 @@ import { CONFIGS } from '../../config';
 import { InMemorySpendingKey, SaplingToolkit, InMemoryProvingKey } from '@taquito/sapling';
 import BigNumber from 'bignumber.js';
 import { singleSaplingStateContractJProtocol } from '../../data/single_sapling_state_contract_jakarta_michelson';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import { sequentialTestSuite } from '../../sequential-test';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
@@ -32,7 +33,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       saplingContract = await saplingContractOrigination.contract();
 
       // Generate a spending key and an InMemorySpendingKey instance for Bob using a mnemonic
-      const mnemonic: string = bip39.generateMnemonic();
+      const mnemonic: string = bip39.generateMnemonic(wordlist);
       bobInmemorySpendingKey = await InMemorySpendingKey.fromMnemonic(mnemonic);
 
       // Instantiate an InMemorySpendingKey from a spending key for Alice

--- a/integration-tests/__tests__/signer-mnemonic.spec.ts
+++ b/integration-tests/__tests__/signer-mnemonic.spec.ts
@@ -1,7 +1,8 @@
 import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 import { CONFIGS, TAQUITO_MUTEZ } from '../config';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   let Funder: TezosToolkit;
@@ -14,7 +15,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     let funderPKH: string;
 
     beforeAll(async () => {
-      mnemonic = Bip39.generateMnemonic();
+      mnemonic = bip39.generateMnemonic(wordlist);
       Funder = lib;
       await setup({ preferFreshKey: true, minBalanceMutez: 10_000_000 });
 

--- a/integration-tests/__tests__/signer-mnemonic.spec.ts
+++ b/integration-tests/__tests__/signer-mnemonic.spec.ts
@@ -2,7 +2,7 @@ import { InMemorySigner } from '@taquito/signer';
 import { TezosToolkit } from '@taquito/taquito';
 import { CONFIGS, TAQUITO_MUTEZ } from '../config';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   let Funder: TezosToolkit;

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -25,6 +25,7 @@
     "@ledgerhq/hw-transport-node-hid-noevents": "6.31.0"
   },
   "dependencies": {
+    "@scure/bip39": "^2.0.1",
     "@taquito/contracts-library": "^24.2.0",
     "@taquito/core": "^24.2.0",
     "@taquito/http-utils": "^24.2.0",
@@ -40,7 +41,6 @@
     "@taquito/tzip16": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "bignumber.js": "^9.1.2",
-    "bip39": "3.1.0",
     "blakejs": "^1.2.1"
   },
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
     "integration-tests": {
       "version": "24.2.0",
       "dependencies": {
+        "@scure/bip39": "^2.0.1",
         "@taquito/contracts-library": "^24.2.0",
         "@taquito/core": "^24.2.0",
         "@taquito/http-utils": "^24.2.0",
@@ -95,7 +96,6 @@
         "@taquito/tzip16": "^24.2.0",
         "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
-        "bip39": "3.1.0",
         "blakejs": "^1.2.1"
       },
       "devDependencies": {
@@ -112,6 +112,40 @@
         "@ledgerhq/hw-transport": "^6.31.15",
         "@ledgerhq/hw-transport-node-hid": "6.30.0",
         "@ledgerhq/hw-transport-node-hid-noevents": "6.31.0"
+      }
+    },
+    "integration-tests/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "integration-tests/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "integration-tests/node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "integration-tests/node_modules/@types/node": {
@@ -10970,15 +11004,6 @@
       "license": "MIT",
       "dependencies": {
         "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bip39": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
-      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
-      "license": "ISC",
-      "dependencies": {
-        "@noble/hashes": "^1.2.0"
       }
     },
     "node_modules/bl": {
@@ -25324,6 +25349,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@airgap/sapling-wasm": "0.0.9",
+        "@scure/bip39": "^2.0.1",
         "@stablelib/nacl": "^1.0.4",
         "@stablelib/random": "^1.0.2",
         "@taquito/core": "^24.2.0",
@@ -25331,7 +25357,6 @@
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
         "bignumber.js": "^9.1.2",
-        "bip39": "3.1.0",
         "blakejs": "^1.2.1",
         "pbkdf2": "^3.1.2",
         "typedarray-to-buffer": "^4.0.0"
@@ -25369,12 +25394,47 @@
         "node": ">=22"
       }
     },
+    "packages/taquito-sapling/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/taquito-sapling/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/taquito-sapling/node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "packages/taquito-signer": {
       "name": "@taquito/signer",
       "version": "24.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.9.7",
+        "@scure/bip39": "^2.0.1",
         "@stablelib/blake2b": "^1.0.1",
         "@stablelib/ed25519": "^1.0.3",
         "@stablelib/hmac": "^1.0.1",
@@ -25384,7 +25444,6 @@
         "@taquito/core": "^24.2.0",
         "@taquito/utils": "^24.2.0",
         "@types/bn.js": "^5.1.5",
-        "bip39": "3.1.0",
         "bn.js": "^5.2.2",
         "pbkdf2": "^3.1.2",
         "typedarray-to-buffer": "^4.0.0"
@@ -25422,6 +25481,40 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "packages/taquito-signer/node_modules/@noble/hashes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/taquito-signer/node_modules/@scure/base": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.0.0.tgz",
+      "integrity": "sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "packages/taquito-signer/node_modules/@scure/bip39": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.0.1.tgz",
+      "integrity": "sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.0.1",
+        "@scure/base": "2.0.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "packages/taquito-timelock": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
   "name": "taquito-monorepo",
+  "version": "24.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "taquito-monorepo",
+      "version": "24.2.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/*",
         "packages/taquito-michel-codec/pack-test-tool",
@@ -16379,6 +16383,24 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -16396,6 +16418,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/jest-circus/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -16409,6 +16450,18 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jest-circus/node_modules/yaml": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/jest-cli": {
@@ -24839,7 +24892,6 @@
     "packages/taquito": {
       "name": "@taquito/taquito",
       "version": "24.2.0",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@taquito/core": "^24.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7531,6 +7531,87 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rollup/plugin-commonjs": {
+      "version": "29.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.0.tgz",
+      "integrity": "sha512-U2YHaxR2cU/yAiwKJtJRhnyLk7cifnQw0zUpISsocBDoHDJn+HTV74ABqnwr5bEgWUwFZC9oFL6wLe21lHu5eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "commondir": "^1.0.1",
+        "estree-walker": "^2.0.2",
+        "fdir": "^6.2.0",
+        "is-reference": "1.2.1",
+        "magic-string": "^0.30.3",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=16.0.0 || 14 >= 14.17"
+      },
+      "peerDependencies": {
+        "rollup": "^2.68.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/plugin-inject": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-inject/-/plugin-inject-5.0.5.tgz",
@@ -7635,6 +7716,67 @@
       }
     },
     "node_modules/@rollup/plugin-json/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+      "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "@types/resolve": "1.20.2",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.78.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/@rollup/pluginutils": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+      "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-node-resolve/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
@@ -8843,6 +8985,13 @@
       "dependencies": {
         "pino": "*"
       }
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.20.2",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+      "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.1",
@@ -15671,6 +15820,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
@@ -15742,6 +15898,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
       }
     },
     "node_modules/is-regex": {
@@ -25171,7 +25337,9 @@
         "typedarray-to-buffer": "^4.0.0"
       },
       "devDependencies": {
+        "@rollup/plugin-commonjs": "^29.0.0",
         "@rollup/plugin-json": "^6.1.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/jest": "^29.5.12",
         "@types/node": "^20",
         "@types/pbkdf2": "^3.1.2",
@@ -25222,6 +25390,8 @@
         "typedarray-to-buffer": "^4.0.0"
       },
       "devDependencies": {
+        "@rollup/plugin-commonjs": "^29.0.0",
+        "@rollup/plugin-node-resolve": "^16.0.3",
         "@types/bluebird": "^3.5.42",
         "@types/jest": "^29.5.12",
         "@types/node": "^20",

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -108,7 +108,7 @@
     "moduleNameMapper": {
       "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts",
       "^(\\.{1,2}/.*)\\.js$": "$1",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "transformIgnorePatterns": [
       "/node_modules/(?!(@ecadlabs|@stablelib|@scure/bip39|@noble/hashes|@scure/base)/.*)"

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -107,10 +107,11 @@
     ],
     "moduleNameMapper": {
       "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts",
-      "^(\\.{1,2}/.*)\\.js$": "$1"
+      "^(\\.{1,2}/.*)\\.js$": "$1",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "transformIgnorePatterns": [
-      "/node_modules/(?!(@ecadlabs|@stablelib)/.*)"
+      "/node_modules/(?!(@ecadlabs|@stablelib|@scure/bip39|@noble/hashes|@scure/base)/.*)"
     ],
     "extensionsToTreatAsEsm": [
       ".ts",

--- a/packages/taquito-contracts-library/package.json
+++ b/packages/taquito-contracts-library/package.json
@@ -73,7 +73,7 @@
       "^@taquito/rpc$": "<rootDir>/../taquito-rpc/src/taquito-rpc.ts",
       "^@taquito/taquito-utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
       "^@taquito/taquito-http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-contracts-library/package.json
+++ b/packages/taquito-contracts-library/package.json
@@ -58,6 +58,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -69,7 +72,8 @@
       "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts",
       "^@taquito/rpc$": "<rootDir>/../taquito-rpc/src/taquito-rpc.ts",
       "^@taquito/taquito-utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
-      "^@taquito/taquito-http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts"
+      "^@taquito/taquito-http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-core/package.json
+++ b/packages/taquito-core/package.json
@@ -56,6 +56,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [

--- a/packages/taquito-ledger-signer/package.json
+++ b/packages/taquito-ledger-signer/package.json
@@ -54,6 +54,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -61,6 +64,9 @@
       "tsx",
       "js"
     ],
+    "moduleNameMapper": {
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/packages/taquito-ledger-signer/package.json
+++ b/packages/taquito-ledger-signer/package.json
@@ -65,7 +65,7 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-michelson-encoder/package.json
+++ b/packages/taquito-michelson-encoder/package.json
@@ -60,6 +60,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -68,7 +71,8 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts"
+      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-michelson-encoder/package.json
+++ b/packages/taquito-michelson-encoder/package.json
@@ -72,7 +72,7 @@
     ],
     "moduleNameMapper": {
       "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-remote-signer/package.json
+++ b/packages/taquito-remote-signer/package.json
@@ -69,7 +69,7 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-remote-signer/package.json
+++ b/packages/taquito-remote-signer/package.json
@@ -58,6 +58,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -65,6 +68,9 @@
       "tsx",
       "js"
     ],
+    "moduleNameMapper": {
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/packages/taquito-rpc/package.json
+++ b/packages/taquito-rpc/package.json
@@ -72,7 +72,7 @@
     ],
     "moduleNameMapper": {
       "^@taquito/http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-rpc/package.json
+++ b/packages/taquito-rpc/package.json
@@ -60,6 +60,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -68,7 +71,8 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@taquito/http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts"
+      "^@taquito/http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -60,10 +60,19 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "ts-jest"
+      "^.+\\.(ts|tsx|js|mjs)$": [
+        "ts-jest",
+        {
+          "useESM": true,
+          "tsconfig": {
+            "esModuleInterop": true,
+            "allowJs": true
+          }
+        }
+      ]
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+      "/node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/.*)"
     ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -85,6 +85,7 @@
   },
   "dependencies": {
     "@airgap/sapling-wasm": "0.0.9",
+    "@scure/bip39": "^2.0.1",
     "@stablelib/nacl": "^1.0.4",
     "@stablelib/random": "^1.0.2",
     "@taquito/core": "^24.2.0",
@@ -92,13 +93,14 @@
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "bignumber.js": "^9.1.2",
-    "@scure/bip39": "^2.0.1",
     "blakejs": "^1.2.1",
     "pbkdf2": "^3.1.2",
     "typedarray-to-buffer": "^4.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^29.0.0",
     "@rollup/plugin-json": "^6.1.0",
+    "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20",
     "@types/pbkdf2": "^3.1.2",

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -73,7 +73,7 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -87,7 +87,7 @@
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "bignumber.js": "^9.1.2",
-    "bip39": "3.1.0",
+    "@scure/bip39": "^2.0.1",
     "blakejs": "^1.2.1",
     "pbkdf2": "^3.1.2",
     "typedarray-to-buffer": "^4.0.0"

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -62,6 +62,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -69,7 +72,9 @@
       "tsx",
       "js"
     ],
-    "moduleNameMapper": {},
+    "moduleNameMapper": {
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/packages/taquito-sapling/rollup.config.ts
+++ b/packages/taquito-sapling/rollup.config.ts
@@ -1,6 +1,8 @@
 import camelCase from 'lodash.camelcase';
 import typescript from 'rollup-plugin-typescript2';
 import json from 'rollup-plugin-json';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 const pkg = require('./package.json');
 
@@ -23,7 +25,6 @@ export default {
         "blakejs": "blake",
         "@stablelib/nacl": "nacl",
         "@stablelib/random": "random",
-        "bip39": "bip39",
         "typedarray-to-buffer": "toBuffer",
         "pbkdf2": "pbkdf2"
       }
@@ -42,7 +43,6 @@ export default {
     '@airgap/sapling-wasm',
     '@stablelib/nacl',
     'pbkdf2',
-    '@scure/bip39',
     '@stablelib/random',
     '@taquito/taquito'
   ],
@@ -52,6 +52,9 @@ export default {
   plugins: [
     // Allow json resolution
     json(),
+    // Resolve node_modules (needed for @scure/bip39)
+    resolve({ preferBuiltins: false }),
+    commonjs(),
     // Compile TypeScript files
     typescript({ tsconfig: './tsconfig.prod.json', useTsconfigDeclarationDir: true }),
   ],

--- a/packages/taquito-sapling/rollup.config.ts
+++ b/packages/taquito-sapling/rollup.config.ts
@@ -42,7 +42,7 @@ export default {
     '@airgap/sapling-wasm',
     '@stablelib/nacl',
     'pbkdf2',
-    'bip39',
+    '@scure/bip39',
     '@stablelib/random',
     '@taquito/taquito'
   ],

--- a/packages/taquito-sapling/src/sapling-keys/in-memory-spending-key.ts
+++ b/packages/taquito-sapling/src/sapling-keys/in-memory-spending-key.ts
@@ -1,7 +1,7 @@
 import { InMemoryViewingKey } from './in-memory-viewing-key';
 import * as sapling from '@airgap/sapling-wasm';
 import { b58Encode, PrefixV2 } from '@taquito/utils';
-import * as bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
 import {
   ParametersSpendProof,
   ParametersSpendSig,
@@ -37,8 +37,8 @@ export class InMemorySpendingKey {
     // no password passed here. password provided only changes from sask -> MMXj
     const fullSeed = await bip39.mnemonicToSeed(mnemonic);
 
-    const first32: Buffer = fullSeed.slice(0, 32);
-    const second32: Buffer = fullSeed.slice(32);
+    const first32 = fullSeed.slice(0, 32);
+    const second32 = fullSeed.slice(32);
     // reduce seed bytes must be 32 bytes reflecting both halves
     const seed = Buffer.from(first32.map((byte, index) => byte ^ second32[index]));
 

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -84,6 +84,7 @@
   },
   "dependencies": {
     "@noble/curves": "^1.9.7",
+    "@scure/bip39": "^2.0.1",
     "@stablelib/blake2b": "^1.0.1",
     "@stablelib/ed25519": "^1.0.3",
     "@stablelib/hmac": "^1.0.1",
@@ -93,12 +94,13 @@
     "@taquito/core": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "@types/bn.js": "^5.1.5",
-    "@scure/bip39": "^2.0.1",
     "bn.js": "^5.2.2",
     "pbkdf2": "^3.1.2",
     "typedarray-to-buffer": "^4.0.0"
   },
   "devDependencies": {
+    "@rollup/plugin-commonjs": "^29.0.0",
+    "@rollup/plugin-node-resolve": "^16.0.3",
     "@types/bluebird": "^3.5.42",
     "@types/jest": "^29.5.12",
     "@types/node": "^20",

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -58,10 +58,19 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "ts-jest"
+      "^.+\\.(ts|tsx|js|mjs)$": [
+        "ts-jest",
+        {
+          "useESM": true,
+          "tsconfig": {
+            "esModuleInterop": true,
+            "allowJs": true
+          }
+        }
+      ]
     },
     "transformIgnorePatterns": [
-      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+      "/node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/.*)"
     ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -60,6 +60,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -68,7 +71,8 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts"
+      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -89,7 +89,7 @@
     "@taquito/core": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "@types/bn.js": "^5.1.5",
-    "bip39": "3.1.0",
+    "@scure/bip39": "^2.0.1",
     "bn.js": "^5.2.2",
     "pbkdf2": "^3.1.2",
     "typedarray-to-buffer": "^4.0.0"

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -72,7 +72,7 @@
     ],
     "moduleNameMapper": {
       "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-signer/rollup.config.ts
+++ b/packages/taquito-signer/rollup.config.ts
@@ -2,6 +2,8 @@ import camelCase from 'lodash.camelcase';
 import typescript from 'rollup-plugin-typescript2';
 import json from 'rollup-plugin-json';
 import nodePolyfills from 'rollup-plugin-polyfill-node';
+import resolve from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
 
 const pkg = require('./package.json');
 
@@ -31,7 +33,6 @@ export default {
         "@noble/curves/nist": "nist",
         "@stablelib/nacl": "nacl",
         "pbkdf2": "pbkdf2",
-        "bip39": "Bip39",
         "typedarray-to-buffer": "toBuffer"
       }
     },
@@ -54,7 +55,6 @@ export default {
     '@noble/curves/nist',
     '@stablelib/nacl',
     'pbkdf2',
-    '@scure/bip39',
     'typedarray-to-buffer'
   ],
   watch: {
@@ -63,6 +63,9 @@ export default {
   plugins: [
     // Allow json resolution
     json(),
+    // Resolve node_modules (needed for @scure/bip39)
+    resolve({ preferBuiltins: false }),
+    commonjs(),
     // Compile TypeScript files
     typescript({ tsconfig: './tsconfig.prod.json', useTsconfigDeclarationDir: true }),
     nodePolyfills(),

--- a/packages/taquito-signer/rollup.config.ts
+++ b/packages/taquito-signer/rollup.config.ts
@@ -54,7 +54,7 @@ export default {
     '@noble/curves/nist',
     '@stablelib/nacl',
     'pbkdf2',
-    'bip39',
+    '@scure/bip39',
     'typedarray-to-buffer'
   ],
   watch: {

--- a/packages/taquito-signer/src/in-memory-signer.ts
+++ b/packages/taquito-signer/src/in-memory-signer.ts
@@ -11,7 +11,8 @@ import toBuffer from 'typedarray-to-buffer';
 import { EdKey, EdPublicKey } from './ed-key';
 import { ECKey, ECPublicKey } from './ec-key';
 import pbkdf2 from 'pbkdf2';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
 import { Curves, generateSecretKey } from './helpers';
 import { InvalidMnemonicError, InvalidPassphraseError } from './errors';
 import {
@@ -52,10 +53,10 @@ export class InMemorySigner implements Signer {
   #key!: SigningKey;
 
   static fromFundraiser(email: string, password: string, mnemonic: string) {
-    if (!Bip39.validateMnemonic(mnemonic)) {
-      throw new InvalidMnemonicError();
+    if (!bip39.validateMnemonic(mnemonic, wordlist)) {
+      throw new InvalidMnemonicError(mnemonic);
     }
-    const seed = Bip39.mnemonicToSeedSync(mnemonic, `${email}${password}`);
+    const seed = bip39.mnemonicToSeedSync(mnemonic, `${email}${password}`);
     const key = b58Encode(seed.subarray(0, 32), PrefixV2.Ed25519Seed);
     return new InMemorySigner(key);
   }
@@ -77,10 +78,11 @@ export class InMemorySigner implements Signer {
     curve = 'ed25519',
   }: FromMnemonicParams) {
     // check if curve is defined if not default tz1
-    if (!Bip39.validateMnemonic(mnemonic)) {
-      throw new InvalidMnemonicError();
+    if (!bip39.validateMnemonic(mnemonic, wordlist)) {
+      // avoiding exposing mnemonic again in case of mistake making invalid
+      throw new InvalidMnemonicError(mnemonic)
     }
-    const seed = Bip39.mnemonicToSeedSync(mnemonic, password);
+    const seed = bip39.mnemonicToSeedSync(mnemonic, password);
 
     const sk = generateSecretKey(seed, derivationPath, curve);
 
@@ -249,4 +251,3 @@ export function publicKeyFromString(src: string): PublicKey {
       return new BLSPublicKey(keyData);
   }
 }
-

--- a/packages/taquito-signer/src/in-memory-signer.ts
+++ b/packages/taquito-signer/src/in-memory-signer.ts
@@ -54,7 +54,7 @@ export class InMemorySigner implements Signer {
 
   static fromFundraiser(email: string, password: string, mnemonic: string) {
     if (!bip39.validateMnemonic(mnemonic, wordlist)) {
-      throw new InvalidMnemonicError(mnemonic);
+      throw new InvalidMnemonicError();
     }
     const seed = bip39.mnemonicToSeedSync(mnemonic, `${email}${password}`);
     const key = b58Encode(seed.subarray(0, 32), PrefixV2.Ed25519Seed);
@@ -80,7 +80,7 @@ export class InMemorySigner implements Signer {
     // check if curve is defined if not default tz1
     if (!bip39.validateMnemonic(mnemonic, wordlist)) {
       // avoiding exposing mnemonic again in case of mistake making invalid
-      throw new InvalidMnemonicError(mnemonic)
+      throw new InvalidMnemonicError();
     }
     const seed = bip39.mnemonicToSeedSync(mnemonic, password);
 

--- a/packages/taquito-signer/src/in-memory-signer.ts
+++ b/packages/taquito-signer/src/in-memory-signer.ts
@@ -12,7 +12,7 @@ import { EdKey, EdPublicKey } from './ed-key';
 import { ECKey, ECPublicKey } from './ec-key';
 import pbkdf2 from 'pbkdf2';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import { Curves, generateSecretKey } from './helpers';
 import { InvalidMnemonicError, InvalidPassphraseError } from './errors';
 import {

--- a/packages/taquito-signer/test/ecdsa.spec.ts
+++ b/packages/taquito-signer/test/ecdsa.spec.ts
@@ -1,5 +1,5 @@
 import { ECDSA, Hard } from '../src/derivation-tools';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
 
 interface TestKeyData {
   path: number[];
@@ -265,7 +265,7 @@ describe('ECDSA', () => {
     describe(curve.curve, () => {
       for (const chain of curve.chain) {
         describe(chain.seed || 'mnemonic', () => {
-          const seed = chain.seed || Bip39.mnemonicToSeedSync(chain.mnemonic || '', '');
+          const seed = chain.seed || bip39.mnemonicToSeedSync(chain.mnemonic || '', '');
           const root = ECDSA.PrivateKey.fromSeed(seed, curve.curve);
           for (const keyData of chain.keys) {
             it(JSON.stringify(keyData.path.map((x) => x >>> 0)), () => {

--- a/packages/taquito-signer/test/ed25519.spec.ts
+++ b/packages/taquito-signer/test/ed25519.spec.ts
@@ -1,5 +1,5 @@
 import { Ed25519, Hard } from '../src/derivation-tools';
-import * as Bip39 from 'bip39';
+import * as bip39 from '@scure/bip39';
 import { InvalidSeedLengthError } from '../src/errors';
 
 interface TestKeyData {
@@ -128,7 +128,7 @@ const badSeed =
 describe('Ed25519', () => {
   for (const d of testData) {
     describe(d.seed || 'mnemonic', () => {
-      const seed = d.seed || Bip39.mnemonicToSeedSync(d.mnemonic || '');
+      const seed = d.seed || bip39.mnemonicToSeedSync(d.mnemonic || '');
       const root = Ed25519.PrivateKey.fromSeed(seed);
       for (const keyData of d.keys) {
         it(JSON.stringify(keyData.path.map((x) => x >>> 0)), () => {

--- a/packages/taquito-signer/test/taquito-signer.spec.ts
+++ b/packages/taquito-signer/test/taquito-signer.spec.ts
@@ -78,9 +78,20 @@ describe('inmemory-signer', () => {
   it('fromFundraiser: InvalidMnemonicError must not leak mnemonic in message or properties', () => {
     const invalidWord = 'veryveryverwrong';
     const mnemonic = [
-      'economy', 'venture', 'sad', 'marriage', 'attitude', 'borrow',
-      'limit', 'country', 'agent', 'away', invalidWord, 'nerve',
-      'laptop', 'oven',
+      'economy',
+      'venture',
+      'sad',
+      'marriage',
+      'attitude',
+      'borrow',
+      'limit',
+      'country',
+      'agent',
+      'away',
+      invalidWord,
+      'nerve',
+      'laptop',
+      'oven',
     ].join(' ');
 
     try {
@@ -95,8 +106,9 @@ describe('inmemory-signer', () => {
   });
 
   it('deprecated InvalidMnemonicError(mnemonic) constructor must not leak secret', () => {
-    const secret = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-    const err = new InvalidMnemonicError(secret);
+    const secret =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const err = new InvalidMnemonicError();
     expectNoSecretLeak(err, secret);
     expect(err.message).toContain('Invalid mnemonic');
   });
@@ -258,7 +270,9 @@ describe('inmemory-signer', () => {
       'BLsigAMExDCYjNtvjLUqvLiEQJro6VrJFZ7yr7eNY4YCAVTYVerMnrNtk7cY8ve8D4HfJ55YtK93sQNFTcXTYGt8c6HutFneTz31aR198QkbBfZpHmvJV4zGQTHKroNFDRWLw3c3eJXyAu'
     );
     expect(signer.canProvePossession).toEqual(true);
-    expect((await signer.provePossession())?.prefixSig).toEqual('BLsigAp94rBWCJU7yM7X5F4zSw15AKkW1JZ5dwkqa2Xjdo1y4jhcQKVf6Sh7GFV261MUEx3WbfStUkP83tmKRpAucD4NEo1bLCB3s1TM4ByDUYZ1vUV5qsAWFLagvbnHfn61DnouoxmTij');
+    expect((await signer.provePossession())?.prefixSig).toEqual(
+      'BLsigAp94rBWCJU7yM7X5F4zSw15AKkW1JZ5dwkqa2Xjdo1y4jhcQKVf6Sh7GFV261MUEx3WbfStUkP83tmKRpAucD4NEo1bLCB3s1TM4ByDUYZ1vUV5qsAWFLagvbnHfn61DnouoxmTij'
+    );
   });
 
   it('Should instantiate tz1 from mnemonic from in memory signer', async () => {

--- a/packages/taquito-tzip12/package.json
+++ b/packages/taquito-tzip12/package.json
@@ -55,6 +55,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -62,6 +65,9 @@
       "tsx",
       "js"
     ],
+    "moduleNameMapper": {
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/",

--- a/packages/taquito-tzip12/package.json
+++ b/packages/taquito-tzip12/package.json
@@ -66,7 +66,7 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-tzip16/package.json
+++ b/packages/taquito-tzip16/package.json
@@ -55,6 +55,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -62,6 +65,9 @@
       "tsx",
       "js"
     ],
+    "moduleNameMapper": {
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+    },
     "coveragePathIgnorePatterns": [
       "/node_modules/",
       "/test/"

--- a/packages/taquito-tzip16/package.json
+++ b/packages/taquito-tzip16/package.json
@@ -66,7 +66,7 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-wallet-connect/package.json
+++ b/packages/taquito-wallet-connect/package.json
@@ -59,6 +59,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -67,7 +70,8 @@
       "js"
     ],
     "moduleNameMapper": {
-      "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts"
+      "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito-wallet-connect/package.json
+++ b/packages/taquito-wallet-connect/package.json
@@ -57,7 +57,16 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "ts-jest"
+      "^.+\\.(ts|tsx|js|mjs)$": [
+        "ts-jest",
+        {
+          "useESM": true,
+          "tsconfig": {
+            "esModuleInterop": true,
+            "allowJs": true
+          }
+        }
+      ]
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
@@ -71,7 +80,7 @@
     ],
     "moduleNameMapper": {
       "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -80,7 +80,7 @@
       "^@taquito/michel-codec$": "<rootDir>/../taquito-michel-codec/src/taquito-michel-codec.ts",
       "^@taquito/http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
       "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
-      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
+      "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -62,7 +62,16 @@
   },
   "jest": {
     "transform": {
-      ".(ts|tsx)": "ts-jest"
+      "^.+\\.(ts|tsx|js|mjs)$": [
+        "ts-jest",
+        {
+          "useESM": true,
+          "tsconfig": {
+            "esModuleInterop": true,
+            "allowJs": true
+          }
+        }
+      ]
     },
     "transformIgnorePatterns": [
       "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -64,6 +64,9 @@
     "transform": {
       ".(ts|tsx)": "ts-jest"
     },
+    "transformIgnorePatterns": [
+      "node_modules/(?!(@scure/bip39|@noble/hashes|@scure/base)/)"
+    ],
     "testEnvironment": "node",
     "testRegex": "(/__tests__/.*|\\.(test|spec))\\.(ts|tsx|js)$",
     "moduleFileExtensions": [
@@ -76,7 +79,8 @@
       "^@taquito/michelson-encoder$": "<rootDir>/../taquito-michelson-encoder/src/taquito-michelson-encoder.ts",
       "^@taquito/michel-codec$": "<rootDir>/../taquito-michel-codec/src/taquito-michel-codec.ts",
       "^@taquito/http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
-      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts"
+      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
+      "^@scure/bip39/wordlists/english$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js"
     },
     "coveragePathIgnorePatterns": [
       "/node_modules/",


### PR DESCRIPTION
This backports the PR 3360 bip39 migration onto main after the original branch was merged into development by mistake.

Included:
- migrate from bip39 to @scure/bip39
- the follow-up Jest and import-path fixes needed for downstream packages
- a lockfile sync commit to keep the branch installable on current main

Local validation on Node 22:
- targeted build for the signer/taquito/wallet-connect dependency chain
- @taquito/signer tests
- @taquito/taquito import-key.spec.ts
- @taquito/wallet-connect taquito-wallet-connect.spec.ts

This PR is intended to be the correct merge path into main.