### PR TITLE
fix(beacon-wallet): remove Papers relay defaults

### DIFF
--- a/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
+++ b/packages/taquito-beacon-wallet/src/taquito-beacon-wallet.ts
@@ -50,29 +50,18 @@ export type { DAppClientOptions } from '@ecadlabs/beacon-dapp';
 /**
  * Default matrix relay nodes curated by Taquito.
  *
- * Includes only nodes operated by Papers and Trilitech running the latest
- * Synapse version. These replace the Beacon SDK built-in defaults so that
- * Taquito controls which relay infrastructure its users hit.
+ * Includes only Trilitech-operated `octez.io` nodes. These replace the Beacon
+ * SDK built-in defaults so that Taquito controls which relay infrastructure
+ * its users hit.
  *
- * The geographically distributed Papers nodes (NA-East, NA-West, Asia-East,
- * Australia) have been decommissioned by Papers, so those regions are emptied
- * to prevent connection attempts to dead servers.
+ * Non-European regions are intentionally empty because Taquito no longer
+ * curates Papers-operated relay nodes for those regions.
  *
  * Users can still override specific regions (or the entire list) by passing
  * their own `matrixNodes` in the BeaconWallet constructor options.
  */
 const TAQUITO_CURATED_MATRIX_NODES: NodeDistributions = {
   [Regions.EUROPE_WEST]: [
-    // Papers
-    'beacon-node-1.diamond.papers.tech',
-    'beacon-node-1.sky.papers.tech',
-    'beacon-node-2.sky.papers.tech',
-    'beacon-node-1.hope.papers.tech',
-    'beacon-node-1.hope-2.papers.tech',
-    'beacon-node-1.hope-3.papers.tech',
-    'beacon-node-1.hope-4.papers.tech',
-    'beacon-node-1.hope-5.papers.tech',
-    // Trilitech
     'beacon-node-1.octez.io',
     'beacon-node-2.octez.io',
     'beacon-node-3.octez.io',
@@ -82,7 +71,7 @@ const TAQUITO_CURATED_MATRIX_NODES: NodeDistributions = {
     'beacon-node-7.octez.io',
     'beacon-node-8.octez.io',
   ],
-  // Decommissioned by Papers; emptied to prevent connections to dead servers
+  // Left empty so Taquito does not point users at soon-to-be-retired Papers relays
   [Regions.NORTH_AMERICA_EAST]: [],
   [Regions.NORTH_AMERICA_WEST]: [],
   [Regions.ASIA_EAST]: [],
@@ -275,7 +264,9 @@ export class BeaconWallet implements WalletProvider {
     );
   }
 
-  async mapRegisterGlobalConstantParamsToWalletParams(params: () => Promise<WalletRegisterGlobalConstantParams>) {
+  async mapRegisterGlobalConstantParamsToWalletParams(
+    params: () => Promise<WalletRegisterGlobalConstantParams>
+  ) {
     let walletParams: WalletRegisterGlobalConstantParams;
     await this.client.showPrepare();
     try {

--- a/packages/taquito-beacon-wallet/test/taquito-beacon-wallet.spec.ts
+++ b/packages/taquito-beacon-wallet/test/taquito-beacon-wallet.spec.ts
@@ -4,7 +4,13 @@ import {
   MissingRequiredScopes,
 } from '../src/taquito-beacon-wallet';
 import LocalStorageMock from './mock-local-storage';
-import { PermissionScope, LocalStorage, SigningType } from '@ecadlabs/beacon-dapp';
+import {
+  PermissionScope,
+  LocalStorage,
+  SigningType,
+  getDAppClientInstance,
+  Regions,
+} from '@ecadlabs/beacon-dapp';
 import { indexedDB } from 'fake-indexeddb';
 global.localStorage = new LocalStorageMock();
 global.indexedDB = indexedDB;
@@ -17,6 +23,20 @@ jest.mock('@stablelib/random', () => ({
     randomBytes: (n: number) => new Uint8Array(n).fill(1),
   })),
 }));
+
+jest.mock('@ecadlabs/beacon-dapp', () => {
+  const originalModule = jest.requireActual('@ecadlabs/beacon-dapp');
+
+  return {
+    ...originalModule,
+    getDAppClientInstance: jest.fn().mockImplementation(() => ({
+      requestPermissions: jest.fn(),
+      getActiveAccount: jest.fn(),
+      showPrepare: jest.fn(),
+      hideUI: jest.fn(),
+    })),
+  };
+});
 
 jest.mock('@ecadlabs/beacon-ui', () => {
   return {
@@ -60,8 +80,64 @@ jest.mock('@ecadlabs/beacon-transport-postmessage', () => {
 });
 
 describe('Beacon Wallet tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('Verify that BeaconWallet is instantiable', () => {
     expect(new BeaconWallet({ name: 'testWallet' })).toBeInstanceOf(BeaconWallet);
+  });
+
+  it('Uses only octez.io relays in the curated default matrix node list', () => {
+    new BeaconWallet({ name: 'testWallet' });
+
+    expect(getDAppClientInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matrixNodes: {
+          [Regions.EUROPE_WEST]: [
+            'beacon-node-1.octez.io',
+            'beacon-node-2.octez.io',
+            'beacon-node-3.octez.io',
+            'beacon-node-4.octez.io',
+            'beacon-node-5.octez.io',
+            'beacon-node-6.octez.io',
+            'beacon-node-7.octez.io',
+            'beacon-node-8.octez.io',
+          ],
+          [Regions.NORTH_AMERICA_EAST]: [],
+          [Regions.NORTH_AMERICA_WEST]: [],
+          [Regions.ASIA_EAST]: [],
+          [Regions.AUSTRALIA]: [],
+        },
+      })
+    );
+  });
+
+  it('Merges caller-provided matrix node overrides on top of the curated defaults', () => {
+    new BeaconWallet({
+      name: 'testWallet',
+      matrixNodes: {
+        [Regions.NORTH_AMERICA_EAST]: ['custom-relay.example'],
+      },
+    });
+
+    expect(getDAppClientInstance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        matrixNodes: expect.objectContaining({
+          [Regions.EUROPE_WEST]: [
+            'beacon-node-1.octez.io',
+            'beacon-node-2.octez.io',
+            'beacon-node-3.octez.io',
+            'beacon-node-4.octez.io',
+            'beacon-node-5.octez.io',
+            'beacon-node-6.octez.io',
+            'beacon-node-7.octez.io',
+            'beacon-node-8.octez.io',
+          ],
+          [Regions.NORTH_AMERICA_EAST]: ['custom-relay.example'],
+        }),
+      })
+    );
   });
 
   it('Verify BeaconWallet not initialized error', () => {


### PR DESCRIPTION
## Summary
- remove Papers-operated Beacon relay nodes from Taquito curated defaults
- keep only `beacon-node-{1..8}.octez.io` in the Europe West relay list
- add coverage for the curated default list and caller-provided `matrixNodes` overrides

## Context
Papers-operated relay nodes are expected to shut down soon, so Taquito should stop advertising them in `@taquito/beacon-wallet` defaults. Follow-up planning for broader Beacon and octez.connect sync work is tracked in ecadlabs/taquito-internal#6.

## Testing
- `npx jest packages/taquito-beacon-wallet/test/taquito-beacon-wallet.spec.ts --runInBand` *(currently fails before test execution with an existing `ts-jest` / TypeScript `sourceFile` crash in this workspace)*
