### PR TITLE
feat(wallet-connect): update walletconnect deps and session handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9490,9 +9490,9 @@
       }
     },
     "node_modules/@walletconnect/core": {
-      "version": "2.23.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.7.tgz",
-      "integrity": "sha512-yTyymn9mFaDZkUfLfZ3E9VyaSDPeHAXlrPxQRmNx2zFsEt/25GmTU2A848aomimLxZnAG2jNLhxbJ8I0gyNV+w==",
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.23.9.tgz",
+      "integrity": "sha512-ws4WG8LeagUo2ERRo02HryXRcpwIRmCQ3pHLW5gWbVReLXXIpgk6ZAfID3fEGHevIwwnHSGww+nNhNpdXyiq0g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/heartbeat": "1.2.2",
@@ -9506,8 +9506,8 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.7",
-        "@walletconnect/utils": "2.23.7",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
         "@walletconnect/window-getters": "1.0.1",
         "es-toolkit": "1.44.0",
         "events": "3.3.0",
@@ -9775,19 +9775,19 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/sign-client": {
-      "version": "2.23.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.7.tgz",
-      "integrity": "sha512-SX61lzb1bTl/LijlcHQttnoHPBzzoY5mW9ArR6qhFtDNDTS7yr2rcH7rCngxHlYeb4rAYcWLHgbiGSrdKxl/mg==",
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.23.9.tgz",
+      "integrity": "sha512-Xj+hw4E6mGRyhCdVOT/RMgnG+up/Y3v0ho5PlkVozvXWeVSqHNh9DmjLuU97a7OACoGd/oHBF6g3NVqD7MgCMQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@walletconnect/core": "2.23.7",
+        "@walletconnect/core": "2.23.9",
         "@walletconnect/events": "1.0.1",
         "@walletconnect/heartbeat": "1.2.2",
         "@walletconnect/jsonrpc-utils": "1.0.8",
         "@walletconnect/logger": "3.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.7",
-        "@walletconnect/utils": "2.23.7",
+        "@walletconnect/types": "2.23.9",
+        "@walletconnect/utils": "2.23.9",
         "events": "3.3.0"
       }
     },
@@ -9807,9 +9807,9 @@
       "license": "0BSD"
     },
     "node_modules/@walletconnect/types": {
-      "version": "2.23.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.7.tgz",
-      "integrity": "sha512-6PAKK+iR2IntmlkCFLMAHjYeIaerCJJYRDmdRimhon0u+aNmQT+HyGM6zxDAth0rdpBD7qEvKP5IXZTE7KFUhw==",
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.23.9.tgz",
+      "integrity": "sha512-IUl1PpD/Dig8IE2OZ9XtjbPohEyOZJ73xs92EDUzoIyzRtfm36g2D340pY3iu3AAdLv1yFiaZafB8Hf8RFze8A==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@walletconnect/events": "1.0.1",
@@ -9821,9 +9821,9 @@
       }
     },
     "node_modules/@walletconnect/utils": {
-      "version": "2.23.7",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.7.tgz",
-      "integrity": "sha512-3p38gNrkVcIiQixVrlsWSa66Gjs5PqHOug2TxDgYUVBW5NcKjwQA08GkC6CKBQUfr5iaCtbfy6uZJW1LKSIvWQ==",
+      "version": "2.23.9",
+      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.23.9.tgz",
+      "integrity": "sha512-C5TltCs8UPypNiteYnKSv8+ZDK2EjVDyXCxN6kA9bkA+j6KGsNIV7l9MUA8WBAvE5Gi5EcBdhD3R9Hpo/1HHqQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@msgpack/msgpack": "3.1.3",
@@ -9838,7 +9838,7 @@
         "@walletconnect/relay-auth": "1.1.0",
         "@walletconnect/safe-json": "1.0.2",
         "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.23.7",
+        "@walletconnect/types": "2.23.9",
         "@walletconnect/window-getters": "1.0.1",
         "@walletconnect/window-metadata": "1.0.1",
         "blakejs": "1.2.1",
@@ -16362,24 +16362,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
-      }
-    },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -16397,25 +16379,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-circus/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-circus/node_modules/dedent": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
@@ -16429,18 +16392,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/jest-circus/node_modules/yaml": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
-      "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/jest-cli": {
@@ -25824,9 +25775,9 @@
       "dependencies": {
         "@taquito/taquito": "^24.2.0",
         "@walletconnect/modal": "^2.7.0",
-        "@walletconnect/sign-client": "^2.16.2",
-        "@walletconnect/types": "^2.16.2",
-        "@walletconnect/utils": "^2.16.2"
+        "@walletconnect/sign-client": "^2.23.9",
+        "@walletconnect/types": "^2.23.9",
+        "@walletconnect/utils": "^2.23.9"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.42",

--- a/packages/taquito-wallet-connect/README.md
+++ b/packages/taquito-wallet-connect/README.md
@@ -10,6 +10,7 @@ _Documentation can be found [here](https://taquito.io/docs/walletconnect)_
 
 `@taquito/wallet-connect` is an npm package that provides developers a way to connect a dapp built with Taquito to a wallet giving the freedom to the users of the dapp to choose the wallet via the WalletConnect/Reown protocol. The `WalletConnect` class implements the `WalletProvider` interface, providing an alternative to `BeaconWallet`.
 Note: Currently, a QR code is displayed to establish a connection with a wallet. As more Tezos wallets integrate with WalletConnect, we plan showing a list of available wallets alongside the QR code.
+Note: The current QR pairing flow still relies on the legacy WalletConnect modal package. We plan to replace that modal integration in a future release.
 
 ## Install
 
@@ -52,6 +53,8 @@ await wallet.requestPermissions({
 const Tezos = new TezosToolkit('https://YOUR_PREFERRED_RPC_URL');
 Tezos.setWalletProvider(wallet);
 ```
+
+Existing sessions can be restored with `configureWithExistingSessionKey()`. Restored sessions are validated before activation, so invalid or stale non-Tezos session data may be rejected during restore.
 
 ## Additional Info
 

--- a/packages/taquito-wallet-connect/package.json
+++ b/packages/taquito-wallet-connect/package.json
@@ -61,10 +61,7 @@
         "ts-jest",
         {
           "useESM": true,
-          "tsconfig": {
-            "esModuleInterop": true,
-            "allowJs": true
-          }
+          "tsconfig": "<rootDir>/tsconfig.jest.json"
         }
       ]
     },
@@ -79,7 +76,17 @@
       "js"
     ],
     "moduleNameMapper": {
+      "^@taquito/core$": "<rootDir>/../taquito-core/src/taquito-core.ts",
+      "^@taquito/contracts-library$": "<rootDir>/../taquito-contracts-library/src/contracts-library.ts",
+      "^@taquito/http-utils$": "<rootDir>/../taquito-http-utils/src/taquito-http-utils.ts",
+      "^@taquito/local-forging$": "<rootDir>/../taquito-local-forging/src/taquito-local-forging.ts",
+      "^@taquito/michel-codec$": "<rootDir>/../taquito-michel-codec/src/taquito-michel-codec.ts",
+      "^@taquito/michelson-encoder$": "<rootDir>/../taquito-michelson-encoder/src/taquito-michelson-encoder.ts",
+      "^@taquito/rpc$": "<rootDir>/../taquito-rpc/src/taquito-rpc.ts",
+      "^@taquito/sapling$": "<rootDir>/../taquito-sapling/taquito-sapling.ts",
+      "^@taquito/signer$": "<rootDir>/../taquito-signer/src/taquito-signer.ts",
       "^@taquito/taquito$": "<rootDir>/../taquito/src/taquito.ts",
+      "^@taquito/utils$": "<rootDir>/../taquito-utils/src/taquito-utils.ts",
       "^@scure/bip39/wordlists/english.js$": "<rootDir>/../../node_modules/@scure/bip39/wordlists/english.js",
       "^@noble/hashes/blake2$": "<rootDir>/../../node_modules/@noble/hashes/blake2.js",
       "^@noble/hashes/hmac$": "<rootDir>/../../node_modules/@noble/hashes/hmac.js",
@@ -97,9 +104,9 @@
   "dependencies": {
     "@taquito/taquito": "^24.2.0",
     "@walletconnect/modal": "^2.7.0",
-    "@walletconnect/sign-client": "^2.16.2",
-    "@walletconnect/types": "^2.16.2",
-    "@walletconnect/utils": "^2.16.2"
+    "@walletconnect/sign-client": "^2.23.9",
+    "@walletconnect/types": "^2.23.9",
+    "@walletconnect/utils": "^2.23.9"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.42",

--- a/packages/taquito-wallet-connect/src/taquito-wallet-connect.ts
+++ b/packages/taquito-wallet-connect/src/taquito-wallet-connect.ts
@@ -79,20 +79,26 @@ export class WalletConnect implements WalletProvider {
 
     this.signClient.on('session_delete', ({ topic }) => {
       if (this.session?.topic === topic) {
-        this.session = undefined;
+        this.clearState();
       }
     });
 
     this.signClient.on('session_expire', ({ topic }) => {
       if (this.session?.topic === topic) {
-        this.session = undefined;
+        this.clearState();
       }
     });
 
     this.signClient.on('session_update', ({ params, topic }) => {
       if (this.session?.topic === topic) {
-        this.session.namespaces = params.namespaces;
-        // TODO determine if we need validation on the namespace here
+        this.activateSession(
+          {
+            ...this.session,
+            namespaces: params.namespaces,
+          },
+          undefined,
+          false
+        );
       }
     });
 
@@ -143,12 +149,13 @@ export class WalletConnect implements WalletProvider {
     registryUrl?: string;
   }) {
     // TODO when Tezos wallets will officially support wallet connect, we need to provide a default value for registryUrl
+    let approvedSession: SessionTypes.Struct;
     try {
       const chains = connectParams.permissionScope.networks.map(
         (network) => `${TEZOS_PLACEHOLDER}:${network}`
       );
       const { uri, approval } = await this.signClient.connect({
-        requiredNamespaces: {
+        optionalNamespaces: {
           [TEZOS_PLACEHOLDER]: {
             chains,
             methods: connectParams.permissionScope.methods,
@@ -164,14 +171,13 @@ export class WalletConnect implements WalletProvider {
           chains,
         });
       }
-      this.session = await approval();
+      approvedSession = await approval();
     } catch (error) {
       throw new ConnectionFailed(error);
     } finally {
       this.walletConnectModal.closeModal();
     }
-    this.validateReceivedNamespace(connectParams.permissionScope, this.session.namespaces);
-    this.setDefaultAccountAndNetwork();
+    this.activateSession(approvedSession!, connectParams.permissionScope);
   }
 
   /**
@@ -199,8 +205,7 @@ export class WalletConnect implements WalletProvider {
     if (!sessions.includes(key)) {
       throw new InvalidSessionKey(key);
     }
-    this.session = this.signClient.session.get(key);
-    this.setDefaultAccountAndNetwork();
+    this.activateSession(this.signClient.session.get(key));
   }
 
   async disconnect() {
@@ -369,14 +374,33 @@ export class WalletConnect implements WalletProvider {
     return this.activeNetwork;
   }
 
-  private setDefaultAccountAndNetwork() {
-    const activeAccount = this.getAccounts();
-    if (activeAccount.length === 1) {
-      this.activeAccount = activeAccount[0];
+  private activateSession(
+    session: SessionTypes.Struct,
+    permissionScope?: PermissionScopeParam,
+    resetActiveState = true
+  ) {
+    this.session = session;
+    if (permissionScope) {
+      this.validateReceivedNamespace(permissionScope, session.namespaces);
+    } else {
+      this.validateRestoredNamespace(session.namespaces);
     }
-    const activeNetwork = this.getNetworks();
-    if (activeNetwork.length === 1) {
-      this.activeNetwork = activeNetwork[0];
+    if (resetActiveState) {
+      this.activeAccount = undefined;
+      this.activeNetwork = undefined;
+    }
+    this.reconcileActiveAccountAndNetwork();
+  }
+
+  private reconcileActiveAccountAndNetwork() {
+    const accounts = this.getAccounts();
+    if (!this.activeAccount || !accounts.includes(this.activeAccount)) {
+      this.activeAccount = accounts.length === 1 ? accounts[0] : undefined;
+    }
+
+    const networks = this.getNetworks();
+    if (!this.activeNetwork || !networks.includes(this.activeNetwork)) {
+      this.activeNetwork = networks.length === 1 ? networks[0] : undefined;
     }
   }
 
@@ -442,6 +466,19 @@ export class WalletConnect implements WalletProvider {
     }
   }
 
+  private validateRestoredNamespace(receivedNamespaces: Record<string, SessionTypes.Namespace>) {
+    const tezosNamespace = receivedNamespaces[TEZOS_PLACEHOLDER];
+    if (!tezosNamespace) {
+      this.clearState();
+      throw new InvalidSession('Tezos not found in namespaces');
+    }
+
+    this.validateAccounts(
+      this.getChainsFromAccounts(tezosNamespace.accounts),
+      tezosNamespace.accounts
+    );
+  }
+
   private validateEvents(requiredEvents: string[], receivedEvents: string[]) {
     const missingEvents: string[] = [];
     requiredEvents.forEach((method) => {
@@ -469,7 +506,6 @@ export class WalletConnect implements WalletProvider {
         'incomplete'
       );
     }
-    const receivedChains: string[] = [];
     const invalidChains: string[] = [];
     const missingChains: string[] = [];
     const invalidChainsNamespace: string[] = [];
@@ -481,10 +517,6 @@ export class WalletConnect implements WalletProvider {
       }
       if (accountId[0] !== TEZOS_PLACEHOLDER) {
         invalidChainsNamespace.push(chain);
-      }
-      const network = accountId[1];
-      if (!receivedChains.includes(network)) {
-        receivedChains.push(network);
       }
     });
 
@@ -507,6 +539,7 @@ export class WalletConnect implements WalletProvider {
         invalidChainsNamespace
       );
     }
+    const receivedChains = this.getChainsFromAccounts(receivedAccounts);
     requiredNetwork.forEach((network) => {
       if (!receivedChains.includes(network)) {
         missingChains.push(network);
@@ -535,18 +568,6 @@ export class WalletConnect implements WalletProvider {
     }
   }
 
-  private getTezosRequiredNamespace(): {
-    chains?: string[];
-    methods: string[];
-    events: string[];
-  } {
-    if (TEZOS_PLACEHOLDER in this.getSession().requiredNamespaces) {
-      return this.getSession().requiredNamespaces[TEZOS_PLACEHOLDER];
-    } else {
-      throw new InvalidSession('Tezos not found in requiredNamespaces');
-    }
-  }
-
   private validateNetworkAndAccount(network: string, account: string) {
     if (!this.getTezosNamespace().accounts.includes(`${TEZOS_PLACEHOLDER}:${network}:${account}`)) {
       throw new InvalidNetworkOrAccount(network, account);
@@ -554,11 +575,15 @@ export class WalletConnect implements WalletProvider {
   }
 
   private getPermittedMethods() {
-    return this.getTezosRequiredNamespace().methods;
+    return this.getTezosNamespace().methods;
   }
 
   private getPermittedNetwork() {
-    return this.getTezosRequiredNamespace().chains!.map((chain) => chain.split(':')[1]);
+    return this.getChainsFromAccounts(this.getTezosNamespace().accounts);
+  }
+
+  private getChainsFromAccounts(accounts: string[]) {
+    return [...new Set(accounts.map((account) => account.split(':')[1]))];
   }
 
   private formatParameters(
@@ -683,9 +708,11 @@ export class WalletConnect implements WalletProvider {
     );
   }
 
-  async mapRegisterGlobalConstantParamsToWalletParams(params: () => Promise<WalletRegisterGlobalConstantParams>) {
+  async mapRegisterGlobalConstantParamsToWalletParams(
+    params: () => Promise<WalletRegisterGlobalConstantParams>
+  ) {
     const walletParams: WalletRegisterGlobalConstantParams = await params();
-  
+
     return this.removeDefaultLimits(
       walletParams,
       await createRegisterGlobalConstantOperation(this.formatParameters(walletParams))

--- a/packages/taquito-wallet-connect/test/taquito-wallet-connect.spec.ts
+++ b/packages/taquito-wallet-connect/test/taquito-wallet-connect.spec.ts
@@ -92,7 +92,7 @@ describe('Wallet connect tests', () => {
     });
 
     expect(mockSignClient.connect).toHaveBeenCalledWith({
-      requiredNamespaces: {
+      optionalNamespaces: {
         tezos: {
           chains: ['tezos:shadownet'],
           methods: ['tezos_send'],
@@ -114,7 +114,7 @@ describe('Wallet connect tests', () => {
     ).rejects.toThrow('Unable to connect');
   });
 
-  it('should throw an error if tezos is not part of the requiredNamespace', async () => {
+  it('should ignore requiredNamespaces when the granted namespace is valid', async () => {
     mockSignClient.connect.mockReturnValue({
       approval: async () => {
         return {
@@ -130,14 +130,14 @@ describe('Wallet connect tests', () => {
       },
     });
 
-    await expect(
-      walletConnect.requestPermissions({
-        permissionScope: {
-          methods: [PermissionScopeMethods.TEZOS_SEND],
-          networks: [NetworkType.SHADOWNET],
-        },
-      })
-    ).rejects.toThrow('Tezos not found in requiredNamespaces');
+    await walletConnect.requestPermissions({
+      permissionScope: {
+        methods: [PermissionScopeMethods.TEZOS_SEND],
+        networks: [NetworkType.SHADOWNET],
+      },
+    });
+
+    expect(walletConnect.isActiveSession()).toBeTruthy();
   });
 
   describe('test pairing', () => {
@@ -183,6 +183,24 @@ describe('Wallet connect tests', () => {
 
       expect(mockSignClient.session.get).toHaveBeenCalledWith(sessionMultipleChains.topic);
       expect(walletConnect.getSession().topic).toEqual(sessionMultipleChains.topic);
+    });
+
+    it('should reject an existing session with no tezos namespace', async () => {
+      mockSignClient.session.get.mockReturnValue({
+        ...sessionExample,
+        namespaces: {
+          unknown: {
+            accounts: ['unknown:shadownet:tz2AJ8DYxeRSUWr8zS5DcFfJYzTSNYzALxSh'],
+            methods: [PermissionScopeMethods.TEZOS_SEND],
+            events: [],
+          },
+        },
+      });
+
+      expect(() =>
+        walletConnect.configureWithExistingSessionKey(sessionMultipleChains.topic)
+      ).toThrow('Tezos not found in namespaces');
+      expect(walletConnect.isActiveSession()).toBeFalsy();
     });
 
     it('should throw an error if the session key does not exist', async () => {
@@ -656,7 +674,7 @@ describe('Wallet connect tests', () => {
       });
 
       expect(mockSignClient.connect).toHaveBeenCalledWith({
-        requiredNamespaces: {
+        optionalNamespaces: {
           tezos: {
             chains: ['tezos:shadownet'],
             methods: ['tezos_send'],
@@ -690,7 +708,7 @@ describe('Wallet connect tests', () => {
       });
 
       expect(mockSignClient.connect).toHaveBeenCalledWith({
-        requiredNamespaces: {
+        optionalNamespaces: {
           tezos: {
             chains: ['tezos:shadownet'],
             methods: ['tezos_send'],
@@ -758,7 +776,7 @@ describe('Wallet connect tests', () => {
       });
 
       expect(mockSignClient.connect).toHaveBeenCalledWith({
-        requiredNamespaces: {
+        optionalNamespaces: {
           tezos: {
             chains: ['tezos:shadownet'],
             methods: ['tezos_send'],
@@ -1312,18 +1330,53 @@ describe('Wallet connect tests', () => {
       expect(walletConnect.isActiveSession()).toBeTruthy();
       sessionDeletedEvent({ topic: sessionExample.topic });
       expect(walletConnect.isActiveSession()).toBeFalsy();
+      await expect(walletConnect.getPKH()).rejects.toThrow('Not connected, no active session');
+      expect(() => walletConnect.getActiveNetwork()).toThrow('Not connected, no active session');
     });
 
     it('should delete session when session_expire event is received', async () => {
       expect(walletConnect.isActiveSession()).toBeTruthy();
       sessionExpiredEvent({ topic: sessionExample.topic });
       expect(walletConnect.isActiveSession()).toBeFalsy();
+      await expect(walletConnect.getPKH()).rejects.toThrow('Not connected, no active session');
+      expect(() => walletConnect.getActiveNetwork()).toThrow('Not connected, no active session');
     });
 
-    it('should update session when session_update event is received', async () => {
+    it('should reconcile session when session_update event is received', async () => {
       expect(walletConnect.getSession().namespaces).toEqual(sessionExample.namespaces);
       sessionUpdatedEvent({ topic: sessionExample.topic, params: sessionMultipleChains });
       expect(walletConnect.getSession().namespaces).toEqual(sessionMultipleChains.namespaces);
+      expect(await walletConnect.getPKH()).toEqual('tz2AJ8DYxeRSUWr8zS5DcFfJYzTSNYzALxSh');
+      expect(walletConnect.getActiveNetwork()).toEqual(NetworkType.SHADOWNET);
+    });
+
+    it('should preserve active selections that remain valid after a session update', async () => {
+      walletConnect.setActiveAccount('tz2AJ8DYxeRSUWr8zS5DcFfJYzTSNYzALxSh');
+      walletConnect.setActiveNetwork(NetworkType.SHADOWNET);
+
+      sessionUpdatedEvent({ topic: sessionExample.topic, params: sessionMultipleChains });
+
+      expect(await walletConnect.getPKH()).toEqual('tz2AJ8DYxeRSUWr8zS5DcFfJYzTSNYzALxSh');
+      expect(walletConnect.getActiveNetwork()).toEqual(NetworkType.SHADOWNET);
+    });
+
+    it('should clear the session when a session update removes the tezos namespace', async () => {
+      expect(() =>
+        sessionUpdatedEvent({
+          topic: sessionExample.topic,
+          params: {
+            namespaces: {
+              unknown: {
+                accounts: ['unknown:shadownet:tz2AJ8DYxeRSUWr8zS5DcFfJYzTSNYzALxSh'],
+                methods: [PermissionScopeMethods.TEZOS_SEND],
+                events: [],
+              },
+            },
+          },
+        })
+      ).toThrow('Tezos not found in namespaces');
+
+      expect(walletConnect.isActiveSession()).toBeFalsy();
     });
   });
 });

--- a/packages/taquito-wallet-connect/tsconfig.jest.json
+++ b/packages/taquito-wallet-connect/tsconfig.jest.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": "../../packages",
+    "paths": {
+      "@taquito/core": ["taquito-core/src/taquito-core.ts"],
+      "@taquito/contracts-library": ["taquito-contracts-library/src/contracts-library.ts"],
+      "@taquito/http-utils": ["taquito-http-utils/src/taquito-http-utils.ts"],
+      "@taquito/local-forging": ["taquito-local-forging/src/taquito-local-forging.ts"],
+      "@taquito/michel-codec": ["taquito-michel-codec/src/taquito-michel-codec.ts"],
+      "@taquito/michelson-encoder": ["taquito-michelson-encoder/src/taquito-michelson-encoder.ts"],
+      "@taquito/rpc": ["taquito-rpc/src/taquito-rpc.ts"],
+      "@taquito/sapling": ["taquito-sapling/taquito-sapling.ts"],
+      "@taquito/signer": ["taquito-signer/src/taquito-signer.ts"],
+      "@taquito/taquito": ["taquito/src/taquito.ts"],
+      "@taquito/utils": ["taquito-utils/src/taquito-utils.ts"],
+      "@taquito/wallet-connect": ["taquito-wallet-connect/src/taquito-wallet-connect.ts"]
+    }
+  },
+  "include": ["src", "test"]
+}

--- a/packages/taquito-wallet-connect/tsconfig.prod.json
+++ b/packages/taquito-wallet-connect/tsconfig.prod.json
@@ -1,9 +1,11 @@
 {
-  "extends": "../../tsconfig.prod.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "declarationDir": "./dist/types",
     "outDir": "./dist/lib",
-    "jsx": "react"
+    "jsx": "react",
+    "sourceMap": false,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*"]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -38,7 +38,7 @@
         "taquito-local-forging/src/taquito-local-forging.ts"
       ],
       "@taquito/michel-codec": [
-        "taquito-michelson-encoder/src/taquito-michel-codec.ts"
+        "taquito-michel-codec/src/taquito-michel-codec.ts"
       ],
       "@taquito/michelson-encoder": [
         "taquito-michelson-encoder/src/taquito-michelson-encoder.ts"

--- a/website/src/content/docs/24.2.0/walletconnect.mdx
+++ b/website/src/content/docs/24.2.0/walletconnect.mdx
@@ -5,6 +5,8 @@ author: Roxane Letourneau
 
 The `@taquito/wallet-connect` package provides a `WalletConnect` class which implements the `WalletProvider` interface. The package is intended to be used by dapp developers. Similarly to `BeaconWallet`, an instance of `WalletConnect` can be injected into the `TezosToolkit` to work with the wallet API.
 
+The current QR pairing flow still relies on the legacy WalletConnect modal package. We plan to replace that modal integration in a future release.
+
 ## Instantiate `WalletConnect` and connect to a wallet
 
 The first step is to instantiate `WalletConnect` by passing your dapp details as a parameter of the `init` method as follows:
@@ -42,13 +44,11 @@ await walletConnect.requestPermissions({
 
 The parameter of the `requestPermissions` method has a `permissionScope` property allowing to specify the networks, methods, and events that will be granted permission.
 
-It has an optional `pairingTopic` property, which allows connecting to an existing active pairing. If `pairingTopic` is undefined, a QR/deep-links Modal will open in the dapp, allowing the user to connect to a wallet. If `pairingTopic` is defined, no modal will be shown in the dapp, and a prompt will appear in the corresponding wallet to accept or decline the session proposal. The list of active pairings can be accessed using the `getAvailablePairing` method. A good practice is to show the dapp user available pairings if they exist and to allow him to connect through one of them (skip the QR/deep-links Modal) or to connect using a new pairing (using the QR/deep-links)
-
-The parameter of the `requestPermissions` method also has an optional `registryUrl` parameter allowing to customize the list of wallet deep links to show in the Modal.
+It has an optional `pairingTopic` property, which allows connecting to an existing active pairing. If `pairingTopic` is undefined, a QR/deep-links Modal will open in the dapp, allowing the user to connect to a wallet. If `pairingTopic` is defined, no modal will be shown in the dapp, and a prompt will appear in the corresponding wallet to accept or decline the session proposal. The list of active pairings can be accessed using the `getAvailablePairing` method. A good practice is to show the dapp user available pairings if they exist and to allow them to connect through one of them (skip the QR/deep-links Modal) or to connect using a new pairing (using the QR/deep-links Modal).
 
 If no connection can be established with a wallet, the error `ConnectionFailed` will be thrown.
 
-Suppose there is a need to restore a session in the dapp rather than using the `requestPermissions` method, which would establish a new session. In that case, it is possible to configure the `WalletConnect` class with an existing session using the `configureWithExistingSessionKey` method. The session will be immediately restored without a prompt in the wallet to accept/decline it. The list of existing sessions can be retrieved with the `getAllExistingSessionKeys` method. An `InvalidSessionKey` error will be thrown if the provided session key doesn't exist.
+Suppose there is a need to restore a session in the dapp rather than using the `requestPermissions` method, which would establish a new session. In that case, it is possible to configure the `WalletConnect` class with an existing session using the `configureWithExistingSessionKey` method. The session will be immediately restored without a prompt in the wallet to accept/decline it. The list of existing sessions can be retrieved with the `getAllExistingSessionKeys` method. An `InvalidSessionKey` error will be thrown if the provided session key doesn't exist. Restored sessions are also validated before activation, so invalid or stale non-Tezos session data may be rejected during restore.
 
 ## Send Tezos operation with `WalletConnect` and `TezosToolkit`
 
@@ -101,18 +101,20 @@ The `sign` method of `WalletConnect` can be called to sign a payload. The respon
 
 ## Events handling
 
-Wallet connect allows listening to specific events. Taquito has listeners on the events `session_delete`, `session_expire`, and `session_update` and will update its internal session member accordingly if one of these events is emitted. The dapp should also handle those events as follow:
+WalletConnect allows listening to specific events. Taquito has listeners on the events `session_delete`, `session_expire`, and `session_update` and reconciles its internal session state if one of these events is emitted. The dapp should also handle those events as follows:
 
 ```ts
 walletConnect.signClient.on("session_delete", ({ topic }) => {
   // The session was deleted from the wallet
+  // Taquito clears its local session state
   // the dapp should listen for the event and reset the dapp state,
   // clean up from user session (for example, go back to the connect wallet page)
 });
 
 walletConnect.signClient.on("session_update", ({ topic }) => {
   // The session was updated in the wallet
-  // Does the accounts/network have changed, which requires calling the `setActiveAccount/setActiveNetwork` methods?
+  // Taquito revalidates the session and reconciles the active account/network
+  // the app should still update its own derived state (selected account, balances, UI, ...)
   // Update the app's state (selected account, available accounts, balance, ...)
 });
 ```

--- a/website/src/content/docs/next/walletconnect.mdx
+++ b/website/src/content/docs/next/walletconnect.mdx
@@ -5,6 +5,8 @@ author: Roxane Letourneau
 
 The `@taquito/wallet-connect` package provides a `WalletConnect` class which implements the `WalletProvider` interface. The package is intended to be used by dapp developers. Similarly to `BeaconWallet`, an instance of `WalletConnect` can be injected into the `TezosToolkit` to work with the wallet API.
 
+The current QR pairing flow still relies on the legacy WalletConnect modal package. We plan to replace that modal integration in a future release.
+
 ## Instantiate `WalletConnect` and connect to a wallet
 
 The first step is to instantiate `WalletConnect` by passing your dApp details as a parameter of the `init` method as follows:
@@ -13,7 +15,7 @@ The first step is to instantiate `WalletConnect` by passing your dApp details as
 import { WalletConnect } from "@taquito/wallet-connect";
 
 const walletConnect = await WalletConnect.init({
-  projectId: "YOUR_PROJECT_ID", // can get YOUR_PROJECT_ID from https://dashboard.walletconnect.com
+  projectId: "YOUR_PROJECT_ID", // can get YOUR_PROJECT_ID from https://cloud.reown.com
   metadata: {
     name: "YOUR_DAPP_NAME",
     description: "YOUR_DAPP_DESCRIPTION",
@@ -42,13 +44,11 @@ await walletConnect.requestPermissions({
 
 The parameter of the `requestPermissions` method has a `permissionScope` property allowing to specify the networks, methods, and events that will be granted permission.
 
-It has an optional `pairingTopic` property, which allows connecting to an existing active pairing. If `pairingTopic` is undefined, a QR/deep-links Modal will open in the dApp, allowing the user to connect to a wallet. If `pairingTopic` is defined, no modal will be shown in the dApp, and a prompt will appear in the corresponding wallet to accept or decline the session proposal. The list of active pairings can be accessed using the `getAvailablePairing` method. A good practice is to show the dApp user available pairings if they exist and to allow them to connect through one of them (skip the QR/deep-links Modal) or to connect using a new pairing (using the QR/deep-links)
-
-The parameter of the `requestPermissions` method also has an optional `registryUrl` parameter allowing to customize the list of wallet deep links to show in the Modal.
+It has an optional `pairingTopic` property, which allows connecting to an existing active pairing. If `pairingTopic` is undefined, a QR/deep-links Modal will open in the dApp, allowing the user to connect to a wallet. If `pairingTopic` is defined, no modal will be shown in the dApp, and a prompt will appear in the corresponding wallet to accept or decline the session proposal. The list of active pairings can be accessed using the `getAvailablePairing` method. A good practice is to show the dApp user available pairings if they exist and to allow them to connect through one of them (skip the QR/deep-links Modal) or to connect using a new pairing (using the QR/deep-links Modal).
 
 If no connection can be established with a wallet, the error `ConnectionFailed` will be thrown.
 
-Suppose there is a need to restore a session in the dApp rather than using the `requestPermissions` method, which would establish a new session. In that case, it is possible to configure the `WalletConnect` class with an existing session using the `configureWithExistingSessionKey` method. The session will be immediately restored without a prompt in the wallet to accept/decline it. The list of existing sessions can be retrieved with the `getAllExistingSessionKeys` method. An `InvalidSessionKey` error will be thrown if the provided session key doesn't exist.
+Suppose there is a need to restore a session in the dApp rather than using the `requestPermissions` method, which would establish a new session. In that case, it is possible to configure the `WalletConnect` class with an existing session using the `configureWithExistingSessionKey` method. The session will be immediately restored without a prompt in the wallet to accept/decline it. The list of existing sessions can be retrieved with the `getAllExistingSessionKeys` method. An `InvalidSessionKey` error will be thrown if the provided session key doesn't exist. Restored sessions are also validated before activation, so invalid or stale non-Tezos session data may be rejected during restore.
 
 ## Send Tezos operation with `WalletConnect` and `TezosToolkit`
 
@@ -101,18 +101,20 @@ The `sign` method of `WalletConnect` can be called to sign a payload. The respon
 
 ## Events handling
 
-Wallet connect allows listening to specific events. Taquito has listeners on the events `session_delete`, `session_expire`, and `session_update` and will update its internal session member accordingly if one of these events is emitted. The dapp should also handle those events as follows:
+WalletConnect allows listening to specific events. Taquito has listeners on the events `session_delete`, `session_expire`, and `session_update` and reconciles its internal session state if one of these events is emitted. The dApp should also handle those events as follows:
 
 ```ts
 walletConnect.signClient.on("session_delete", ({ topic }) => {
   // The session was deleted from the wallet
+  // Taquito clears its local session state
   // the dApp should listen for the event and reset the dApp state,
   // clean up from user session (for example, go back to the connect wallet page)
 });
 
 walletConnect.signClient.on("session_update", ({ topic }) => {
   // The session was updated in the wallet
-  // Does the accounts/network have changed, which requires calling the `setActiveAccount/setActiveNetwork` methods?
+  // Taquito revalidates the session and reconciles the active account/network
+  // the app should still update its own derived state (selected account, balances, UI, ...)
   // Update the app's state (selected account, available accounts, balance, ...)
 });
 ```


### PR DESCRIPTION
## Summary
- update the wallet-connect package to the current published WalletConnect sign stack
- harden session lifecycle handling for restored, updated, expired, and deleted sessions
- refresh the wallet-connect docs to match the stricter runtime behavior

## Changes
- update @walletconnect/sign-client, @walletconnect/types, and @walletconnect/utils to ^2.23.9
- keep @walletconnect/modal at ^2.7.0 for now, with docs noting it will be replaced in a future release
- switch connection setup to optionalNamespaces and stop treating deprecated requiredNamespaces as the runtime source of truth
- validate restored sessions before accepting them
- reconcile local active account and network state on session_update, and fully clear state on session_delete and session_expire
- add package-local Jest path config so the wallet-connect suite runs reliably from the workspace package
- update the package README and website docs to describe the current modal plan and the stricter restored-session behavior

## Testing
- npm run lint -w @taquito/wallet-connect
- npm test -w @taquito/wallet-connect -- --runInBand
- npm run build -w @taquito/wallet-connect

## Notes
- the package build still emits existing Rollup unresolved dependency warnings from sibling Taquito packages, but the build completes successfully
- the modal replacement is deferred to a future release