### PR TITLE
chore: update GitHub Actions and release sync workflows

### DIFF
--- a/.github/workflows/bundle_webpack.yml
+++ b/.github/workflows/bundle_webpack.yml
@@ -20,14 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run build
       - run: npm -w packages/taquito-local-forging run build-webpack
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: taquito-local-forging-vanilla
           path: |
@@ -35,7 +36,7 @@ jobs:
             packages/taquito-local-forging/dist/taquito_local_forging.js.map
 
       - run: npm -w packages/taquito-beacon-wallet run build-webpack
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: taquito-beacon-wallet-vanilla
           path: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/deploy_edge.yml
+++ b/.github/workflows/deploy_edge.yml
@@ -20,10 +20,11 @@ jobs:
     env:
       VERDACCIO_TOKEN: ${{ secrets.EDGE_VERDACCIO_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
+          package-manager-cache: false
       - run: echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
       - run: echo "PACKAGE_VERSION=`node -p "require('./packages/taquito/package.json').version"`" >> $GITHUB_ENV
       - run: echo "BRANCH_NAME=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}" | sed 's/[^a-zA-Z0-9-]/-/g')" >> $GITHUB_ENV

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -20,10 +20,11 @@ jobs:
       issues: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
+          package-manager-cache: false
       # Install and build all packages (required for TypeDoc)
       - name: Install root dependencies
         run: npm ci

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,21 @@ permissions:
   contents: read
 
 jobs:
+  integration-tests-change-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      run_expensive: ${{ steps.filter.outputs.run_expensive }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "run_expensive=$(node scripts/should-run-expensive-integration.js)" >> "$GITHUB_OUTPUT"
+
   http-utils-test:
     runs-on: ubuntu-latest
     strategy:
@@ -35,6 +50,8 @@ jobs:
       - run: npx nx test @taquito/http-utils -- --coverage
 
   integration-tests-keygen-preflight:
+    needs: integration-tests-change-filter
+    if: ${{ needs.integration-tests-change-filter.outputs.run_expensive == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -74,8 +91,11 @@ jobs:
           RUN_INTEGRATION: true
 
   integration-tests-testnet:
+    if: ${{ needs.integration-tests-change-filter.outputs.run_expensive == 'true' }}
     name: integration-tests-shadownet
-    needs: integration-tests-keygen-preflight
+    needs:
+      - integration-tests-change-filter
+      - integration-tests-keygen-preflight
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -192,8 +212,11 @@ jobs:
           retention-days: 30
 
   integration-tests-sapling:
+    if: ${{ needs.integration-tests-change-filter.outputs.run_expensive == 'true' }}
     name: integration-tests-shadownet-sapling
-    needs: integration-tests-keygen-preflight
+    needs:
+      - integration-tests-change-filter
+      - integration-tests-keygen-preflight
     runs-on: ubuntu-latest
     concurrency:
       group: shadownet-itest-sapling
@@ -302,9 +325,10 @@ jobs:
 
   integration-tests-timing-summary:
     needs:
+      - integration-tests-change-filter
       - integration-tests-testnet
       - integration-tests-sapling
-    if: always()
+    if: ${{ always() && needs.integration-tests-change-filter.outputs.run_expensive == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Download timing artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,8 @@ jobs:
           - '22'
           - '24'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -37,7 +37,7 @@ jobs:
   integration-tests-keygen-preflight:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Keygen preflight
         run: bash .github/scripts/check-keygen-health.sh
 
@@ -54,8 +54,8 @@ jobs:
           - 'lts/Jod'
           - '24'
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: npm
@@ -65,7 +65,7 @@ jobs:
       - run: npm run build-docs
       - run: npm run test
       - name: Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: packages/**/coverage/coverage-final.json
           use_oidc: true
@@ -85,8 +85,8 @@ jobs:
       group: shadownet-itest-testnet-shard-${{ matrix.shard }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -184,7 +184,7 @@ jobs:
           done
       - name: Upload timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: itest-timing-shadownet-${{ matrix.shard }}
           path: ci-metrics/itest-shadownet-${{ matrix.shard }}.json
@@ -199,8 +199,8 @@ jobs:
       group: shadownet-itest-sapling
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: npm
@@ -293,7 +293,7 @@ jobs:
           done
       - name: Upload timing artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: itest-timing-sapling
           path: ci-metrics/itest-sapling.json
@@ -309,7 +309,7 @@ jobs:
     steps:
       - name: Download timing artifacts
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: itest-timing-*
           path: ci-metrics

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,14 +23,15 @@ jobs:
     env:
       VERSION: ${{ inputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - run: npm ci
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,11 +143,14 @@ jobs:
             package-lock.json \
             example/package.json \
             integration-tests/package.json \
+            packages/*/package.json \
+            packages/*/src/version.ts \
+            packages/taquito-michel-codec/pack-test-tool/package.json \
+            packages/taquito/README.md \
             website/package.json \
             website/package-lock.json \
             website/src/config/versions.mjs \
             website/src/content/docs
-          git add -u packages
 
           if git diff --cached --quiet; then
             echo "No release sync changes to commit."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      pull-requests: write
     env:
       VERSION: ${{ inputs.version }}
     steps:
@@ -98,3 +99,81 @@ jobs:
             --title "v${VERSION}" \
             --generate-notes \
             ${prerelease_flag}
+
+      - name: Sync website release metadata
+        if: ${{ !inputs.prerelease }}
+        run: node scripts/sync-website-release.js "${VERSION}"
+
+      - name: Sync root lockfile metadata
+        if: ${{ !inputs.prerelease }}
+        run: npm install --package-lock-only --ignore-scripts
+
+      - name: Sync website lockfile metadata
+        if: ${{ !inputs.prerelease }}
+        run: npm install --package-lock-only --ignore-scripts
+        working-directory: website
+
+      - name: Snapshot website docs for stable release
+        if: ${{ !inputs.prerelease }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -d "src/content/docs/${VERSION}" ]; then
+            npm run docs:version -- "${VERSION}"
+          fi
+        working-directory: website
+
+      - name: Open release sync PR
+        if: ${{ !inputs.prerelease }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branch="release-sync/v${VERSION}"
+          pr_body_file="$(mktemp)"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -C "${branch}"
+          git add \
+            package.json \
+            package-lock.json \
+            example/package.json \
+            integration-tests/package.json \
+            website/package.json \
+            website/package-lock.json \
+            website/src/config/versions.mjs \
+            website/src/content/docs
+          git add -u packages
+
+          if git diff --cached --quiet; then
+            echo "No release sync changes to commit."
+            exit 0
+          fi
+
+          git commit -m "chore: sync repo after v${VERSION} release"
+          git push --force-with-lease --set-upstream origin "${branch}"
+
+          existing_pr="$(gh pr list --base main --head "${branch}" --json number --jq '.[0].number')"
+          if [ -n "${existing_pr}" ]; then
+            echo "PR #${existing_pr} already exists for ${branch}."
+            exit 0
+          fi
+
+          cat > "${pr_body_file}" <<EOF
+          Syncs repository metadata after publishing Taquito v${VERSION}.
+
+          - updates workspace package versions and generated version stamps
+          - updates website Taquito dependencies and lockfile
+          - snapshots docs/next into docs/${VERSION}
+          - updates website default docs version
+          EOF
+
+          gh pr create \
+            --base main \
+            --head "${branch}" \
+            --title "chore: sync repo after v${VERSION} release" \
+            --body-file "${pr_body_file}"

--- a/.github/workflows/release_rehearsal.yml
+++ b/.github/workflows/release_rehearsal.yml
@@ -22,14 +22,15 @@ jobs:
       VERSION: ${{ inputs.version }}
       npm_config_cache: /tmp/taquito-npm-cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org
+          package-manager-cache: false
 
       - run: npm ci
 

--- a/.github/workflows/shadownet.yml
+++ b/.github/workflows/shadownet.yml
@@ -17,10 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run build
       - if: always()

--- a/.github/workflows/tezlinkshadownet.yml
+++ b/.github/workflows/tezlinkshadownet.yml
@@ -12,10 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run build
       - if: always()

--- a/.github/workflows/weeklynet.yml
+++ b/.github/workflows/weeklynet.yml
@@ -13,10 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
+          cache: npm
       - run: npm ci
       - run: npm run build
       - if: always()

--- a/scripts/should-run-expensive-integration.js
+++ b/scripts/should-run-expensive-integration.js
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+
+const eventName = process.env.EVENT_NAME;
+const baseSha = process.env.BASE_SHA;
+const headSha = process.env.HEAD_SHA;
+
+if (eventName !== 'pull_request') {
+  process.stdout.write('true');
+  process.exit(0);
+}
+
+if (!baseSha || !headSha) {
+  console.error('BASE_SHA and HEAD_SHA are required for pull_request events');
+  process.exit(1);
+}
+
+const changedFiles = execFileSync('git', ['diff', '--name-only', `${baseSha}...${headSha}`], {
+  encoding: 'utf8',
+})
+  .split('\n')
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+const safePathPatterns = [
+  /^website\//,
+  /^packages\/[^/]+\/src\/version\.ts$/,
+  /^packages\/taquito\/README\.md$/,
+];
+
+const jsonMetadataPatterns = [
+  /^package\.json$/,
+  /^package-lock\.json$/,
+  /^example\/package\.json$/,
+  /^integration-tests\/package\.json$/,
+  /^website\/package\.json$/,
+  /^website\/package-lock\.json$/,
+  /^packages\/[^/]+\/package\.json$/,
+  /^packages\/taquito-michel-codec\/pack-test-tool\/package\.json$/,
+];
+
+const shouldRun = changedFiles.some((file) => {
+  if (safePathPatterns.some((pattern) => pattern.test(file))) {
+    return false;
+  }
+
+  if (jsonMetadataPatterns.some((pattern) => pattern.test(file))) {
+    return !isSafeJsonMetadataChange(file);
+  }
+
+  return true;
+});
+
+process.stdout.write(shouldRun ? 'true' : 'false');
+
+function isSafeJsonMetadataChange(file) {
+  try {
+    const before = readJson(`${baseSha}:${file}`);
+    const after = readJson(`${headSha}:${file}`);
+
+    if (file.endsWith('package-lock.json')) {
+      return JSON.stringify(sanitizePackageLock(file, before)) === JSON.stringify(sanitizePackageLock(file, after));
+    }
+
+    return JSON.stringify(sanitizePackageJson(before)) === JSON.stringify(sanitizePackageJson(after));
+  } catch {
+    return false;
+  }
+}
+
+function readJson(ref) {
+  return JSON.parse(
+    execFileSync('git', ['show', ref], {
+      encoding: 'utf8',
+    }),
+  );
+}
+
+function sanitizePackageJson(json) {
+  const clone = structuredClone(json);
+  delete clone.version;
+
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    normalizeTaquitoDependencyMap(clone[field]);
+  }
+
+  return clone;
+}
+
+function sanitizePackageLock(file, json) {
+  const clone = structuredClone(json);
+
+  if (clone.version) clone.version = '__VERSION__';
+  if (clone.packages && clone.packages[''] && clone.packages[''].version) {
+    clone.packages[''].version = '__VERSION__';
+  }
+  if (clone.packages && clone.packages['']) {
+    normalizeTaquitoDependencyMap(clone.packages[''].dependencies);
+  }
+
+  if (!clone.packages) {
+    return clone;
+  }
+
+  if (file === 'website/package-lock.json') {
+    for (const [pkgPath, pkg] of Object.entries(clone.packages)) {
+      if (!pkgPath.startsWith('node_modules/@taquito/')) continue;
+      normalizePackageLockPackage(pkg, true);
+    }
+    return clone;
+  }
+
+  for (const [pkgPath, pkg] of Object.entries(clone.packages)) {
+    if (
+      pkgPath === '' ||
+      pkgPath.startsWith('packages/') ||
+      pkgPath.startsWith('node_modules/@taquito/') ||
+      pkgPath === 'example' ||
+      pkgPath === 'integration-tests'
+    ) {
+      normalizePackageLockPackage(pkg, false);
+    }
+  }
+
+  return clone;
+}
+
+function normalizePackageLockPackage(pkg, normalizeRegistryFields) {
+  if (!pkg || typeof pkg !== 'object') return;
+
+  if (pkg.version) pkg.version = '__VERSION__';
+  if (normalizeRegistryFields) {
+    if (pkg.resolved) pkg.resolved = '__RESOLVED__';
+    if (pkg.integrity) pkg.integrity = '__INTEGRITY__';
+  }
+
+  for (const field of ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies']) {
+    normalizeTaquitoDependencyMap(pkg[field]);
+  }
+}
+
+function normalizeTaquitoDependencyMap(map) {
+  if (!map || typeof map !== 'object') return;
+
+  for (const key of Object.keys(map)) {
+    if (key.startsWith('@taquito/')) {
+      map[key] = '__TAQUITO_VERSION__';
+    }
+  }
+}

--- a/scripts/sync-website-release.js
+++ b/scripts/sync-website-release.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+
+const { readFileSync, writeFileSync } = require('fs');
+const { resolve } = require('path');
+
+const version = process.argv[2];
+
+if (!version) {
+  console.error('Usage: sync-website-release.js <version>');
+  process.exit(1);
+}
+
+const websitePackageJsonPath = resolve(__dirname, '..', 'website', 'package.json');
+const versionsConfigPath = resolve(__dirname, '..', 'website', 'src', 'config', 'versions.mjs');
+
+const websitePackage = JSON.parse(readFileSync(websitePackageJsonPath, 'utf8'));
+websitePackage.version = version;
+
+for (const [name] of Object.entries(websitePackage.dependencies || {})) {
+  if (name.startsWith('@taquito/')) {
+    websitePackage.dependencies[name] = `^${version}`;
+  }
+}
+
+writeFileSync(websitePackageJsonPath, `${JSON.stringify(websitePackage, null, 2)}\n`);
+
+const versionsConfig = readFileSync(versionsConfigPath, 'utf8');
+const versionsMatch = versionsConfig.match(/export const VERSIONS = \[(.*)\];/);
+if (!versionsMatch) {
+  console.error(`Unable to parse versions list in ${versionsConfigPath}`);
+  process.exit(1);
+}
+
+const versions = Array.from(versionsMatch[1].matchAll(/"([^"]+)"/g), (match) => match[1]).filter(
+  (item, index, items) => items.indexOf(item) === index,
+);
+
+const stableVersions = versions.filter((item) => item !== 'next' && item !== version);
+const nextVersions = ['next', version, ...stableVersions];
+
+let nextConfig = versionsConfig.replace(
+  /export const VERSIONS = \[.*\];/,
+  `export const VERSIONS = ${JSON.stringify(nextVersions)};`,
+);
+nextConfig = nextConfig.replace(/export const DEFAULT_VERSION = ".*";/, `export const DEFAULT_VERSION = "${version}";`);
+
+writeFileSync(versionsConfigPath, nextConfig);


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions to current major versions
- automate stable release follow-up PRs that sync repo and website release metadata
- gate expensive integration jobs on actual PR contents so version-only maintenance PRs skip them

## Notes
- prerelease releases still publish on the `next` dist-tag and do not open follow-on sync PRs
- stable releases now open a `release-sync/v<version>` PR after publish
- release-sync PR staging is narrowed to version metadata and website docs files

## Validation
- YAML parse for updated workflows
- `node --check` on new workflow helper scripts
- `git diff --check`
- repo precommit hook during commits