### PR TITLE
fix(taquito): finalize rpc read consistency semantics

### DIFF
--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -397,8 +397,7 @@ const defaultConfig = ({
     rpc: process.env[`TEZOS_RPC_${networkName}`] || defaultRpc,
     pollingIntervalMilliseconds: process.env[`POLLING_INTERVAL_MILLISECONDS`] || undefined,
     rpcCacheMilliseconds: process.env[`RPC_CACHE_MILLISECONDS`] || '1000',
-    knownBaker:
-      process.env[`TEZOS_BAKER`] || 'tz1TnEtqDV9mZyts2pfMy6Jw1BTPs4LMjL8M', // ECAD 1 : Teztnets Baker
+    knownBaker: process.env[`TEZOS_BAKER`] || 'tz1TnEtqDV9mZyts2pfMy6Jw1BTPs4LMjL8M', // ECAD 1 : Teztnets Baker
     knownContract: process.env[`TEZOS_${networkName}_CONTRACT_ADDRESS`] || knownContracts.contract,
     knownBigMapContract:
       process.env[`TEZOS_${networkName}_BIGMAPCONTRACT_ADDRESS`] || knownContracts.bigMapContract,
@@ -428,7 +427,7 @@ const shadownetEphemeral: Config = defaultConfig({
 
 const shadownetSecretKey: Config = {
   ...shadownetEphemeral,
-  ...{ signerConfig: defaultSecretKey, rpc: 'https://shadownet.tezos.ecadinfra.com' },
+  signerConfig: defaultSecretKey,
 };
 
 const tallinnnetEphemeral: Config = defaultConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -18362,6 +18362,70 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/ts-loader": {
+      "version": "9.5.7",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
+      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.0.0",
+        "micromatch": "^4.0.0",
+        "semver": "^7.3.4",
+        "source-map": "^0.7.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "typescript": "*",
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/ts-loader/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.9.2",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
@@ -20056,6 +20120,7 @@
         "rollup-plugin-polyfill-node": "^0.13.0",
         "rollup-plugin-typescript2": "^0.37.0",
         "shelljs": "^0.8.5",
+        "ts-loader": "^9.5.7",
         "ts-node": "^10.9.2",
         "ts-toolbelt": "^9.6.0",
         "typescript": "^5.9.3",
@@ -20410,39 +20475,6 @@
         "node": ">=22"
       }
     },
-    "packages/taquito-local-forging/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/taquito-local-forging/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "packages/taquito-local-forging/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -20465,37 +20497,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "packages/taquito-local-forging/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/taquito-local-forging/node_modules/ts-loader": {
-      "version": "9.5.7",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
-      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4",
-        "source-map": "^0.7.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "*",
-        "webpack": "^5.0.0"
       }
     },
     "packages/taquito-local-forging/node_modules/webpack": {
@@ -21073,70 +21074,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "packages/taquito-timelock/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "packages/taquito-timelock/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "packages/taquito-timelock/node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "packages/taquito-timelock/node_modules/ts-loader": {
-      "version": "9.5.7",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.7.tgz",
-      "integrity": "sha512-/ZNrKgA3K3PtpMYOC71EeMWIloGw3IYEa5/t1cyz2r5/PyUwTXGzYJvcD3kfUvmhlfpz1rhV8B2O6IVTQ0avsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "enhanced-resolve": "^5.0.0",
-        "micromatch": "^4.0.0",
-        "semver": "^7.3.4",
-        "source-map": "^0.7.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "typescript": "*",
-        "webpack": "^5.0.0"
       }
     },
     "packages/taquito-tzip12": {

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -73,10 +73,10 @@
   "dependencies": {
     "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
     "@ecadlabs/beacon-types": "^4.8.1-ecad",
+    "@stablelib/ed25519": "^2.0.2",
     "@taquito/core": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "@stablelib/ed25519": "^2.0.2",
     "crypto-browserify": "^3.12.1",
     "typedarray-to-buffer": "^4.0.0",
     "util": "^0.12.5"
@@ -106,6 +106,7 @@
     "rollup-plugin-polyfill-node": "^0.13.0",
     "rollup-plugin-typescript2": "^0.37.0",
     "shelljs": "^0.8.5",
+    "ts-loader": "^9.5.7",
     "ts-node": "^10.9.2",
     "ts-toolbelt": "^9.6.0",
     "typescript": "^5.9.3",

--- a/packages/taquito-signer/test/taquito-signer.spec.ts
+++ b/packages/taquito-signer/test/taquito-signer.spec.ts
@@ -237,7 +237,7 @@ describe('inmemory-signer', () => {
     expect((await signer.sign('1234', new Uint8Array([3]))).sig).toEqual(
       'sigZiUh7khZmjP1kGSSNe3LQdZC5GMpWHuyFkqcR37pwiGUJrpKaatUxWcRPBE5sHwqfydUsPM4JvK14dBMoHbCxC7VHdMZC'
     );
-  });
+  }, 15000);
 
   it('Tz3 with bytes producing signature that needs padding', async () => {
     const signer = new InMemorySigner('p2sk2ke47zhFz3znRZj39TW5KKS9VgfU1Hax7KeErgnShNe9oQFQUP');

--- a/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
+++ b/packages/taquito-tzip16/src/handlers/tezos-storage-handler.ts
@@ -29,10 +29,12 @@ export class TezosStorageHandler implements Handler {
     if (!parsedTezosStorageUri) {
       throw new InvalidUriError(`tezos-storage:${location}`);
     }
-    const script = await context.readProvider.getScript(
-      parsedTezosStorageUri.contractAddress || contractAbstraction.address,
-      'head'
-    );
+    const block = contractAbstraction.readBlock;
+    const targetAddress = parsedTezosStorageUri.contractAddress || contractAbstraction.address;
+    const script =
+      !parsedTezosStorageUri.contractAddress && block !== 'head'
+        ? contractAbstraction.script
+        : await context.readProvider.getScript(targetAddress, block);
     const bigMapId = Schema.fromRPCResponse({ script }).FindFirstInTopLevelPair<BigMapId>(
       script.storage,
       typeOfValueToFind
@@ -44,7 +46,8 @@ export class TezosStorageHandler implements Handler {
     const bytes = await context.contract.getBigMapKeyByID<string>(
       bigMapId.int.toString(),
       parsedTezosStorageUri.path,
-      new Schema(typeOfValueToFind)
+      new Schema(typeOfValueToFind),
+      block
     );
 
     if (!bytes) {

--- a/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
+++ b/packages/taquito-tzip16/src/tzip16-contract-abstraction.ts
@@ -43,7 +43,9 @@ export class Tzip16ContractAbstraction {
 
   private async findMetadataBigMap(): Promise<BigMapAbstraction> {
     const metadataBigMapId = this.constractAbstraction.schema.FindFirstInTopLevelPair<BigMapId>(
-      await this.context.readProvider.getStorage(this.constractAbstraction.address, 'head'),
+      this.constractAbstraction.readBlock === 'head'
+        ? await this.context.readProvider.getStorage(this.constractAbstraction.address, 'head')
+        : this.constractAbstraction.script.storage,
       metadataBigMapType
     );
 
@@ -54,7 +56,8 @@ export class Tzip16ContractAbstraction {
     return new BigMapAbstraction(
       new BigNumber(metadataBigMapId['int']),
       new Schema(metadataBigMapType),
-      this.context.contract
+      this.context.contract,
+      this.constractAbstraction.readBlock
     );
   }
 

--- a/packages/taquito-tzip16/src/viewKind/michelson-storage-view.ts
+++ b/packages/taquito-tzip16/src/viewKind/michelson-storage-view.ts
@@ -147,12 +147,15 @@ export class MichelsonStorageView implements View {
     const storageArgs = storageType.args[0];
 
     // currentContext
-    const storageValue: any = await this.readProvider.getStorage(this.contract.address, 'head');
+    const storageValue: any =
+      this.contract.readBlock === 'head'
+        ? await this.readProvider.getStorage(this.contract.address, 'head')
+        : this.contract.script.storage;
     const chainId = await this.readProvider.getChainId();
     const contractBalance = (
-      await this.readProvider.getBalance(this.contract.address, 'head')
+      await this.readProvider.getBalance(this.contract.address, this.contract.readBlock)
     ).toString();
-    const blockTimestamp = await this.readProvider.getBlockTimestamp('head');
+    const blockTimestamp = await this.readProvider.getBlockTimestamp(this.contract.readBlock);
 
     const code = this.adaptViewCodeToContext(this.code, contractBalance, blockTimestamp, chainId);
 

--- a/packages/taquito-tzip16/test/handlers/tezos-storage-handler.spec.ts
+++ b/packages/taquito-tzip16/test/handlers/tezos-storage-handler.spec.ts
@@ -69,6 +69,30 @@ describe('Tzip16 tezos storage handler test', () => {
   const tezosStorageHandler = new TezosStorageHandler();
 
   beforeEach(() => {
+    mockContractAbstraction.readBlock = 'BLockHash200';
+    mockContractAbstraction.address = 'KT1CurrentContractAddress111111111111111';
+    mockContractAbstraction.script = {
+      code: [
+        {
+          prim: 'storage',
+          args: [
+            {
+              prim: 'pair',
+              args: [
+                {
+                  prim: 'big_map',
+                  args: [{ prim: 'string' }, { prim: 'bytes' }],
+                  annots: ['%metadata'],
+                },
+                {},
+              ],
+            },
+          ],
+        },
+        { prim: 'code', args: [] },
+      ],
+      storage: { prim: 'Pair', args: [{ int: '32527' }, []] },
+    };
     mockReadProvider = {
       getScript: vi.fn(),
     };
@@ -121,6 +145,41 @@ describe('Tzip16 tezos storage handler test', () => {
 
     expect(metadata).toEqual(
       `{"name":"test","description":"A metadata test","version":"0.1","license":"MIT","authors":["Taquito <https://taquito.io/>"],"homepage":"https://taquito.io/"}`
+    );
+    expect(mockReadProvider.getScript).toHaveBeenCalledWith(
+      'KT1RF4nXUitQb2G8TE5H9zApatxeKLtQymtg',
+      'BLockHash200'
+    );
+    expect(mockContractProvider.getBigMapKeyByID).toHaveBeenCalledWith(
+      '32527',
+      'here',
+      expect.anything(),
+      'BLockHash200'
+    );
+  });
+
+  it('Should reuse the pinned contract script for same-contract metadata', async () => {
+    mockContractProvider.getBigMapKeyByID.mockResolvedValue('63616665');
+
+    const tzip16Uri = {
+      sha256hash: undefined,
+      protocol: 'tezos-storage',
+      location: 'here',
+    };
+
+    const metadata = await tezosStorageHandler.getMetadata(
+      mockContractAbstraction,
+      tzip16Uri,
+      mockContext as any
+    );
+
+    expect(metadata).toEqual('cafe');
+    expect(mockReadProvider.getScript).not.toHaveBeenCalled();
+    expect(mockContractProvider.getBigMapKeyByID).toHaveBeenCalledWith(
+      '32527',
+      'here',
+      expect.anything(),
+      'BLockHash200'
     );
   });
 

--- a/packages/taquito-tzip16/test/tzip16-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip16/test/tzip16-contract-abstraction.spec.ts
@@ -54,6 +54,18 @@ describe('Tzip16 contract abstraction test', () => {
     mockContext['readProvider'] = mockReadProvider;
 
     mockContractAbstraction['schema'] = mockSchema;
+    mockContractAbstraction['readBlock'] = 'BLockHash200';
+    mockContractAbstraction['script'] = {
+      storage: {
+        prim: 'Pair',
+        args: [
+          {
+            int: '20350',
+          },
+          [],
+        ],
+      },
+    };
     mockReadProvider.getStorage.mockResolvedValue({
       prim: 'Pair',
       args: [
@@ -80,6 +92,13 @@ describe('Tzip16 contract abstraction test', () => {
       authors: ['Test <https://test/>'],
       homepage: 'https://test/',
     });
+    expect(mockReadProvider.getStorage).not.toHaveBeenCalled();
+    expect(mockRpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith(
+      '20350',
+      '',
+      expect.anything(),
+      'BLockHash200'
+    );
   });
 
   it('Should get metadata by each property', async () => {

--- a/packages/taquito-tzip16/test/viewKind/michelson-storage-view.spec.ts
+++ b/packages/taquito-tzip16/test/viewKind/michelson-storage-view.spec.ts
@@ -19,6 +19,7 @@ describe('MichelsonStorageView test', () => {
     };
 
     mockContractAbstraction.address = 'KT1test';
+    mockContractAbstraction.readBlock = 'BLockHash200';
     mockContractAbstraction.script = {
       code: [
         { prim: 'parameter', args: [{ prim: 'unit' }] },
@@ -81,6 +82,9 @@ describe('MichelsonStorageView test', () => {
     const result = await michelsonStorageView.executeView();
 
     expect(result.toString()).toEqual('0');
+    expect(mockRpcClient.getStorage).not.toHaveBeenCalled();
+    expect(mockRpcClient.getBalance).toHaveBeenCalledWith('KT1test', { block: 'BLockHash200' });
+    expect(mockRpcClient.getBlockHeader).toHaveBeenCalledWith({ block: 'BLockHash200' });
   });
 
   it('Should throw IllegalInstructionInViewCode when code of the view contains the instruction AMOUNT', async () => {

--- a/packages/taquito/src/contract/big-map.ts
+++ b/packages/taquito/src/contract/big-map.ts
@@ -1,10 +1,16 @@
 import { Schema, BigMapKeyType } from '@taquito/michelson-encoder';
 import BigNumber from 'bignumber.js';
-import { ContractProvider } from './interface';
+import { StorageProvider } from './interface';
 import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
+import { BlockIdentifier } from '../read-provider/interface';
 
 export class BigMapAbstraction {
-  constructor(private id: BigNumber, private schema: Schema, private provider: ContractProvider) {}
+  constructor(
+    private id: BigNumber,
+    private schema: Schema,
+    private provider: StorageProvider,
+    private defaultBlock?: BlockIdentifier
+  ) {}
 
   /**
    *
@@ -15,13 +21,13 @@ export class BigMapAbstraction {
    * @returns Return a well formatted json object of a big map value or undefined if the key is not found in the big map
    *
    */
-  async get<T>(keyToEncode: BigMapKeyType, block?: number) {
+  async get<T>(keyToEncode: BigMapKeyType, block?: BlockIdentifier) {
     try {
       const id = await this.provider.getBigMapKeyByID<T>(
         this.id.toString(),
         keyToEncode,
         this.schema,
-        block
+        block ?? this.defaultBlock
       );
       return id;
     } catch (e) {
@@ -46,12 +52,16 @@ export class BigMapAbstraction {
    * @returns A MichelsonMap containing the keys queried in the big map and their value in a well-formatted JSON object format
    *
    */
-  async getMultipleValues<T>(keysToEncode: Array<BigMapKeyType>, block?: number, batchSize = 5) {
+  async getMultipleValues<T>(
+    keysToEncode: Array<BigMapKeyType>,
+    block?: BlockIdentifier,
+    batchSize = 5
+  ) {
     return this.provider.getBigMapKeysByID<T>(
       this.id.toString(),
       keysToEncode,
       this.schema,
-      block,
+      block ?? this.defaultBlock,
       batchSize
     );
   }

--- a/packages/taquito/src/contract/contract.ts
+++ b/packages/taquito/src/contract/contract.ts
@@ -5,13 +5,9 @@ import {
   RpcClientInterface,
   ScriptResponse,
 } from '@taquito/rpc';
-import {
-  validateChain,
-  validateContractAddress,
-  ValidationResult,
-} from '@taquito/utils';
+import { validateChain, validateContractAddress, ValidationResult } from '@taquito/utils';
 import { ChainIds } from '../constants';
-import { TzReadProvider } from '../read-provider/interface';
+import { BlockIdentifier, TzReadProvider } from '../read-provider/interface';
 import type { Wallet } from '../wallet/wallet';
 import { ContractMethodFactory } from './contract-methods/contract-method-factory';
 import { ContractMethodObject } from './contract-methods/contract-method-object-param';
@@ -20,6 +16,7 @@ import { InvalidParameterError } from './errors';
 import { ContractProvider, StorageProvider } from './interface';
 import { InvalidChainIdError, DeprecationError } from '@taquito/core';
 import { DEFAULT_SMART_CONTRACT_METHOD_NAME } from './constants';
+import { smartContractAbstractionSemantic } from './semantic';
 
 export { DEFAULT_SMART_CONTRACT_METHOD_NAME };
 
@@ -35,7 +32,7 @@ export class ContractView {
     private args: any[],
     private rpc: RpcClientInterface,
     private readProvider: TzReadProvider
-  ) { }
+  ) {}
 
   async read(chainId?: ChainIds) {
     const chainIdValidation = validateChain(chainId ?? '');
@@ -141,7 +138,8 @@ export class ContractAbstraction<
     private storageProvider: StorageProvider,
     public readonly entrypoints: EntrypointsResponse,
     private rpc: RpcClientInterface,
-    private readProvider: TzReadProvider
+    private readProvider: TzReadProvider,
+    public readonly readBlock: BlockIdentifier = 'head'
   ) {
     this.contractMethodFactory = new ContractMethodFactory(provider, address);
     this.schema = Schema.fromRPCResponse({ script: this.script });
@@ -208,9 +206,10 @@ export class ContractAbstraction<
       // Deal with methods with no annotations which were not discovered by the RPC endpoint
       // Methods with no annotations are discovered using parameter schema
       const generatedSchema = parameterSchema.generateSchema();
-      const schemaKeys = generatedSchema.schema && typeof generatedSchema.schema === 'object'
-        ? Object.keys(generatedSchema.schema)
-        : [];
+      const schemaKeys =
+        generatedSchema.schema && typeof generatedSchema.schema === 'object'
+          ? Object.keys(generatedSchema.schema)
+          : [];
       const anonymousMethods = schemaKeys.filter(
         (key) => Object.keys(entrypoints).indexOf(key) === -1
       );
@@ -267,7 +266,14 @@ export class ContractAbstraction<
   /**
    * Return a friendly representation of the smart contract storage
    */
-  public storage<T extends TStorage = TStorage>() {
-    return this.storageProvider.getStorage<T>(this.address, this.schema);
+  public async storage<T extends TStorage = TStorage>() {
+    if (this.readBlock !== 'head') {
+      return this.schema.Execute(
+        this.script.storage,
+        smartContractAbstractionSemantic(this.storageProvider, this.readBlock)
+      ) as T;
+    }
+
+    return this.storageProvider.getStorage<T>(this.address, this.schema, this.readBlock);
   }
 }

--- a/packages/taquito/src/contract/interface.ts
+++ b/packages/taquito/src/contract/interface.ts
@@ -42,6 +42,7 @@ import { SmartRollupAddMessagesOperation } from '../operations/smart-rollup-add-
 import { SmartRollupOriginateOperation } from '../operations/smart-rollup-originate-operation';
 import { SmartRollupExecuteOutboxMessageOperation } from '../operations/smart-rollup-execute-outbox-message-operation';
 import { FailingNoopOperation } from '../operations/failing-noop-operation';
+import type { BlockIdentifier } from '../read-provider/interface';
 
 export type ContractSchema = Schema | unknown;
 
@@ -55,7 +56,7 @@ export interface StorageProvider {
    *
    * @see https://tezos.gitlab.io/api/rpc.html#get-block-id-context-contracts-contract-id-script
    */
-  getStorage<T>(contract: string, schema?: ContractSchema): Promise<T>;
+  getStorage<T>(contract: string, schema?: ContractSchema, block?: BlockIdentifier): Promise<T>;
 
   /**
    *
@@ -72,7 +73,7 @@ export interface StorageProvider {
     id: string,
     keyToEncode: BigMapKeyType,
     schema: Schema,
-    block?: number
+    block?: BlockIdentifier
   ): Promise<T>;
 
   /**
@@ -91,7 +92,7 @@ export interface StorageProvider {
     id: string,
     keysToEncode: Array<BigMapKeyType>,
     schema: Schema,
-    block?: number,
+    block?: BlockIdentifier,
     batchSize?: number
   ): Promise<MichelsonMap<MichelsonMapKey, T | undefined>>;
 
@@ -103,7 +104,7 @@ export interface StorageProvider {
    * @param block optional block level to fetch the value from
    *
    */
-  getSaplingDiffByID(id: string, block?: number): Promise<SaplingDiffResponse>;
+  getSaplingDiffByID(id: string, block?: BlockIdentifier): Promise<SaplingDiffResponse>;
 }
 
 export interface ContractProvider extends StorageProvider {

--- a/packages/taquito/src/contract/not-found-retry.ts
+++ b/packages/taquito/src/contract/not-found-retry.ts
@@ -1,0 +1,36 @@
+import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
+
+const CONTRACT_READ_RETRY_DELAYS_MS = [0, 200, 400, 800];
+
+const sleep = (durationMs: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, durationMs);
+  });
+
+export const isNotFoundError = (error: unknown): error is HttpResponseError =>
+  error instanceof HttpResponseError && error.status === STATUS_CODE.NOT_FOUND;
+
+export const retryOnNotFound = async <T>(
+  read: () => Promise<T>,
+  retryDelaysMs = CONTRACT_READ_RETRY_DELAYS_MS
+): Promise<T> => {
+  let lastError: unknown;
+
+  for (const delayMs of retryDelaysMs) {
+    if (delayMs > 0) {
+      await sleep(delayMs);
+    }
+
+    try {
+      return await read();
+    } catch (error) {
+      if (!isNotFoundError(error)) {
+        throw error;
+      }
+
+      lastError = error;
+    }
+  }
+
+  throw lastError;
+};

--- a/packages/taquito/src/contract/rpc-contract-provider.ts
+++ b/packages/taquito/src/contract/rpc-contract-provider.ts
@@ -90,6 +90,7 @@ import { Provider } from '../provider';
 import { PrepareProvider } from '../prepare';
 import { FailingNoopOperation } from '../operations/failing-noop-operation';
 import { BlockIdentifier } from '../read-provider/interface';
+import { isNotFoundError, retryOnNotFound } from './not-found-retry';
 
 export class RpcContractProvider extends Provider implements ContractProvider, StorageProvider {
   constructor(
@@ -110,12 +111,19 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
    * @throws {@link InvalidContractAddressError}
    * @see https://tezos.gitlab.io/api/rpc.html#get-block-id-context-contracts-contract-id-script
    */
-  async getStorage<T>(contract: string, schema?: ContractSchema): Promise<T> {
+  async getStorage<T>(
+    contract: string,
+    schema?: ContractSchema,
+    block: BlockIdentifier = 'head'
+  ): Promise<T> {
     const contractValidation = validateContractAddress(contract);
     if (contractValidation !== ValidationResult.VALID) {
       throw new InvalidContractAddressError(contract, contractValidation);
     }
-    const script = await this.context.readProvider.getScript(contract, 'head');
+    const script =
+      block === 'head'
+        ? await retryOnNotFound(() => this.context.readProvider.getScript(contract, 'head'))
+        : await this.context.readProvider.getScript(contract, block);
     if (!schema) {
       schema = script;
     }
@@ -127,7 +135,10 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       contractSchema = Schema.fromRPCResponse({ script: schema as ScriptResponse });
     }
 
-    return contractSchema.Execute(script.storage, smartContractAbstractionSemantic(this)) as T; // Cast into T because only the caller can know the true type of the storage
+    return contractSchema.Execute(
+      script.storage,
+      smartContractAbstractionSemantic(this, block)
+    ) as T; // Cast into T because only the caller can know the true type of the storage
   }
 
   /**
@@ -145,24 +156,23 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     id: string,
     keyToEncode: BigMapKeyType,
     schema: Schema,
-    block?: number
+    block?: BlockIdentifier
   ): Promise<T> {
     const { key, type } = schema.EncodeBigMapKey(keyToEncode);
     const { packed } = await this.context.packer.packData({ data: key, type });
 
     const encodedExpr = encodeExpr(packed);
 
-    const bigMapValue = block
-      ? await this.context.readProvider.getBigMapValue(
-          { id: id.toString(), expr: encodedExpr },
-          block
-        )
-      : await this.context.readProvider.getBigMapValue(
-          { id: id.toString(), expr: encodedExpr },
-          'head'
-        );
+    const requestedBlock = block ?? 'head';
+    const bigMapValue = await this.context.readProvider.getBigMapValue(
+      { id: id.toString(), expr: encodedExpr },
+      requestedBlock
+    );
 
-    return schema.ExecuteOnBigMapValue(bigMapValue, smartContractAbstractionSemantic(this)) as T;
+    return schema.ExecuteOnBigMapValue(
+      bigMapValue,
+      smartContractAbstractionSemantic(this, requestedBlock)
+    ) as T;
   }
 
   /**
@@ -184,7 +194,7 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     id: string,
     keys: Array<BigMapKeyType>,
     schema: Schema,
-    block?: number,
+    block?: BlockIdentifier,
     batchSize = 5
   ): Promise<MichelsonMap<MichelsonMapKey, T | undefined>> {
     const level = await this.getBlockForRequest(keys, block);
@@ -210,7 +220,7 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     return bigMapValues;
   }
 
-  private async getBlockForRequest(keys: Array<BigMapKeyType>, block?: number) {
+  private async getBlockForRequest(keys: Array<BigMapKeyType>, block?: BlockIdentifier) {
     return keys.length === 1 || typeof block !== 'undefined'
       ? block
       : await this.context.readProvider.getBlockLevel('head');
@@ -220,7 +230,7 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     keyToEncode: BigMapKeyType,
     id: string,
     schema: Schema,
-    level?: number
+    level?: BlockIdentifier
   ) {
     try {
       return await this.getBigMapKeyByID<T>(id, keyToEncode, schema, level);
@@ -241,11 +251,8 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
    * @param block optional block level to fetch the value from
    *
    */
-  async getSaplingDiffByID(id: string, block?: number) {
-    const saplingState = block
-      ? await this.context.readProvider.getSaplingDiffById({ id: id.toString() }, block)
-      : await this.context.readProvider.getSaplingDiffById({ id: id.toString() }, 'head');
-    return saplingState;
+  async getSaplingDiffByID(id: string, block: BlockIdentifier = 'head') {
+    return this.context.readProvider.getSaplingDiffById({ id: id.toString() }, block);
   }
 
   /**
@@ -918,7 +925,7 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
    */
   async at<T extends DefaultContractType = DefaultContractType>(
     address: string,
-    contractAbstractionComposer: ContractAbstractionComposer<T> = (x) => x as any,
+    contractAbstractionComposer: ContractAbstractionComposer<T> = (x) => x as unknown as T,
     block: BlockIdentifier = 'head'
   ): Promise<T> {
     const addressValidation = validateContractAddress(address);
@@ -947,13 +954,10 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
     } catch (error) {
       // Shadownet's rolling nodes occasionally 404 a just-originated contract at the exact
       // inclusion level even after confirmation. Retry at head so the contract abstraction still
-      // resolves once the node's contract index catches up.
-      if (
-        block !== 'head' &&
-        error instanceof HttpResponseError &&
-        error.status === STATUS_CODE.NOT_FOUND
-      ) {
-        contractState = await loadContractState('head');
+      // resolves once the node's contract index catches up. The head index can lag briefly too,
+      // so give it a few bounded retries before surfacing the 404.
+      if (block !== 'head' && isNotFoundError(error)) {
+        contractState = await retryOnNotFound(() => loadContractState('head'));
       } else {
         throw error;
       }
@@ -966,8 +970,37 @@ export class RpcContractProvider extends Provider implements ContractProvider, S
       this,
       contractState.entrypoints,
       rpc,
-      readProvider
+      readProvider,
+      'head'
     );
+    return contractAbstractionComposer(abs, this.context);
+  }
+
+  async atExactBlock<T extends DefaultContractType = DefaultContractType>(
+    address: string,
+    contractAbstractionComposer: ContractAbstractionComposer<T> = (x) => x as unknown as T,
+    block: BlockIdentifier
+  ): Promise<T> {
+    const addressValidation = validateContractAddress(address);
+    if (addressValidation !== ValidationResult.VALID) {
+      throw new InvalidContractAddressError(address, addressValidation);
+    }
+
+    const rpc = this.context.withExtensions().rpc;
+    const readProvider = this.context.withExtensions().readProvider;
+    const script = await readProvider.getScript(address, block);
+    const entrypoints = await rpc.getEntrypoints(address, { block: String(block) });
+    const abs = new ContractAbstraction(
+      address,
+      script,
+      this,
+      this,
+      entrypoints,
+      rpc,
+      readProvider,
+      block
+    );
+
     return contractAbstractionComposer(abs, this.context);
   }
 

--- a/packages/taquito/src/contract/sapling-state-abstraction.ts
+++ b/packages/taquito/src/contract/sapling-state-abstraction.ts
@@ -1,22 +1,27 @@
 import BigNumber from 'bignumber.js';
-import { ContractProvider } from './interface';
+import { StorageProvider } from './interface';
+import { BlockIdentifier } from '../read-provider/interface';
 
 export class SaplingStateAbstraction {
-    constructor(private id: BigNumber, private provider: ContractProvider) { }
+  constructor(
+    private id: BigNumber,
+    private provider: StorageProvider,
+    private defaultBlock?: BlockIdentifier
+  ) {}
 
-    /**
-     *
-     * Fetch the sapling state
-     * 
-     * @param block optional block level to fetch the values from (head will be use by default)
-     * @returns Return a json object of the sapling_state
-     *
-     */
-    async getSaplingDiff(block?: number) {
-        return this.provider.getSaplingDiffByID(this.id.toString(), block);
-    }
+  /**
+   *
+   * Fetch the sapling state
+   *
+   * @param block optional block level to fetch the values from (head will be use by default)
+   * @returns Return a json object of the sapling_state
+   *
+   */
+  async getSaplingDiff(block?: BlockIdentifier) {
+    return this.provider.getSaplingDiffByID(this.id.toString(), block ?? this.defaultBlock);
+  }
 
-    getId() {
-        return this.id.toString();
-    }
+  getId() {
+    return this.id.toString();
+  }
 }

--- a/packages/taquito/src/contract/semantic.ts
+++ b/packages/taquito/src/contract/semantic.ts
@@ -1,18 +1,20 @@
 import { Schema, Semantic } from '@taquito/michelson-encoder';
 import { BigMapAbstraction } from './big-map';
-import { ContractProvider } from './interface';
+import { StorageProvider } from './interface';
 import BigNumber from 'bignumber.js';
 import { MichelsonV1Expression } from '@taquito/rpc';
 import { SaplingStateAbstraction } from './sapling-state-abstraction';
+import { BlockIdentifier } from '../read-provider/interface';
 
 /**
  * Override the default michelson encoder semantic to provide richer abstraction over storage properties
- * @param p ContractProvider (contract API)
+ * @param p StorageProvider (contract API)
  */
 // Override the default michelson encoder semantic to provide richer abstraction over storage properties
-export const smartContractAbstractionSemantic: (p: ContractProvider) => Semantic = (
-  provider: ContractProvider
-) => ({
+export const smartContractAbstractionSemantic: (
+  p: StorageProvider,
+  block?: BlockIdentifier
+) => Semantic = (provider: StorageProvider, block?: BlockIdentifier) => ({
   // Provide a specific abstraction for BigMaps
   big_map: (val: MichelsonV1Expression, code: MichelsonV1Expression) => {
     if (!val || !('int' in val) || val.int === undefined) {
@@ -20,7 +22,7 @@ export const smartContractAbstractionSemantic: (p: ContractProvider) => Semantic
       return {};
     } else {
       const schema = new Schema(code);
-      return new BigMapAbstraction(new BigNumber(val.int), schema, provider);
+      return new BigMapAbstraction(new BigNumber(val.int), schema, provider, block);
     }
   },
   sapling_state: (val: MichelsonV1Expression) => {
@@ -28,7 +30,7 @@ export const smartContractAbstractionSemantic: (p: ContractProvider) => Semantic
       // Return an empty object in case of missing sapling state ID
       return {};
     } else {
-      return new SaplingStateAbstraction(new BigNumber(val.int), provider);
+      return new SaplingStateAbstraction(new BigNumber(val.int), provider, block);
     }
   },
   /*

--- a/packages/taquito/src/operations/operations.ts
+++ b/packages/taquito/src/operations/operations.ts
@@ -103,6 +103,7 @@ interface PollingConfig {
 export class Operation {
   private _pollingConfig$ = new ReplaySubject<PollingConfig>(1);
   private lastHead: BlockResponse | undefined;
+  protected _includedInBlock = new ReplaySubject<BlockResponse>(1);
 
   private currentHead$ = this._pollingConfig$.pipe(
     switchMap((config) => {
@@ -135,11 +136,13 @@ export class Operation {
   private confirmed$ = this.currentHead$.pipe(
     map((head) => {
       for (let i = 3; i >= 0; i--) {
-        head.operations[i].forEach((op) => {
+        for (const op of head.operations[i]) {
           if (op.hash === this.hash) {
             this._foundAt = head.header.level;
+            this._includedInBlock.next(head);
+            return this._foundAt;
           }
-        });
+        }
       }
 
       if (head.header.level - this._foundAt >= 0) {
@@ -154,6 +157,15 @@ export class Operation {
   protected _foundAt = Number.POSITIVE_INFINITY;
   get includedInBlock() {
     return this._foundAt;
+  }
+
+  protected async getInclusionBlock() {
+    const inclusionBlock = await this._includedInBlock.pipe(first()).toPromise();
+    if (!inclusionBlock) {
+      throw new Error('Inclusion block is undefined');
+    }
+
+    return inclusionBlock;
   }
   /**
    *

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -7,6 +7,7 @@ import { BigNumber } from 'bignumber.js';
 import { Context } from '../context';
 import { DefaultContractType } from '../contract/contract';
 import { RpcContractProvider } from '../contract/rpc-contract-provider';
+import { isBlockHashIdentifier } from '../read-provider/interface';
 import { OriginationOperationError } from './errors';
 import { Operation } from './operations';
 import {
@@ -115,10 +116,16 @@ export class OriginationOperation<TContract extends DefaultContractType = Defaul
     if (!Number.isFinite(this.includedInBlock)) {
       throw new OriginationOperationError('Confirmation completed but includedInBlock was not set');
     }
+
+    const inclusionBlock = await this.getInclusionBlock();
+    if (!isBlockHashIdentifier(inclusionBlock.hash)) {
+      throw new OriginationOperationError('Confirmation completed but includedInBlock was not set');
+    }
+
     return this.contractProvider.at<TContract>(
       this.contractAddress,
       undefined,
-      this.includedInBlock
+      inclusionBlock.hash
     );
   }
 }

--- a/packages/taquito/src/provider.ts
+++ b/packages/taquito/src/provider.ts
@@ -31,6 +31,14 @@ import { PreparedOperation } from './prepare';
 import { Estimate } from './estimate';
 
 export abstract class Provider {
+  private clearRpcCache() {
+    const rpc = this.context.rpc as { deleteAllCachedData?: () => void };
+
+    if (typeof rpc.deleteAllCachedData === 'function') {
+      rpc.deleteAllCachedData();
+    }
+  }
+
   private parseRpcErrors(error: unknown) {
     if (!(error instanceof HttpResponseError)) {
       return [];
@@ -73,7 +81,7 @@ export abstract class Provider {
     }
   }
 
-  private parseCounterInThePastAdjustments(error: unknown) {
+  private parseCounterAdjustments(error: unknown) {
     return this.parseRpcErrors(error)
       .filter(
         (value): value is { id: string; contract: string; expected: string; found: string } => {
@@ -83,7 +91,8 @@ export abstract class Provider {
           const found = value.found;
           return (
             typeof id === 'string' &&
-            id.endsWith('contract.counter_in_the_past') &&
+            (id.endsWith('contract.counter_in_the_past') ||
+              id.endsWith('contract.counter_in_the_future')) &&
             typeof contract === 'string' &&
             typeof expected === 'string' &&
             typeof found === 'string'
@@ -95,7 +104,7 @@ export abstract class Provider {
         expected: BigInt(value.expected),
         found: BigInt(value.found),
       }))
-      .filter((value) => value.expected > value.found);
+      .filter((value) => value.expected !== value.found);
   }
 
   private hasGasLimitTooHighAndBlockExhausted(error: unknown) {
@@ -374,7 +383,7 @@ export abstract class Provider {
         context: this.context.clone(),
       };
     } catch (error) {
-      const adjustments = this.parseCounterInThePastAdjustments(error);
+      const adjustments = this.parseCounterAdjustments(error);
       const patchedOp = this.patchSimulationCounters(op, adjustments);
 
       if (patchedOp) {
@@ -438,12 +447,26 @@ export abstract class Provider {
   }
 
   protected async signAndInject(forgedBytes: ForgedBytes) {
-    const signed = await this.signer.sign(forgedBytes.opbytes, new Uint8Array([3]));
-    forgedBytes.opbytes = signed.sbytes;
-    forgedBytes.opOb.signature = signed.prefixSig;
-
+    let signedForgedBytes = await this.signForgedBytes(forgedBytes);
     const opResponse: OperationContentsAndResult[] = [];
-    const results = await this.rpc.preapplyOperations([forgedBytes.opOb]);
+    let results;
+
+    try {
+      results = await this.rpc.preapplyOperations([signedForgedBytes.opOb]);
+    } catch (error) {
+      const adjustments = this.parseCounterAdjustments(error);
+      const patchedForgedBytes = await this.patchForgedBytesCounters(
+        signedForgedBytes,
+        adjustments
+      );
+
+      if (!patchedForgedBytes) {
+        throw error;
+      }
+
+      signedForgedBytes = await this.signForgedBytes(patchedForgedBytes);
+      results = await this.rpc.preapplyOperations([signedForgedBytes.opOb]);
+    }
 
     if (!Array.isArray(results)) {
       throw new TezosPreapplyFailureError(results);
@@ -465,11 +488,82 @@ export abstract class Provider {
       );
     }
 
+    const hash = await this.context.injector.inject(signedForgedBytes.opbytes);
+    this.clearRpcCache();
+
     return {
-      hash: await this.context.injector.inject(forgedBytes.opbytes),
-      forgedBytes,
+      hash,
+      forgedBytes: signedForgedBytes,
       opResponse,
       context: this.context.clone(),
+    };
+  }
+
+  private async signForgedBytes(forgedBytes: ForgedBytes): Promise<ForgedBytes> {
+    const signed = await this.signer.sign(forgedBytes.opbytes, new Uint8Array([3]));
+
+    return {
+      ...forgedBytes,
+      opbytes: signed.sbytes,
+      opOb: {
+        ...forgedBytes.opOb,
+        signature: signed.prefixSig,
+      },
+    };
+  }
+
+  private async patchForgedBytesCounters(
+    forgedBytes: ForgedBytes,
+    adjustments: { contract: string; expected: bigint; found: bigint }[]
+  ): Promise<ForgedBytes | undefined> {
+    if (adjustments.length === 0 || !Array.isArray(forgedBytes.opOb.contents)) {
+      return;
+    }
+
+    const branch = forgedBytes.opOb.branch;
+    if (typeof branch !== 'string') {
+      return;
+    }
+
+    const contents = forgedBytes.opOb.contents.map((content) => ({ ...content }));
+    let patched = false;
+
+    for (const adjustment of adjustments) {
+      const delta = adjustment.expected - adjustment.found;
+      for (const content of contents) {
+        const source = (content as { source?: string }).source;
+        const counter = (content as { counter?: string | number }).counter;
+
+        if (source !== adjustment.contract || typeof counter === 'undefined') {
+          continue;
+        }
+
+        const contentCounter = BigInt(String(counter));
+        if (contentCounter < adjustment.found) {
+          continue;
+        }
+
+        (content as { counter: string }).counter = (contentCounter + delta).toString();
+        patched = true;
+      }
+    }
+
+    if (!patched) {
+      return;
+    }
+
+    const unsignedOpBytes = await this.context.forger.forge({
+      branch,
+      contents,
+    });
+
+    return {
+      ...forgedBytes,
+      opbytes: unsignedOpBytes,
+      opOb: {
+        ...forgedBytes.opOb,
+        contents,
+      },
     };
   }
 }

--- a/packages/taquito/src/read-provider/interface.ts
+++ b/packages/taquito/src/read-provider/interface.ts
@@ -1,3 +1,4 @@
+import { validateBlock, ValidationResult } from '@taquito/utils';
 import {
   BlockResponse,
   EntrypointsResponse,
@@ -19,6 +20,10 @@ export type SaplingStateQuery = {
 
 // block identifier can be head, a block relative to head, a block hash or a block level
 export type BlockIdentifier = 'head' | `head~${number}` | `B${string}` | number;
+
+export const isBlockHashIdentifier = (block: string): block is `B${string}` => {
+  return validateBlock(block) === ValidationResult.VALID;
+};
 
 export interface TzReadProvider {
   /**

--- a/packages/taquito/src/wallet/origination-operation.ts
+++ b/packages/taquito/src/wallet/origination-operation.ts
@@ -7,6 +7,7 @@ import {
 import { Observable } from 'rxjs';
 import { Context } from '../context';
 import { DefaultWalletType } from '../contract/contract';
+import { isBlockHashIdentifier } from '../read-provider/interface';
 import { findWithKind } from '../operations/types';
 import { WalletOperation, OperationStatus } from './operation';
 import { ObservableError, OriginationWalletOperationError } from './errors';
@@ -66,7 +67,10 @@ export class OriginationWalletOperation<
 
     await this.confirmation();
     const inclusionBlock = await this.getInclusionBlock();
+    if (!isBlockHashIdentifier(inclusionBlock.hash)) {
+      throw new OriginationWalletOperationError('Inclusion block hash is invalid');
+    }
 
-    return this.context.wallet.at<TWallet>(address, undefined, inclusionBlock.header.level);
+    return this.context.wallet.at<TWallet>(address, undefined, inclusionBlock.hash);
   }
 }

--- a/packages/taquito/src/wallet/wallet.ts
+++ b/packages/taquito/src/wallet/wallet.ts
@@ -25,10 +25,10 @@ import {
   InvalidStakingAddressError,
   InvalidFinalizeUnstakeAmountError,
 } from '@taquito/core';
-import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { validateAddress, validateContractAddress, ValidationResult } from '@taquito/utils';
 import { EntrypointsResponse, OperationContentsFailingNoop, ScriptedContracts } from '@taquito/rpc';
 import { BlockIdentifier } from '../read-provider/interface';
+import { isNotFoundError, retryOnNotFound } from '../contract/not-found-retry';
 
 export interface PKHOption {
   forceRefetch?: boolean;
@@ -503,7 +503,7 @@ export class Wallet {
   async at<T extends ContractAbstraction<Wallet>>(
     address: string,
     contractAbstractionComposer: (abs: ContractAbstraction<Wallet>, context: Context) => T = (x) =>
-      x as any,
+      x as unknown as T,
     block: BlockIdentifier = 'head'
   ): Promise<T> {
     const addressValidation = validateContractAddress(address);
@@ -533,13 +533,10 @@ export class Wallet {
       // Newly originated contracts can be visible at the operation's inclusion level in one RPC
       // call and still lag on another endpoint of the same rolling node. Retry at head so
       // wallet op.contract() behaves like octez-client, which resolves the originated contract
-      // after confirmation instead of pinning itself to a stale context forever.
-      if (
-        block !== 'head' &&
-        error instanceof HttpResponseError &&
-        error.status === STATUS_CODE.NOT_FOUND
-      ) {
-        contractState = await loadContractState('head');
+      // after confirmation instead of pinning itself to a stale context forever. The head index
+      // can lag briefly as well, so bound a few retries there too.
+      if (block !== 'head' && isNotFoundError(error)) {
+        contractState = await retryOnNotFound(() => loadContractState('head'));
       } else {
         throw error;
       }
@@ -552,8 +549,38 @@ export class Wallet {
       this.context.contract,
       contractState.entrypoints,
       rpc,
-      readProvider
+      readProvider,
+      'head'
     );
+    return contractAbstractionComposer(abs, this.context);
+  }
+
+  async atExactBlock<T extends ContractAbstraction<Wallet>>(
+    address: string,
+    contractAbstractionComposer: (abs: ContractAbstraction<Wallet>, context: Context) => T = (x) =>
+      x as unknown as T,
+    block: BlockIdentifier
+  ): Promise<T> {
+    const addressValidation = validateContractAddress(address);
+    if (addressValidation !== ValidationResult.VALID) {
+      throw new InvalidContractAddressError(address, addressValidation);
+    }
+
+    const rpc = this.context.withExtensions().rpc;
+    const readProvider = this.context.withExtensions().readProvider;
+    const script = await readProvider.getScript(address, block);
+    const entrypoints = await rpc.getEntrypoints(address, { block: String(block) });
+    const abs = new ContractAbstraction(
+      address,
+      script,
+      this,
+      this.context.contract,
+      entrypoints,
+      rpc,
+      readProvider,
+      block
+    );
+
     return contractAbstractionComposer(abs, this.context);
   }
 }

--- a/packages/taquito/test/contract/big-map.spec.ts
+++ b/packages/taquito/test/contract/big-map.spec.ts
@@ -128,6 +128,28 @@ describe('BigMapAbstraction test', () => {
       expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith('1', '23', schema, 123456);
     });
 
+    it('uses the pinned read block when no block is provided', async () => {
+      rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
+      const schema = new Schema({
+        prim: 'big_map',
+        args: [{ prim: 'int' }, { prim: 'string' }],
+      });
+      const bigMap = new BigMapAbstraction(
+        new BigNumber('1'),
+        schema,
+        rpcContractProvider as any,
+        'BLockHash200'
+      );
+
+      expect(await bigMap.get('23')).toEqual('test');
+      expect(rpcContractProvider.getBigMapKeyByID).toHaveBeenCalledWith(
+        '1',
+        '23',
+        schema,
+        'BLockHash200'
+      );
+    });
+
     it('includes type argument when calling the get method', async () => {
       rpcContractProvider.getBigMapKeyByID.mockResolvedValue('test');
       const schema = new Schema({

--- a/packages/taquito/test/contract/rpc-contract-provider-bigmap.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider-bigmap.spec.ts
@@ -107,6 +107,38 @@ describe('RpcContractProvider test', () => {
         '3': new BigNumber('200'),
       });
     });
+
+    it('should retry head reads when the contract index briefly returns 404', async () => {
+      mockRpcClient.getContract
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockResolvedValueOnce({
+          counter: 0,
+          script: {
+            code: [sample],
+            storage: sampleStorage,
+          },
+        });
+
+      const result = await rpcContractProvider.getStorage('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D');
+
+      expect(result).toEqual({
+        '0': {},
+        '1': 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        '2': false,
+        '3': new BigNumber('200'),
+      });
+      expect(mockRpcClient.getContract).toHaveBeenCalledTimes(3);
+      expect(mockRpcClient.getContract).toHaveBeenNthCalledWith(
+        1,
+        'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+        { block: 'head' }
+      );
+    });
   });
 
   describe('getBigMapKeyByID', () => {
@@ -710,6 +742,24 @@ describe('RpcContractProvider test', () => {
 
       const keyList = storage.keyMap;
       expect(keyList.size).toEqual(1);
+    });
+
+    it('reuses the pinned script storage for exact-block contract abstractions', async () => {
+      mockRpcClient.getEntrypoints.mockResolvedValue({
+        entrypoints: {},
+      });
+      mockRpcClient.getContract.mockResolvedValue(ticketTokenTestMock);
+
+      const rpcContract = await rpcContractProvider.atExactBlock(
+        'KT19mzgsjrR2Er4rm4vuDqAcMfBF5DBMs2uq',
+        undefined,
+        'BLockHash200'
+      );
+      const storage = (await rpcContract.storage()) as any;
+
+      expect(mockRpcClient.getContract).toHaveBeenCalledTimes(1);
+      expect(rpcContract.readBlock).toEqual('BLockHash200');
+      expect(storage.keyMap.size).toEqual(3);
     });
   });
 });

--- a/packages/taquito/test/contract/rpc-contract-provider.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider.spec.ts
@@ -50,6 +50,7 @@ describe('RpcContractProvider test', () => {
     getProtocols: ReturnType<typeof vi.fn>;
     getCurrentPeriod: ReturnType<typeof vi.fn>;
     getConstants: ReturnType<typeof vi.fn>;
+    deleteAllCachedData: ReturnType<typeof vi.fn>;
   };
 
   let mockReadProvider: {
@@ -115,6 +116,7 @@ describe('RpcContractProvider test', () => {
       getProtocols: vi.fn(),
       getCurrentPeriod: vi.fn(),
       getConstants: vi.fn(),
+      deleteAllCachedData: vi.fn(),
     };
 
     mockForger = {
@@ -405,7 +407,11 @@ describe('RpcContractProvider test', () => {
         new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
       );
 
-      await rpcContractProvider.at('KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD', undefined, 200);
+      const contract = await rpcContractProvider.at(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        undefined,
+        200
+      );
 
       expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
         1,
@@ -420,6 +426,85 @@ describe('RpcContractProvider test', () => {
       expect(mockReadProvider.getEntrypoints).toHaveBeenCalledWith(
         'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD'
       );
+      expect(contract.readBlock).toEqual('head');
+    });
+
+    it('should use an exact block for bootstrap reads without pinning later reads to it', async () => {
+      const contract = await rpcContractProvider.at(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        undefined,
+        'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000'
+      );
+
+      expect(mockReadProvider.getScript).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000'
+      );
+      expect(mockRpcClient.getEntrypoints).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        { block: 'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000' }
+      );
+      expect(contract.readBlock).toEqual('head');
+    });
+
+    it('should read script and entrypoints from the exact block hash without head fallback', async () => {
+      const contract = await rpcContractProvider.atExactBlock(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        undefined,
+        'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000'
+      );
+
+      expect(mockReadProvider.getScript).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000'
+      );
+      expect(mockRpcClient.getEntrypoints).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        { block: 'BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000' }
+      );
+      expect(mockReadProvider.getEntrypoints).not.toHaveBeenCalled();
+      expect(contract.readBlock).toEqual('BKjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD0000000000000');
+    });
+
+    it('should keep retrying at head while the contract index catches up', async () => {
+      mockReadProvider.getScript
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockRejectedValueOnce(
+          new HttpResponseError('fail', STATUS_CODE.NOT_FOUND, 'err', 'test', 'https://test.com')
+        )
+        .mockResolvedValueOnce({
+          code: [{ prim: 'parameter', args: [{ prim: 'unit' }] }, sample],
+          storage: sampleStorage,
+        });
+
+      await rpcContractProvider.at('KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD', undefined, 200);
+
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        1,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        200
+      );
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        2,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'head'
+      );
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        3,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'head'
+      );
+      expect(mockReadProvider.getScript).toHaveBeenNthCalledWith(
+        4,
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        'head'
+      );
+      expect(mockReadProvider.getEntrypoints).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -486,6 +571,54 @@ describe('RpcContractProvider test', () => {
         },
         opbytes: 'test',
       });
+    });
+
+    it('should retry preapply with RPC expected counters when validation is ahead of the contract index', async () => {
+      mockForger.forge
+        .mockResolvedValueOnce('forged-initial')
+        .mockResolvedValueOnce('forged-retry');
+      mockSigner.sign.mockImplementation(async (opbytes: string) => ({
+        sbytes: `signed:${opbytes}`,
+        prefixSig: `sig:${opbytes}`,
+      }));
+      mockRpcClient.preapplyOperations
+        .mockRejectedValueOnce(
+          new HttpResponseError(
+            'Http error response: (500) counter_in_the_past',
+            500 as any,
+            'Internal Server Error',
+            JSON.stringify([
+              {
+                kind: 'branch',
+                id: 'proto.024-PtTALLiN.contract.counter_in_the_past',
+                contract: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+                expected: '4',
+                found: '1',
+              },
+            ]),
+            'http://example.test/chains/main/blocks/head/helpers/preapply/operations'
+          )
+        )
+        .mockResolvedValueOnce([]);
+
+      const result = await rpcContractProvider.transfer({
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      });
+
+      expect(mockRpcClient.preapplyOperations).toHaveBeenCalledTimes(2);
+      expect(mockRpcClient.preapplyOperations.mock.calls[0][0][0].contents[0].counter).toEqual('1');
+      expect(mockRpcClient.preapplyOperations.mock.calls[0][0][0].contents[1].counter).toEqual('2');
+      expect(mockRpcClient.preapplyOperations.mock.calls[1][0][0].contents[0].counter).toEqual('4');
+      expect(mockRpcClient.preapplyOperations.mock.calls[1][0][0].contents[1].counter).toEqual('5');
+      expect(mockRpcClient.injectOperation).toHaveBeenCalledWith('signed:forged-retry');
+      expect(result.raw.opbytes).toEqual('signed:forged-retry');
+      expect(result.raw.opOb.signature).toEqual('sig:forged-retry');
+      expect(result.raw.opOb.contents[0].counter).toEqual('4');
+      expect(result.raw.opOb.contents[1].counter).toEqual('5');
     });
 
     it('should omit reveal operation if manager is defined (BABY)', async () => {
@@ -652,6 +785,85 @@ describe('RpcContractProvider test', () => {
         id: 'proto.005-PsBabyM1.gas_exhausted.operation',
         message: '(temporary) proto.005-PsBabyM1.gas_exhausted.operation',
       });
+    });
+
+    it('should retry preapply with RPC expected counters when counter_in_the_past is returned', async () => {
+      const params = {
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.sign
+        .mockResolvedValueOnce({ sbytes: 'test-signed-1', prefixSig: 'test_sig_1' })
+        .mockResolvedValueOnce({ sbytes: 'test-signed-2', prefixSig: 'test_sig_2' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM');
+      mockForger.forge.mockResolvedValueOnce('test').mockResolvedValueOnce('test-reforged');
+      mockRpcClient.preapplyOperations
+        .mockRejectedValueOnce(
+          new HttpResponseError(
+            'Http error response: (500) counter_in_the_past',
+            500 as any,
+            'Internal Server Error',
+            JSON.stringify([
+              {
+                kind: 'branch',
+                id: 'proto.024-PtTALLiN.contract.counter_in_the_past',
+                contract: 'tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM',
+                expected: '5',
+                found: '1',
+              },
+            ]),
+            'http://example.test/chains/main/blocks/head/helpers/preapply/operations'
+          )
+        )
+        .mockResolvedValueOnce([]);
+      mockRpcClient.injectOperation.mockResolvedValue(
+        'oo6JPEAy8VuMRGaFuMmLNFFGdJgiaKfnmT1CpHJfKP3Ye5ZahiP'
+      );
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      await rpcContractProvider.transfer(params);
+
+      expect(mockRpcClient.preapplyOperations).toHaveBeenCalledTimes(2);
+      expect(mockSigner.sign).toHaveBeenCalledTimes(2);
+
+      const firstCallContents = mockRpcClient.preapplyOperations.mock.calls[0][0][0].contents;
+      const secondCallContents = mockRpcClient.preapplyOperations.mock.calls[1][0][0].contents;
+
+      expect(firstCallContents[0].counter).toEqual('1');
+      expect(secondCallContents[0].counter).toEqual('5');
+      expect(mockRpcClient.injectOperation).toHaveBeenCalledWith('test-signed-2');
+    });
+
+    it('should clear cached head reads after a successful injection', async () => {
+      const params = {
+        to: 'tz1QZ6KY7d3BuZDT1d19dUxoQrtFPN2QJ3hn',
+        amount: 2,
+        fee: 10000,
+        gasLimit: 10600,
+        storageLimit: 300,
+      };
+      mockRpcClient.getContract.mockResolvedValue({ counter: 0 });
+      mockRpcClient.getBlockHeader.mockResolvedValue({ hash: 'test' });
+      mockRpcClient.preapplyOperations.mockResolvedValue([]);
+      mockRpcClient.getManagerKey.mockResolvedValue('test');
+      mockRpcClient.getBlockMetadata.mockResolvedValue({ next_protocol: 'test_proto' });
+      mockSigner.sign.mockResolvedValue({ sbytes: 'test-signed', prefixSig: 'test_sig' });
+      mockSigner.publicKey.mockResolvedValue('test_pub_key');
+      mockSigner.publicKeyHash.mockResolvedValue('tz1gvF4cD2dDtqitL3ZTraggSR1Mju2BKFEM');
+      mockReadProvider.isAccountRevealed.mockResolvedValue(true);
+
+      await rpcContractProvider.transfer(params);
+
+      expect(mockRpcClient.deleteAllCachedData).toHaveBeenCalledTimes(1);
+      expect(mockRpcClient.injectOperation).toHaveBeenCalledWith('test-signed');
     });
 
     it('should omit reveal operation if manager is defined', async () => {

--- a/packages/taquito/test/contract/sapling-state-abs.spec.ts
+++ b/packages/taquito/test/contract/sapling-state-abs.spec.ts
@@ -145,6 +145,18 @@ describe('SaplingStateAbstraction test', () => {
       expect(result.nullifiers.length).toEqual(2);
     });
 
+    it('uses the pinned read block when no block is provided', async () => {
+      const saplingState = new SaplingStateAbstraction(
+        new BigNumber('1'),
+        rpcContractProvider as any,
+        'BLockHash200'
+      );
+
+      await saplingState.getSaplingDiff();
+
+      expect(rpcContractProvider.getSaplingDiffByID).toHaveBeenCalledWith('1', 'BLockHash200');
+    });
+
     it('returns the sapling state id', async () => {
       const saplingState = new SaplingStateAbstraction(
         new BigNumber('12'),

--- a/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
+++ b/packages/taquito/test/estimate/rpc-estimate-provider.spec.ts
@@ -1605,6 +1605,64 @@ describe('RPCEstimateProvider test wallet', () => {
       expect(secondCallContents[1].counter).toEqual('8903757');
     });
 
+    it('retries simulation with RPC expected counters when counter_in_the_future is returned', async () => {
+      mockRpcClient.getManagerKey.mockResolvedValue(null);
+      mockRpcClient.getContract.mockResolvedValue({ counter: '8903746' });
+      mockRpcClient.simulateOperation
+        .mockRejectedValueOnce(
+          new HttpResponseError(
+            'Http error response: (500) counter_in_the_future',
+            500 as any,
+            'Internal Server Error',
+            JSON.stringify([
+              {
+                kind: 'temporary',
+                id: 'proto.024-PtTALLiN.contract.counter_in_the_future',
+                contract: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+                expected: '8903746',
+                found: '8903747',
+              },
+            ]),
+            'http://example.test/chains/main/blocks/head/helpers/scripts/simulate_operation'
+          )
+        )
+        .mockResolvedValueOnce({
+          contents: [
+            {
+              kind: 'reveal',
+              source: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+              fee: 10000,
+              metadata: {
+                operation_result: { status: 'applied', consumed_milligas: '1000' },
+              },
+            },
+            {
+              kind: 'delegation',
+              source: 'tz1VSUr8wwNhLAzempoch5d6hLRiTh8Cjcjb',
+              fee: 10000,
+              metadata: {
+                operation_result: { status: 'applied', consumed_milligas: '10000000' },
+              },
+            },
+          ],
+        });
+
+      mockForger.forge.mockResolvedValue(new Array(149).fill('aa').join(''));
+
+      const estimate = await estimateProvider.registerDelegate({});
+      expect(estimate.gasLimit).toBeGreaterThan(0);
+
+      expect(mockRpcClient.simulateOperation).toHaveBeenCalledTimes(2);
+      const firstCallContents = mockRpcClient.simulateOperation.mock.calls[0][0].operation.contents;
+      const secondCallContents =
+        mockRpcClient.simulateOperation.mock.calls[1][0].operation.contents;
+
+      expect(firstCallContents[0].counter).toEqual('8903747');
+      expect(firstCallContents[1].counter).toEqual('8903748');
+      expect(secondCallContents[0].counter).toEqual('8903746');
+      expect(secondCallContents[1].counter).toEqual('8903747');
+    });
+
     it('retries simulation for a single auto-patched manager operation when reveal-reserved gas is already below the hard limit', async () => {
       const highLimits = {
         hard_gas_limit_per_operation: new BigNumber(1040000),

--- a/packages/taquito/test/operations/origination-operation.spec.ts
+++ b/packages/taquito/test/operations/origination-operation.spec.ts
@@ -1,5 +1,6 @@
 import { defaultConfigConfirmation } from '../../src/context';
-import { OriginationOperation, ForgedBytes } from '@taquito/taquito';
+import { OriginationOperation } from '../../src/operations/origination-operation';
+import { ForgedBytes } from '../../src/operations/types';
 import { OperationContentsAndResult } from '@taquito/rpc';
 import { OriginationOperationBuilder, RevealOperationBuilder } from '../helpers';
 import { OriginationOperationError } from '../../src/operations/errors';
@@ -78,6 +79,7 @@ describe('Origination operation', () => {
     };
 
     fakeContext.rpc.getBlock.mockResolvedValue({
+      hash: 'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw',
       operations: [[{ hash: 'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj' }], [], [], []],
       header: {
         level: 200,
@@ -182,7 +184,32 @@ describe('Origination operation', () => {
       expect(fakeContractProvider.at).toHaveBeenCalledWith(
         'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
         undefined,
-        200
+        'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw'
+      );
+    });
+
+    it('should resolve the originated contract using the inclusion block hash for bootstrap', async () => {
+      const fakeContractProvider: any = {
+        at: vi.fn(),
+      };
+
+      fakeContractProvider.at.mockResolvedValue('contract');
+
+      const op = new OriginationOperation(
+        'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
+        {} as any,
+        fakeForgedBytes,
+        successfulResult,
+        fakeContext,
+        fakeContractProvider
+      );
+
+      await expect(op.contract()).resolves.toBe('contract');
+      expect(fakeContractProvider.at).toHaveBeenCalledTimes(1);
+      expect(fakeContractProvider.at).toHaveBeenCalledWith(
+        'KT1KjGmnNQ6iXWr8VHGM8n8b8EQXHc6eRsPD',
+        undefined,
+        'BLJjnzaPtSsxykZ9pLTFLSfsKuiN3z7SjSPDPWwbE4Q68u5EpBw'
       );
     });
 
@@ -208,10 +235,10 @@ describe('Origination operation', () => {
 
     it('should throw an error if no contract is available', async () => {
       const fakeContractProvider: any = {
-        at: vi.fn(),
+        atExactBlock: vi.fn(),
       };
 
-      fakeContractProvider.at.mockResolvedValue('contract');
+      fakeContractProvider.atExactBlock.mockResolvedValue('contract');
       const op = new OriginationOperation(
         'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj',
         {} as any,

--- a/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
+++ b/packages/taquito/test/wallet/contract-abstraction-composer-wallet.spec.ts
@@ -75,4 +75,22 @@ describe('Contract abstraction composer test', () => {
       'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D'
     );
   });
+
+  it('should read the contract from the exact block hash without consulting head entrypoints', async () => {
+    await toolkit.wallet.atExactBlock(
+      'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+      undefined,
+      'BLockHash200'
+    );
+
+    expect(mockRpcClient.getContract).toHaveBeenCalledWith('KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D', {
+      block: 'BLockHash200',
+    });
+    expect(mockRpcClient.getEntrypoints).toHaveBeenCalledWith(
+      'KT1Fe71jyjrxFg9ZrYqtvaX7uQjcLo7svE4D',
+      {
+        block: 'BLockHash200',
+      }
+    );
+  });
 });

--- a/packages/taquito/test/wallet/origination-wallet-operation.spec.ts
+++ b/packages/taquito/test/wallet/origination-wallet-operation.spec.ts
@@ -6,7 +6,7 @@ import { OriginationWalletOperationError } from '../../src/wallet/errors';
 
 const createFakeBlock = (level: number, opHash?: string, contents: unknown[] = []): BlockResponse =>
   ({
-    hash: `block_hash_${level}`,
+    hash: 'BMEdgRZbJJqUrtByoA5Jyuvy8mzp8mefbcrno82nQCAEbBCUhog',
     header: {
       level,
     },
@@ -56,7 +56,62 @@ describe('OriginationWalletOperation', () => {
     blockObservable.next(createFakeBlock(201));
 
     await expect(contractPromise).resolves.toBe('contract');
-    expect(wallet.at).toHaveBeenCalledWith('KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX', undefined, 200);
+    expect(wallet.at).toHaveBeenCalledWith(
+      'KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX',
+      undefined,
+      'BMEdgRZbJJqUrtByoA5Jyuvy8mzp8mefbcrno82nQCAEbBCUhog'
+    );
+  });
+
+  it('uses the inclusion block hash to bootstrap the wallet lookup', async () => {
+    const wallet = {
+      at: vi.fn().mockResolvedValue('contract'),
+    };
+    const operationHash = 'ood2Y1FLHH9izvYghVcDGGAkvJFo1CgSEjPfWvGsaz3qypCmeUj';
+    const blockObservable = new Subject<BlockResponse>();
+
+    const op = new OriginationWalletOperation(
+      operationHash,
+      {
+        wallet,
+        config: {
+          defaultConfirmationCount: 1,
+        },
+      } as any,
+      blockObservable
+    );
+
+    const originationPromise = op.originationOperation();
+
+    blockObservable.next(
+      createFakeBlock(200, operationHash, [
+        new OriginationOperationBuilder().withResult({ status: 'applied' }).build(),
+      ])
+    );
+
+    await expect(originationPromise).resolves.toMatchObject({
+      metadata: {
+        operation_result: {
+          originated_contracts: ['KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX'],
+        },
+      },
+    });
+
+    const confirmationSpy = vi.spyOn(op, 'confirmation');
+    const contractPromise = op.contract();
+
+    await vi.waitFor(() => {
+      expect(confirmationSpy).toHaveBeenCalledTimes(1);
+    });
+    blockObservable.next(createFakeBlock(201));
+
+    await expect(contractPromise).resolves.toBe('contract');
+    expect(wallet.at).toHaveBeenCalledTimes(1);
+    expect(wallet.at).toHaveBeenCalledWith(
+      'KT1UvU4PamD38HYWwG4UjgTKU2nHJ42DqVhX',
+      undefined,
+      'BMEdgRZbJJqUrtByoA5Jyuvy8mzp8mefbcrno82nQCAEbBCUhog'
+    );
   });
 
   it('throws when no contract was originated', async () => {


### PR DESCRIPTION
## Summary
- propagate exact read context through contract, big map, sapling, and TZIP16 read paths
- keep persistent pinning only for `atExactBlock(...)`, while `at(..., block)` and `op.contract()` use the block only to bootstrap reliably and then return live head-tracking abstractions
- normalize shadownet secret-key integration runs to the same rolling RPC used by the ephemeral shadownet config

## Why
The earlier hardening work fixed the immediate flakes, but the broader consistency change initially over-pinned ordinary contract handles. That made `op.contract()` and `at(..., block)` behave like exact historical snapshots, which is not the intended Taquito contract semantics.

This PR keeps the exact-block correctness work where it belongs, on explicit exact-block abstractions, while preserving existing live-contract behavior everywhere else.

