### PR TITLE
chore: remove whatwg-url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5092,19 +5092,6 @@
         "node": ">= 8.0.0"
       }
     },
-    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -14197,19 +14184,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/miller-rabin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15773,6 +15773,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -18343,18 +18344,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
-      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -19401,15 +19390,6 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
-      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20"
-      }
-    },
     "node_modules/webpack": {
       "version": "5.105.4",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.105.4.tgz",
@@ -19718,19 +19698,6 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
-      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=20"
       }
     },
     "node_modules/which": {
@@ -20481,8 +20448,7 @@
         "@taquito/core": "^24.2.0",
         "@taquito/utils": "^24.2.0",
         "bignumber.js": "^10.0.2",
-        "fast-text-encoding": "^1.0.6",
-        "whatwg-url": "^15.1.0"
+        "fast-text-encoding": "^1.0.6"
       },
       "devDependencies": {
         "@taquito/rpc": "^24.2.0",
@@ -20728,7 +20694,7 @@
         "@taquito/http-utils": "^24.2.0",
         "@taquito/utils": "^24.2.0",
         "bignumber.js": "^10.0.2",
-        "whatwg-url": "^15.1.0"
+        "bignumber.js": "^10.0.2"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.42",
@@ -21208,8 +21174,7 @@
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
         "bignumber.js": "^10.0.2",
-        "crypto-js": "^4.2.0",
-        "whatwg-url": "^15.1.0"
+        "crypto-js": "^4.2.0"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.42",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20693,7 +20693,6 @@
         "@taquito/core": "^24.2.0",
         "@taquito/http-utils": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^10.0.2",
         "bignumber.js": "^10.0.2"
       },
       "devDependencies": {

--- a/packages/taquito-local-forging/package.json
+++ b/packages/taquito-local-forging/package.json
@@ -61,8 +61,7 @@
     "@taquito/core": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "bignumber.js": "^10.0.2",
-    "fast-text-encoding": "^1.0.6",
-    "whatwg-url": "^15.1.0"
+    "fast-text-encoding": "^1.0.6"
   },
   "devDependencies": {
     "@taquito/rpc": "^24.2.0",

--- a/packages/taquito-rpc/package.json
+++ b/packages/taquito-rpc/package.json
@@ -61,7 +61,6 @@
     "@taquito/http-utils": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "bignumber.js": "^10.0.2",
-    "whatwg-url": "^15.1.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.42",

--- a/packages/taquito-rpc/package.json
+++ b/packages/taquito-rpc/package.json
@@ -60,7 +60,7 @@
     "@taquito/core": "^24.2.0",
     "@taquito/http-utils": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^10.0.2",
+    "bignumber.js": "^10.0.2"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.42",

--- a/packages/taquito-tzip16/package.json
+++ b/packages/taquito-tzip16/package.json
@@ -59,8 +59,7 @@
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
     "bignumber.js": "^10.0.2",
-    "crypto-js": "^4.2.0",
-    "whatwg-url": "^15.1.0"
+    "crypto-js": "^4.2.0"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.42",


### PR DESCRIPTION
## Summary
- remove the unused `whatwg-url` dependency from `@taquito/rpc`, `@taquito/local-forging`, and `@taquito/tzip16`
- refresh the root lockfile to drop `whatwg-url` from the install graph

## Why
These packages no longer import `whatwg-url` and rely on the platform `URL` APIs instead. Keeping the dependency declared adds install weight without affecting runtime behavior.


