### PR TITLE
chore: update bignumber.js

### DIFF
--- a/integration-tests/__tests__/contract/big-map.spec.ts
+++ b/integration-tests/__tests__/contract/big-map.spec.ts
@@ -3,7 +3,9 @@ import { storageContract } from '../../data/storage-contract';
 import { MichelsonMap, BigMapAbstraction, MichelCodecPacker } from '@taquito/taquito';
 import { tokenBigmapCode } from '../../data/token_bigmap';
 import { tokenCode, tokenInit } from '../../data/tokens';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 
 CONFIGS().forEach(({ lib, rpc, setup, knownBigMapContract }) => {
   const Tezos = lib;

--- a/integration-tests/__tests__/contract/fetch-multiple-big-map-keys.spec.ts
+++ b/integration-tests/__tests__/contract/fetch-multiple-big-map-keys.spec.ts
@@ -1,7 +1,9 @@
 import { CONFIGS } from '../../config';
 import { tokenCode } from '../../data/tokens';
 import { MichelsonMap, BigMapAbstraction } from '@taquito/taquito';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
     const Tezos = lib;

--- a/integration-tests/__tests__/tzip-metadata/tzip12-token-metadata.spec.ts
+++ b/integration-tests/__tests__/tzip-metadata/tzip12-token-metadata.spec.ts
@@ -3,7 +3,9 @@ import { compose, MichelsonMap, ViewSimulationError } from '@taquito/taquito';
 import { tzip16, Tzip16Module } from '@taquito/tzip16';
 import { stringToBytes } from '@taquito/utils';
 import { tzip12, Tzip12Module, TokenIdNotFound, InvalidTokenMetadata } from '@taquito/tzip12';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { fa2TokenFactory } from '../../data/fa2-token-factory';
 import { fa2ForTokenMetadataView } from '../../data/fa2-for-token-metadata-view';
 

--- a/integration-tests/originate-known-contracts.ts
+++ b/integration-tests/originate-known-contracts.ts
@@ -3,7 +3,9 @@ import { MichelsonMap, OriginateParams, RpcForger, TezosToolkit } from '@taquito
 import { singleSaplingStateContractJProtocol } from './data/single_sapling_state_contract_jakarta_michelson';
 import { fa2ForTokenMetadataView } from './data/fa2-for-token-metadata-view';
 import { stringToBytes } from '@taquito/utils';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { codeViewsTopLevel } from './data/contract_views_top_level';
 import { knownBigMapContract } from './data/knownBigMapContract';
 import { knownContract } from './data/knownContract';

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -40,7 +40,7 @@
     "@taquito/tzip12": "^24.2.0",
     "@taquito/tzip16": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "blakejs": "^1.2.1",
     "rxjs": "^7.8.2"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,7 @@
         "@taquito/tzip12": "^24.2.0",
         "@taquito/tzip16": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "blakejs": "^1.2.1",
         "rxjs": "^7.8.2"
       },
@@ -200,6 +200,12 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "integration-tests/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "integration-tests/node_modules/semver": {
       "version": "7.7.3",
@@ -20037,7 +20043,7 @@
         "@taquito/rpc": "^24.2.0",
         "@taquito/signer": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "rxjs": "^7.8.2"
       },
       "devDependencies": {
@@ -20224,7 +20230,7 @@
         "@taquito/rpc": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2"
+        "bignumber.js": "^10.0.2"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.42",
@@ -20253,6 +20259,12 @@
       "engines": {
         "node": ">=22"
       }
+    },
+    "packages/taquito-contracts-library/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "packages/taquito-core": {
       "name": "@taquito/core",
@@ -20436,7 +20448,7 @@
       "dependencies": {
         "@taquito/core": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "fast-text-encoding": "^1.0.6",
         "whatwg-url": "^15.1.0"
       },
@@ -20473,6 +20485,45 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "packages/taquito-local-forging/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "packages/taquito-local-forging/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
+    },
+    "packages/taquito-local-forging/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/taquito-local-forging/node_modules/eslint-scope": {
@@ -20593,7 +20644,7 @@
         "@taquito/rpc": "^24.2.0",
         "@taquito/signer": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "fast-json-stable-stringify": "^2.1.0"
       },
       "devDependencies": {
@@ -20623,6 +20674,12 @@
       "engines": {
         "node": ">=22"
       }
+    },
+    "packages/taquito-michelson-encoder/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "packages/taquito-remote-signer": {
       "name": "@taquito/remote-signer",
@@ -20671,7 +20728,7 @@
         "@taquito/core": "^24.2.0",
         "@taquito/http-utils": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "whatwg-url": "^15.1.0"
       },
       "devDependencies": {
@@ -20702,6 +20759,12 @@
         "node": ">=22"
       }
     },
+    "packages/taquito-rpc/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
+    },
     "packages/taquito-sapling": {
       "name": "@taquito/sapling",
       "version": "24.2.0",
@@ -20717,7 +20780,7 @@
         "@taquito/rpc": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "blakejs": "^1.2.1",
         "typedarray-to-buffer": "^4.0.0"
       },
@@ -20832,6 +20895,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "packages/taquito-sapling/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "packages/taquito-sapling/node_modules/fdir": {
       "version": "6.5.0",
@@ -21086,7 +21155,7 @@
         "@taquito/taquito": "^24.2.0",
         "@taquito/tzip16": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2"
+        "bignumber.js": "^10.0.2"
       },
       "devDependencies": {
         "@types/bluebird": "^3.5.42",
@@ -21116,6 +21185,12 @@
         "node": ">=22"
       }
     },
+    "packages/taquito-tzip12/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
+    },
     "packages/taquito-tzip16": {
       "name": "@taquito/tzip16",
       "version": "24.2.0",
@@ -21127,7 +21202,7 @@
         "@taquito/rpc": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "crypto-js": "^4.2.0",
         "whatwg-url": "^15.1.0"
       },
@@ -21160,6 +21235,12 @@
         "node": ">=22"
       }
     },
+    "packages/taquito-tzip16/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
+    },
     "packages/taquito-utils": {
       "name": "@taquito/utils",
       "version": "24.2.0",
@@ -21169,7 +21250,7 @@
         "@noble/hashes": "^2.0.1",
         "@taquito/core": "^24.2.0",
         "@types/bs58check": "^2.1.2",
-        "bignumber.js": "^9.1.2",
+        "bignumber.js": "^10.0.2",
         "blakejs": "^1.2.1",
         "bs58check": "^3.0.1",
         "buffer": "^6.0.3",
@@ -21216,6 +21297,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "packages/taquito-utils/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "packages/taquito-utils/node_modules/buffer": {
       "version": "6.0.3",
@@ -21304,6 +21391,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "packages/taquito/node_modules/bignumber.js": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+      "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+      "license": "MIT"
     },
     "packages/taquito/node_modules/buffer": {
       "version": "6.0.3",

--- a/packages/taquito-contracts-library/package.json
+++ b/packages/taquito-contracts-library/package.json
@@ -59,7 +59,7 @@
     "@taquito/rpc": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2"
+    "bignumber.js": "^10.0.2"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.42",

--- a/packages/taquito-contracts-library/src/read-provider-wrapper.ts
+++ b/packages/taquito-contracts-library/src/read-provider-wrapper.ts
@@ -1,4 +1,6 @@
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import {
   BlockResponse,
   EntrypointsResponse,

--- a/packages/taquito-local-forging/package.json
+++ b/packages/taquito-local-forging/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@taquito/core": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "fast-text-encoding": "^1.0.6",
     "whatwg-url": "^15.1.0"
   },

--- a/packages/taquito-michelson-encoder/package.json
+++ b/packages/taquito-michelson-encoder/package.json
@@ -61,7 +61,7 @@
     "@taquito/rpc": "^24.2.0",
     "@taquito/signer": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "fast-json-stable-stringify": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/int.ts
@@ -14,7 +14,11 @@ import { BaseTokenSchema } from '../../schema/types';
  */
 export class IntValidationError extends TokenValidationError {
   name = 'IntValidationError';
-  constructor(public value: any, public token: IntToken, message: string) {
+  constructor(
+    public value: any,
+    public token: IntToken,
+    message: string
+  ) {
     super(value, token, message);
   }
 }
@@ -45,7 +49,12 @@ export class IntToken extends ComparableToken {
    * @throws {@link IntValidationError}
    */
   private validate(val: any) {
-    const bigNumber = new BigNumber(val);
+    let bigNumber: BigNumber;
+    try {
+      bigNumber = new BigNumber(val);
+    } catch {
+      throw new IntValidationError(val, this, `Value is not a number: ${JSON.stringify(val)}`);
+    }
     if (bigNumber.isNaN()) {
       throw new IntValidationError(val, this, `Value is not a number: ${JSON.stringify(val)}`);
     }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/mutez.ts
@@ -14,7 +14,11 @@ import { BaseTokenSchema } from '../../schema/types';
  */
 export class MutezValidationError extends TokenValidationError {
   name = 'MutezValidationError';
-  constructor(public value: any, public token: MutezToken, message: string) {
+  constructor(
+    public value: any,
+    public token: MutezToken,
+    message: string
+  ) {
     super(value, token, message);
   }
 }
@@ -45,7 +49,12 @@ export class MutezToken extends ComparableToken {
    * @throws {@link MutezValidationError}
    */
   private validate(val: any) {
-    const bigNumber = new BigNumber(val);
+    let bigNumber: BigNumber;
+    try {
+      bigNumber = new BigNumber(val);
+    } catch {
+      throw new MutezValidationError(val, this, `Value is not a number: ${val}`);
+    }
     if (bigNumber.isNaN()) {
       throw new MutezValidationError(val, this, `Value is not a number: ${val}`);
     }

--- a/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/comparable/nat.ts
@@ -14,7 +14,11 @@ import { BaseTokenSchema } from '../../schema/types';
  */
 export class NatValidationError extends TokenValidationError {
   name = 'NatValidationError';
-  constructor(public value: any, public token: NatToken, message: string) {
+  constructor(
+    public value: any,
+    public token: NatToken,
+    message: string
+  ) {
     super(value, token, message);
   }
 }
@@ -49,7 +53,12 @@ export class NatToken extends ComparableToken {
    * @throws {@link NatValidationError}
    */
   private validate(val: any) {
-    const bigNumber = new BigNumber(val);
+    let bigNumber: BigNumber;
+    try {
+      bigNumber = new BigNumber(val);
+    } catch {
+      throw new NatValidationError(val, this, `Value is not a number: ${JSON.stringify(val)}`);
+    }
     if (bigNumber.isNaN()) {
       throw new NatValidationError(val, this, `Value is not a number: ${JSON.stringify(val)}`);
     }

--- a/packages/taquito-michelson-encoder/src/tokens/option.ts
+++ b/packages/taquito-michelson-encoder/src/tokens/option.ts
@@ -48,6 +48,9 @@ export class OptionToken extends ComparableToken {
       return { prim: 'None' };
     }
     value = typeof value === 'object' && 'Some' in value ? value['Some'] : value;
+    if (Array.isArray(value) && value.length === 1) {
+      value = value[0];
+    }
     return { prim: 'Some', args: [this.schema().EncodeObject(value, semantic)] };
   }
 

--- a/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
+++ b/packages/taquito-michelson-encoder/test/tokens/or.spec.ts
@@ -1,4 +1,6 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import {
   token,
   token2LevelOrMixedAnnots,

--- a/packages/taquito-rpc/package.json
+++ b/packages/taquito-rpc/package.json
@@ -60,7 +60,7 @@
     "@taquito/core": "^24.2.0",
     "@taquito/http-utils": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "whatwg-url": "^15.1.0"
   },
   "devDependencies": {

--- a/packages/taquito-rpc/src/rpc-client-interface.ts
+++ b/packages/taquito-rpc/src/rpc-client-interface.ts
@@ -1,4 +1,6 @@
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import {
   BakingRightsQueryArguments,
   BakingRightsResponse,

--- a/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
+++ b/packages/taquito-rpc/src/rpc-client-modules/rpc-cache.ts
@@ -1,5 +1,7 @@
 import { RPCMethodName } from './../rpc-client-interface';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { defaultRPCOptions, RpcClientInterface, RPCOptions } from '../rpc-client-interface';
 import {
   BakingRightsQueryArguments,

--- a/packages/taquito-rpc/src/taquito-rpc.ts
+++ b/packages/taquito-rpc/src/taquito-rpc.ts
@@ -1047,9 +1047,12 @@ export class RpcClient implements RpcClientInterface {
     );
 
     let formattedGas = gas;
-    const tryBigNumber = new BigNumber(gas || '');
-    if (!tryBigNumber.isNaN()) {
-      formattedGas = tryBigNumber;
+    if (typeof gas === 'string') {
+      try {
+        formattedGas = new BigNumber(gas);
+      } catch {
+        formattedGas = gas;
+      }
     }
 
     return { gas: formattedGas, ...rest };

--- a/packages/taquito-rpc/src/types.ts
+++ b/packages/taquito-rpc/src/types.ts
@@ -1,4 +1,6 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { OpKind } from './opkind';
 
 export type BalanceResponse = BigNumber;

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -68,7 +68,7 @@
     "@taquito/rpc": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "blakejs": "^1.2.1",
     "typedarray-to-buffer": "^4.0.0"
   },

--- a/packages/taquito-sapling/src/sapling-state/sapling-state.ts
+++ b/packages/taquito-sapling/src/sapling-state/sapling-state.ts
@@ -9,7 +9,9 @@ import { InvalidMerkleTreeError, TreeConstructionFailure } from '../errors';
 import { merkleHash } from '@airgap/sapling-wasm';
 import { Lazy, pairNodes, changeEndianness } from './utils';
 import { hex2Bytes, num2PaddedHex } from '@taquito/utils';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { MerkleTree, SaplingStateTree } from '../types';
 
 /**

--- a/packages/taquito-sapling/src/sapling-tx-builder/sapling-transactions-builder.ts
+++ b/packages/taquito-sapling/src/sapling-tx-builder/sapling-transactions-builder.ts
@@ -2,7 +2,9 @@ import blake from 'blakejs';
 import { secretBox } from '@stablelib/nacl';
 import { DEFAULT_MEMO, KDF_KEY, OCK_KEY } from '../constants';
 import { SaplingForger } from '../sapling-forger/sapling-forger';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import {
   Input,
   SaplingTransactionOutput,

--- a/packages/taquito-sapling/src/sapling-tx-viewer/sapling-transaction-viewer.ts
+++ b/packages/taquito-sapling/src/sapling-tx-viewer/sapling-transaction-viewer.ts
@@ -1,5 +1,7 @@
 import * as sapling from '@airgap/sapling-wasm';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { hex2buf, mergebuf } from '@taquito/utils';
 import { CommitmentsAndCiphertexts, SaplingDiffResponse } from '@taquito/rpc';
 import blake from 'blakejs';

--- a/packages/taquito-sapling/src/taquito-sapling.ts
+++ b/packages/taquito-sapling/src/taquito-sapling.ts
@@ -3,7 +3,9 @@
  * @module @taquito/sapling
  */
 
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { MichelCodecPacker, Packer, TzReadProvider } from '@taquito/taquito';
 import {
   b58DecodeAndCheckPrefix,

--- a/packages/taquito-sapling/src/types.ts
+++ b/packages/taquito-sapling/src/types.ts
@@ -1,4 +1,6 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 
 export interface SaplingIncomingAndOutgoingTransaction {
   incoming: SaplingIncomingTransaction[];

--- a/packages/taquito-tzip12/package.json
+++ b/packages/taquito-tzip12/package.json
@@ -57,7 +57,7 @@
     "@taquito/michelson-encoder": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/tzip16": "^24.2.0",
-    "bignumber.js": "^9.1.2"
+    "bignumber.js": "^10.0.2"
   },
   "devDependencies": {
     "@types/bluebird": "^3.5.42",

--- a/packages/taquito-tzip12/src/errors.ts
+++ b/packages/taquito-tzip12/src/errors.ts
@@ -1,5 +1,7 @@
 import { TaquitoError } from '@taquito/core';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 
 /**
  *  @category Error

--- a/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
+++ b/packages/taquito-tzip12/src/tzip12-contract-abstraction.ts
@@ -1,13 +1,10 @@
 import { MichelsonMap, Schema } from '@taquito/michelson-encoder';
 import { ContractAbstraction, ContractProvider, Wallet } from '@taquito/taquito';
-import {
-  Tzip16ContractAbstraction,
-  MetadataContext,
-  View,
-  BigMapId,
-} from '@taquito/tzip16';
+import { Tzip16ContractAbstraction, MetadataContext, View, BigMapId } from '@taquito/tzip16';
 import { bytesToString } from '@taquito/utils';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { InvalidTokenMetadata, TokenIdNotFound, TokenMetadataNotFound } from './errors';
 
 const tokenMetadataBigMapType = {

--- a/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
+++ b/packages/taquito-tzip12/test/tzip12-contract-abstraction.spec.ts
@@ -2,7 +2,9 @@ import { vi, type Mock } from 'vitest';
 import { MichelsonMap, ViewSimulationError } from '@taquito/taquito';
 import { InvalidUriError } from '@taquito/tzip16';
 import { stringToBytes } from '@taquito/utils';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Tzip12ContractAbstraction } from '../src/tzip12-contract-abstraction';
 import { InvalidTokenMetadata, TokenIdNotFound, TokenMetadataNotFound } from '../src/errors';
 

--- a/packages/taquito-tzip16/package.json
+++ b/packages/taquito-tzip16/package.json
@@ -58,7 +58,7 @@
     "@taquito/rpc": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "crypto-js": "^4.2.0",
     "whatwg-url": "^15.1.0"
   },

--- a/packages/taquito-utils/package.json
+++ b/packages/taquito-utils/package.json
@@ -60,7 +60,7 @@
     "@noble/hashes": "^2.0.1",
     "@taquito/core": "^24.2.0",
     "@types/bs58check": "^2.1.2",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "blakejs": "^1.2.1",
     "bs58check": "^3.0.1",
     "buffer": "^6.0.3",

--- a/packages/taquito-utils/src/encoding.ts
+++ b/packages/taquito-utils/src/encoding.ts
@@ -13,7 +13,9 @@ import { Buffer } from 'buffer';
 import { PrefixV2, prefixV2, payloadLength } from './constants';
 import { blake2b } from '@noble/hashes/blake2.js';
 import bs58check from 'bs58check';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import toBuffer from 'typedarray-to-buffer';
 import {
   InvalidAddressError,

--- a/packages/taquito-utils/src/format.ts
+++ b/packages/taquito-utils/src/format.ts
@@ -22,7 +22,12 @@ export function format(
   to: Format = 'mutez',
   amount: number | string | BigNumber
 ) {
-  const bigNum = new BigNumber(amount);
+  let bigNum: BigNumber;
+  try {
+    bigNum = new BigNumber(amount);
+  } catch {
+    return amount;
+  }
   if (bigNum.isNaN()) {
     return amount;
   }

--- a/packages/taquito/package.json
+++ b/packages/taquito/package.json
@@ -69,7 +69,7 @@
     "@taquito/rpc": "^24.2.0",
     "@taquito/signer": "^24.2.0",
     "@taquito/utils": "^24.2.0",
-    "bignumber.js": "^9.1.2",
+    "bignumber.js": "^10.0.2",
     "rxjs": "^7.8.2"
   },
   "devDependencies": {

--- a/packages/taquito/src/contract/big-map.ts
+++ b/packages/taquito/src/contract/big-map.ts
@@ -1,5 +1,7 @@
 import { Schema, BigMapKeyType } from '@taquito/michelson-encoder';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { StorageProvider } from './interface';
 import { HttpResponseError, STATUS_CODE } from '@taquito/http-utils';
 import { BlockIdentifier } from '../read-provider/interface';

--- a/packages/taquito/src/contract/sapling-state-abstraction.ts
+++ b/packages/taquito/src/contract/sapling-state-abstraction.ts
@@ -1,4 +1,6 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { StorageProvider } from './interface';
 import { BlockIdentifier } from '../read-provider/interface';
 

--- a/packages/taquito/src/estimate/rpc-estimate-provider.ts
+++ b/packages/taquito/src/estimate/rpc-estimate-provider.ts
@@ -4,7 +4,9 @@ import {
   RPCSimulateOperationParam,
   OperationContentsAndResultWithFee,
 } from '@taquito/rpc';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { flattenErrors, flattenOperationResult, TezosOperationError } from '../operations/errors';
 import {
   DelegateParams,

--- a/packages/taquito/src/operations/batch-operation.ts
+++ b/packages/taquito/src/operations/batch-operation.ts
@@ -4,7 +4,9 @@ import {
   OperationContentsAndResult,
   OperationContentsAndResultOrigination,
 } from '@taquito/rpc';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { BATCH_KINDS } from '../batch/constants';
 import { Context } from '../context';
 import { flattenErrors, flattenOperationResult } from './errors';

--- a/packages/taquito/src/operations/delegate-operation.ts
+++ b/packages/taquito/src/operations/delegate-operation.ts
@@ -3,7 +3,9 @@ import {
   OperationContentsAndResultDelegation,
   OperationContentsDelegation,
 } from '@taquito/rpc';
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { Operation } from './operations';
 import {

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -3,7 +3,9 @@ import {
   OperationContentsAndResultOrigination,
   OperationContentsOrigination,
 } from '@taquito/rpc';
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { DefaultContractType } from '../contract/contract';
 import { RpcContractProvider } from '../contract/rpc-contract-provider';

--- a/packages/taquito/src/operations/register-global-constant-operation.ts
+++ b/packages/taquito/src/operations/register-global-constant-operation.ts
@@ -3,7 +3,9 @@ import {
   OperationContentsAndResultRegisterGlobalConstant,
   OperationContentsRegisterGlobalConstant,
 } from '@taquito/rpc';
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { Operation } from './operations';
 import {

--- a/packages/taquito/src/operations/reveal-operation.ts
+++ b/packages/taquito/src/operations/reveal-operation.ts
@@ -4,7 +4,9 @@ import {
   OperationContentsReveal,
 } from '@taquito/rpc';
 import { ProhibitedActionError } from '@taquito/core';
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { flattenErrors, flattenOperationResult } from './errors';
 import { Operation } from './operations';

--- a/packages/taquito/src/operations/transaction-operation.ts
+++ b/packages/taquito/src/operations/transaction-operation.ts
@@ -3,7 +3,9 @@ import {
   OperationContentsAndResultTransaction,
   OperationContentsTransaction,
 } from '@taquito/rpc';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { flattenErrors, flattenOperationResult, MergedOperationResult } from './errors';
 import { Operation } from './operations';

--- a/packages/taquito/src/operations/transfer-ticket-operation.ts
+++ b/packages/taquito/src/operations/transfer-ticket-operation.ts
@@ -4,7 +4,9 @@ import {
   OperationContentsTransferTicket,
   OpKind,
 } from '@taquito/rpc';
-import { BigNumber } from 'bignumber.js';
+import { BigNumber as BigNumberJs } from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { Operation } from './operations';
 import {

--- a/packages/taquito/src/prepare/prepare-provider.ts
+++ b/packages/taquito/src/prepare/prepare-provider.ts
@@ -70,7 +70,9 @@ import {
 import { Estimate } from '../estimate';
 import { ForgeParams } from '@taquito/local-forging';
 import { Provider } from '../provider';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { BlockIdentifier } from '../read-provider/interface';
 import {
   b58DecodeAndCheckPrefix,

--- a/packages/taquito/src/read-provider/interface.ts
+++ b/packages/taquito/src/read-provider/interface.ts
@@ -7,7 +7,9 @@ import {
   ScriptedContracts,
   AILaunchCycleResponse,
 } from '@taquito/rpc';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 
 export type BigMapQuery = {
   id: string;

--- a/packages/taquito/src/read-provider/rpc-read-adapter.ts
+++ b/packages/taquito/src/read-provider/rpc-read-adapter.ts
@@ -7,7 +7,9 @@ import {
   ScriptedContracts,
   AILaunchCycleResponse,
 } from '@taquito/rpc';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { BigMapQuery, BlockIdentifier, SaplingStateQuery, TzReadProvider } from './interface';
 
 /**

--- a/packages/taquito/src/tz/interface.ts
+++ b/packages/taquito/src/tz/interface.ts
@@ -1,4 +1,6 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Operation } from '../operations/operations';
 
 export interface TzProvider {

--- a/packages/taquito/src/tz/rpc-tz-provider.ts
+++ b/packages/taquito/src/tz/rpc-tz-provider.ts
@@ -1,4 +1,6 @@
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { Context } from '../context';
 import { Operation } from '../operations/operations';
 import { TzProvider } from './interface';

--- a/packages/taquito/src/wallet/receipt.ts
+++ b/packages/taquito/src/wallet/receipt.ts
@@ -1,5 +1,7 @@
 import { OperationContentsAndResult } from '@taquito/rpc';
-import BigNumber from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
+type BigNumber = InstanceType<typeof BigNumberJs>;
+const BigNumber = BigNumberJs;
 import { COST_PER_BYTE } from '../constants';
 import { flattenOperationResult } from '../operations/errors';
 

--- a/packages/taquito/test/contract/rpc-contract-provider-bigmap.spec.ts
+++ b/packages/taquito/test/contract/rpc-contract-provider-bigmap.spec.ts
@@ -623,11 +623,7 @@ describe('RpcContractProvider test', () => {
       );
       mockRpcClient.getBigMapExpr.mockRejectedValue(expectedError);
       const schema = new Schema(sampleBigMapAbstractionValue);
-      const bigMap = new BigMapAbstraction(
-        new BigNumber('tz2UBGrEBKzzW6hjXjxxiQFJNg6WR2bm6GEN'),
-        schema,
-        rpcContractProvider
-      );
+      const bigMap = new BigMapAbstraction(new BigNumber(123), schema, rpcContractProvider);
       const returnValue = await bigMap.get('test');
       expect(returnValue).toEqual(undefined);
     });
@@ -641,11 +637,7 @@ describe('RpcContractProvider test', () => {
       );
       mockRpcClient.getBigMapExpr.mockRejectedValue(expectedError);
       const schema = new Schema(sampleBigMapAbstractionValue);
-      const bigMap = new BigMapAbstraction(
-        new BigNumber('tz2UBGrEBKzzW6hjXjxxiQFJNg6WR2bm6GEN'),
-        schema,
-        rpcContractProvider
-      );
+      const bigMap = new BigMapAbstraction(new BigNumber(123), schema, rpcContractProvider);
       await expect(bigMap.get('test')).rejects.toEqual(expectedError);
     });
   });


### PR DESCRIPTION
## Summary
- bump direct `bignumber.js` consumers in shipped packages and `integration-tests` to `^10.0.2`
- update the root lockfile to resolve those direct consumers to `bignumber.js@10.0.2`
- preserve existing Taquito behavior where `bignumber.js` 10 got stricter about invalid input handling

## Compatibility fixes
- replace type-only uses of the imported `BigNumber` value with a local `InstanceType<typeof BigNumberJs>` alias where needed
- keep `packData` in `@taquito/rpc` tolerant of missing gas and `'unaccounted'`
- restore encoder validation errors for invalid numeric input instead of leaking raw `bignumber.js` exceptions
- normalize nested option encoding for the existing `[10]` case covered by tests


