### PR TITLE
chore: trim remaining stablelib crypto deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20093,7 +20093,6 @@
       "dependencies": {
         "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
         "@ecadlabs/beacon-types": "^4.8.1-ecad",
-        "@stablelib/ed25519": "^2.0.2",
         "@taquito/core": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
@@ -20487,44 +20486,11 @@
         "node": ">=22"
       }
     },
-    "packages/taquito-local-forging/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "packages/taquito-local-forging/node_modules/bignumber.js": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
       "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
       "license": "MIT"
-    },
-    "packages/taquito-local-forging/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
     },
     "packages/taquito-local-forging/node_modules/eslint-scope": {
       "version": "5.1.1",
@@ -20775,7 +20741,6 @@
         "@noble/hashes": "^2.0.1",
         "@scure/bip39": "^2.0.1",
         "@stablelib/nacl": "^1.0.4",
-        "@stablelib/random": "^1.0.2",
         "@taquito/core": "^24.2.0",
         "@taquito/rpc": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
@@ -20941,7 +20906,6 @@
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^2.0.1",
         "@scure/bip39": "^2.0.1",
-        "@stablelib/blake2b": "^2.0.1",
         "@stablelib/nacl": "^1.0.4",
         "@taquito/core": "^24.2.0",
         "@taquito/utils": "^24.2.0",

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -73,7 +73,6 @@
   "dependencies": {
     "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
     "@ecadlabs/beacon-types": "^4.8.1-ecad",
-    "@stablelib/ed25519": "^2.0.2",
     "@taquito/core": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",

--- a/packages/taquito-sapling/package.json
+++ b/packages/taquito-sapling/package.json
@@ -63,7 +63,6 @@
     "@scure/bip39": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@stablelib/nacl": "^1.0.4",
-    "@stablelib/random": "^1.0.2",
     "@taquito/core": "^24.2.0",
     "@taquito/rpc": "^24.2.0",
     "@taquito/taquito": "^24.2.0",

--- a/packages/taquito-sapling/src/sapling-module-wrapper.ts
+++ b/packages/taquito-sapling/src/sapling-module-wrapper.ts
@@ -1,5 +1,4 @@
 import * as sapling from '@airgap/sapling-wasm';
-import { randomBytes } from '@stablelib/random';
 import { ParametersOutputProof } from './types';
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const saplingOutputParams = require('../saplingOutputParams');
@@ -8,6 +7,20 @@ const saplingSpendParams = require('../saplingSpendParams');
 
 let cachedParams: { spend: Buffer; output: Buffer } | undefined;
 
+type RandomValueSource = {
+  getRandomValues<T extends ArrayBufferView | null>(array: T): T;
+};
+
+const getRandomValueSource = (): RandomValueSource => {
+  const crypto = globalThis.crypto as RandomValueSource | undefined;
+
+  if (!crypto?.getRandomValues) {
+    throw new Error('Sapling randomness requires globalThis.crypto.getRandomValues');
+  }
+
+  return crypto;
+};
+
 export class SaplingWrapper {
   async withProvingContext<T>(action: (context: number) => Promise<T>) {
     await this.initSaplingParameters();
@@ -15,7 +28,9 @@ export class SaplingWrapper {
   }
 
   getRandomBytes(length: number) {
-    return randomBytes(length);
+    const bytes = new Uint8Array(length);
+    getRandomValueSource().getRandomValues(bytes);
+    return bytes;
   }
 
   async randR() {

--- a/packages/taquito-sapling/test/sapling-tx-builder/sapling-module-wrapper.spec.ts
+++ b/packages/taquito-sapling/test/sapling-tx-builder/sapling-module-wrapper.spec.ts
@@ -3,9 +3,27 @@ import { SaplingWrapper } from '../../src/sapling-module-wrapper';
 describe('SaplingWrapper', () => {
   const saplingWrapper = new SaplingWrapper();
 
-  it('getRandomBytes', () => {
-    const bytes = saplingWrapper.getRandomBytes(24);
-    expect(bytes.length).toEqual(24);
+  it('getRandomBytes uses global crypto', () => {
+    const originalCrypto = globalThis.crypto;
+    const getRandomValues = vi.fn((bytes: Uint8Array) => bytes.fill(7));
+
+    Object.defineProperty(globalThis, 'crypto', {
+      value: { getRandomValues },
+      configurable: true,
+    });
+
+    try {
+      const bytes = saplingWrapper.getRandomBytes(24);
+      expect(getRandomValues).toHaveBeenCalledOnce();
+      expect(bytes).toBeInstanceOf(Uint8Array);
+      expect(bytes.length).toEqual(24);
+      expect(Array.from(bytes)).toEqual(new Array(24).fill(7));
+    } finally {
+      Object.defineProperty(globalThis, 'crypto', {
+        value: originalCrypto,
+        configurable: true,
+      });
+    }
   });
 
   it('randR', async () => {

--- a/packages/taquito-signer/package.json
+++ b/packages/taquito-signer/package.json
@@ -60,7 +60,6 @@
     "@noble/curves": "^1.9.7",
     "@scure/bip39": "^2.0.1",
     "@noble/hashes": "^2.0.1",
-    "@stablelib/blake2b": "^2.0.1",
     "@stablelib/nacl": "^1.0.4",
     "@taquito/core": "^24.2.0",
     "@taquito/utils": "^24.2.0",


### PR DESCRIPTION
## Summary
- remove dead direct stablelib dependencies from signer and beacon-wallet
- stop depending on @stablelib/random in sapling and use globalThis.crypto.getRandomValues instead
- add a focused sapling wrapper test for the randomness source contract

## Validation
- npm ci --ignore-scripts
- ./node_modules/.bin/nx run-many --target=build --projects=@taquito/signer,@taquito/beacon-wallet,@taquito/sapling
- ./node_modules/.bin/nx run-many --target=test --projects=@taquito/signer,@taquito/beacon-wallet -- --coverage=false
- ./node_modules/.bin/nx run @taquito/sapling:test -- --coverage=false test/helpers.spec.ts test/sapling-keys/in-memory-spending-key.spec.ts
- ./node_modules/.bin/nx run @taquito/sapling:test -- --coverage=false test/sapling-tx-builder/sapling-module-wrapper.spec.ts

## Notes
- sapling wrapper spec local validation used temporary untracked param fixture files copied from the vendored-sapling worktree because main still does not include the vendored param modules
- this PR intentionally leaves @stablelib/nacl and bs58check alone because those are real runtime behavior paths and deserve separate focused work