### PR TITLE
docs: add CODEOWNERS and fix website doc drift

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default ownership for the repository.
+* @ecadlabs/taquito-team

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ Use a conventional commit message for your final commit.
 
 ### Running the Website Locally
 
-The [Taquito website][4] is built with [Docusaurus][5]. To run it locally:
+The [Taquito website][4] is built with [Astro][5]. To run it locally:
 
 1. `npm ci`
-2. `npm -w @taquito/website start`
+2. `npm -w @taquito/website dev`
 
 ## Contributions / Reporting Issues
 
@@ -232,4 +232,4 @@ Special thanks to these libraries, which have been excellent references for Taqu
 [discord]: https://discord.com/channels/934567382700146739/939205889901092874
 [stackexchange]: https://tezos.stackexchange.com/questions/tagged/taquito
 [4]: https://taquito.io
-[5]: https://docusaurus.io/
+[5]: https://astro.build/

--- a/website/README.md
+++ b/website/README.md
@@ -15,8 +15,8 @@ See [LICENSE](LICENSE) in this directory for the full proprietary license terms.
 To run the website locally for development purposes:
 
 ```
-npm clean-install
-npm -w @taquito/website start
+npm ci
+npm -w @taquito/website dev
 ```
 
 ## Contact


### PR DESCRIPTION
## Summary
- add a minimal repository-wide CODEOWNERS file for @ecadlabs/taquito-team
- fix the root README website section to reflect Astro and the current dev command
- fix the website README local development command to use the current script

## Testing
- git diff --check
- verified stale website references are gone from the updated README files