### PR TITLE
chore: update Beacon fork to 4.8.1-ecad.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19006,8 +19006,8 @@
       "version": "24.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
-        "@ecadlabs/beacon-types": "^4.8.1-ecad",
+        "@ecadlabs/beacon-dapp": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
         "@taquito/core": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
@@ -19016,8 +19016,8 @@
         "util": "^0.12.5"
       },
       "devDependencies": {
-        "@ecadlabs/beacon-transport-postmessage": "^4.8.1-ecad",
-        "@ecadlabs/beacon-ui": "^4.8.1-ecad",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.4",
         "@types/bluebird": "^3.5.42",
         "@types/chrome": "0.1.40",
         "@types/node": "^22.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2254,18 +2254,17 @@
       }
     },
     "node_modules/@ecadlabs/beacon-core": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-uXN+XG665fGHzbWiUp0mSxnixo+JgEFrKCC9dzTEw5utkAfnrnB2s70eN1y9420ab7D0LJb3iM6TMtNMDmmy+Q==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-VNOT9bBuxQn1cTQZoqQ4WEPE/BGEGBukBA7eKQGDoFA8WUxtv5HoqNS2GEeyuSvm/mija/R5nxD+DKcEuCmSLw==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
-        "@stablelib/ed25519": "^2.0.2",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
         "@stablelib/nacl": "^2.0.1",
-        "@stablelib/utf8": "^2.0.1",
+        "@stablelib/utf8": "^2.1.0",
         "@stablelib/x25519-session": "^2.0.1",
-        "broadcast-channel": "^7.1.0",
+        "broadcast-channel": "^7.3.0",
         "bs58check": "4.0.0"
       }
     },
@@ -2403,514 +2402,115 @@
       }
     },
     "node_modules/@ecadlabs/beacon-dapp": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-KKKu5YQmUzijJAJiVMmHik5mDRBwWkomsOstSkasDUQqIjStg2j2szN4v3CBRDeGihSu9OOICv390+qaen/iEg==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-Oz8RxfEDIsDy0lRy3VjGTQ5yqaQH+ctn7x3bjBDfPWiEJRYYHwRnBXEu+lRhzxhmsWBduH2B1zyY6HWmsWx6LQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.2",
-        "broadcast-channel": "^7.1.0"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "broadcast-channel": "^7.3.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-matrix": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-deztRLczTYx+pHJrSH+G1HtrjJdAOLww7tIyq0IA+OIhTqf5oa4DwA9ULYaeXTqIXVXWmfuUL64mBY/vgEDYqQ==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-CiiUvZGhN4Yd4/B9GHH2k/c3x3WHuL5aZigT/2Y8kQiaAZZ2Mc00LCFgnFY0fLGiAXr9izSZ+nJrHBIBwk5ARg==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
-        "axios": "^1.8.4"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "axios": "^1.15.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-postmessage": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-HjJiYTy+c2AieNXpNRoHqlmqiDGnmEtErecKNZVl6ahaKwKUi3kAtb84S55h4GJv+X8Lez0iFRP7lTtO4P3Fvw==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-h/87eBPnxyGt2eu//xiHc5IKUcfUWwU4Z/hpWMnAckd9ibOWqzpOgUmwkaXZL7U5HA/NUyUbfckRTKDadZc3MA==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.2"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.4"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-walletconnect": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-5FoAqWlSkQBD07EMPFj2oqFoYHCoOIgHqRewNOPwrseJQzPk+gV+2tmczOfco10IF/h73ildLVZ7NeBifhM3fw==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-JIPwynvnbF2gM1ZmdAw+vWl5NJzPnxRGLBOQrLvdMFLQ7Q1gk4yoLsA+GIwWL1fugExGJZqCiMe/t6ZtmyeIxA==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
-        "@walletconnect/sign-client": "2.18.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@walletconnect/sign-client": "^2.23.9",
         "elliptic": "^6.6.1"
       }
     },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@noble/ciphers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
-      "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.7.1"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@walletconnect/core": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/core/-/core-2.18.0.tgz",
-      "integrity": "sha512-i/olu/IwYtBiWYqyfNUMxq4b6QS5dv+ZVVGmLT2buRwdH6MGETN0Bx3/z6rXJzd1sNd+QL07fxhSFxCekL57tA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-provider": "1.0.14",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/jsonrpc-ws-connection": "1.0.16",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.18.0",
-        "@walletconnect/utils": "2.18.0",
-        "@walletconnect/window-getters": "1.0.1",
-        "events": "3.3.0",
-        "lodash.isequal": "4.5.0",
-        "uint8arrays": "3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@walletconnect/logger": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "7.11.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@walletconnect/sign-client": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/sign-client/-/sign-client-2.18.0.tgz",
-      "integrity": "sha512-oUjlRIsbHxMSRif2WvMRdvm6tMsQjMj07rl7YVcKVvZ1gF1/9GcbJPjzL/U87fv8qAQkVhIlbEg2vHaVYf6J/g==",
-      "deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/core": "2.18.0",
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/logger": "2.1.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.18.0",
-        "@walletconnect/utils": "2.18.0",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@walletconnect/types": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.18.0.tgz",
-      "integrity": "sha512-g0jU+6LUuw3E/EPAQfHNK2xK/95IpRfz68tdNAFckLmefZU6kzoE1mIM1SrPJq8rT9kUPp6/APMQE+ReH2OdBA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/@walletconnect/utils": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.18.0.tgz",
-      "integrity": "sha512-6AUXIcjSxTHGRsTtmUP/oqudtwRILrQqrJsH3jS5T28FFDzZt7+On6fR4mXzi64k4nNYeWg1wMCGLEdtxmGbZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ethersproject/transactions": "5.7.0",
-        "@noble/ciphers": "1.2.1",
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.18.0",
-        "@walletconnect/window-getters": "1.0.1",
-        "@walletconnect/window-metadata": "1.0.1",
-        "detect-browser": "5.3.0",
-        "elliptic": "6.6.1",
-        "query-string": "7.1.3",
-        "uint8arrays": "3.1.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/on-exit-leak-free": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
-      "license": "MIT"
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/pino": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.0.0",
-        "on-exit-leak-free": "^0.2.0",
-        "pino-abstract-transport": "v0.5.0",
-        "pino-std-serializers": "^4.0.0",
-        "process-warning": "^1.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.1.0",
-        "safe-stable-stringify": "^2.1.0",
-        "sonic-boom": "^2.2.1",
-        "thread-stream": "^0.15.1"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/pino-abstract-transport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexify": "^4.1.2",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/pino-std-serializers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
-      "license": "MIT"
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/real-require": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
-      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/sonic-boom": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
-      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/thread-stream": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.1.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-transport-walletconnect/node_modules/uint8arrays": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-      "license": "MIT",
-      "dependencies": {
-        "multiformats": "^9.4.2"
-      }
-    },
     "node_modules/@ecadlabs/beacon-types": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-dmONM1TOQQ11ZWQEtmDSgXC428O7CC4ayZQWR8h/oA+bSY7mdcMZU+yijEEuk0SL7w97q7OMcLkCYgwCtsCe+w==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-NnA8O7FKAs7AQBB93+nMZnxw1Hz/tO+NIt5pP8wOLFBogpFNYp72LOJLKhkYZiePTU71EMGI8FmYrEZLqRYoxw==",
       "license": "ISC",
       "dependencies": {
-        "@types/chrome": "0.0.315"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-types/node_modules/@types/chrome": {
-      "version": "0.0.315",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.0.315.tgz",
-      "integrity": "sha512-Oy1dYWkr6BCmgwBtOngLByCHstQ3whltZg7/7lubgIZEYvKobDneqplgc6LKERNRBwckFviV4UU5AZZNUFrJ4A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/filesystem": "*",
-        "@types/har-format": "*"
+        "@types/chrome": "^0.1.40"
       }
     },
     "node_modules/@ecadlabs/beacon-ui": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-K3W2mDkAswBz8SnYEi4tnzlQE79v0TZvntmq/zVaHbskYPIF0QKx+v62qgSOy3TmRK0upqLwyJ2lhu4A6VnbMA==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-0xV28UL0DkOGZiaAC+8Lpin17RWuiIT0X5PcB+8cZ3c8yyRJeYoMlk9pepTqj9NftzY/WjDTWrEuej6jumkiBw==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.2",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.2",
-        "@walletconnect/utils": "2.18.0",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@walletconnect/utils": "^2.23.9",
         "qrcode-svg": "^1.1.0",
-        "react": "^19.1.0",
-        "react-dom": "^19.1.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/@noble/ciphers": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.2.1.tgz",
-      "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
+        "react": "^19.2.5",
+        "react-dom": "^19.2.5"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+      "optionalDependencies": {
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1"
       }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/@noble/curves": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "1.7.1"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/@noble/hashes": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/@walletconnect/logger": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@walletconnect/logger/-/logger-2.1.2.tgz",
-      "integrity": "sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@walletconnect/safe-json": "^1.0.2",
-        "pino": "7.11.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/@walletconnect/types": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/types/-/types-2.18.0.tgz",
-      "integrity": "sha512-g0jU+6LUuw3E/EPAQfHNK2xK/95IpRfz68tdNAFckLmefZU6kzoE1mIM1SrPJq8rT9kUPp6/APMQE+ReH2OdBA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@walletconnect/events": "1.0.1",
-        "@walletconnect/heartbeat": "1.2.2",
-        "@walletconnect/jsonrpc-types": "1.0.4",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/logger": "2.1.2",
-        "events": "3.3.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/@walletconnect/utils": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@walletconnect/utils/-/utils-2.18.0.tgz",
-      "integrity": "sha512-6AUXIcjSxTHGRsTtmUP/oqudtwRILrQqrJsH3jS5T28FFDzZt7+On6fR4mXzi64k4nNYeWg1wMCGLEdtxmGbZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ethersproject/transactions": "5.7.0",
-        "@noble/ciphers": "1.2.1",
-        "@noble/curves": "1.8.1",
-        "@noble/hashes": "1.7.1",
-        "@walletconnect/jsonrpc-utils": "1.0.8",
-        "@walletconnect/keyvaluestorage": "1.1.1",
-        "@walletconnect/relay-api": "1.0.11",
-        "@walletconnect/relay-auth": "1.1.0",
-        "@walletconnect/safe-json": "1.0.2",
-        "@walletconnect/time": "1.0.2",
-        "@walletconnect/types": "2.18.0",
-        "@walletconnect/window-getters": "1.0.1",
-        "@walletconnect/window-metadata": "1.0.1",
-        "detect-browser": "5.3.0",
-        "elliptic": "6.6.1",
-        "query-string": "7.1.3",
-        "uint8arrays": "3.1.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/on-exit-leak-free": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
-      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg==",
-      "license": "MIT"
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/pino": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-7.11.0.tgz",
-      "integrity": "sha512-dMACeu63HtRLmCG8VKdy4cShCPKaYDR4youZqoSWLxl5Gu99HUw8bw75thbPv9Nip+H+QYX8o3ZJbTdVZZ2TVg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "fast-redact": "^3.0.0",
-        "on-exit-leak-free": "^0.2.0",
-        "pino-abstract-transport": "v0.5.0",
-        "pino-std-serializers": "^4.0.0",
-        "process-warning": "^1.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.1.0",
-        "safe-stable-stringify": "^2.1.0",
-        "sonic-boom": "^2.2.1",
-        "thread-stream": "^0.15.1"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/pino-abstract-transport": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
-      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "duplexify": "^4.1.2",
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/pino-std-serializers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
-      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==",
-      "license": "MIT"
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/process-warning": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
-      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
-      "license": "MIT"
     },
     "node_modules/@ecadlabs/beacon-ui/node_modules/react": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-      "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/@ecadlabs/beacon-ui/node_modules/react-dom": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-      "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.4"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/real-require": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
-      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/sonic-boom": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.8.0.tgz",
-      "integrity": "sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/thread-stream": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.15.2.tgz",
-      "integrity": "sha512-UkEhKIg2pD+fjkHQKyJO3yoIvAP3N6RlNFt2dUhcS1FGvCD1cQa1M/PGknCLFIyZdtJOWQjejp7bdNqmN7zwdA==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.1.0"
-      }
-    },
-    "node_modules/@ecadlabs/beacon-ui/node_modules/uint8arrays": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.0.tgz",
-      "integrity": "sha512-ei5rfKtoRO8OyOIor2Rz5fhzjThwIHJZ3uyDPnDHTXbP0aMQ1RN/6AI5B5d9dBxJOU+BvOAk7ZQ1xphsX8Lrog==",
-      "license": "MIT",
-      "dependencies": {
-        "multiformats": "^9.4.2"
+        "react": "^19.2.5"
       }
     },
     "node_modules/@ecadlabs/beacon-utils": {
-      "version": "4.8.1-ecad.2",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.2.tgz",
-      "integrity": "sha512-SyO3O8+XY8B3JHa6E8+erihScz0jFwsdXlwSACdxBmODuW7HCo/b9AgOcelaXi1s/6qTsjk5/2q56FYOMYmgHQ==",
+      "version": "4.8.1-ecad.4",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.4.tgz",
+      "integrity": "sha512-voe1wzJCTuHW3PukN2PL8j+uPKfeeVDKI1B8S9bKk98b5VhUOl6aL82Fpm47aqdCc45aoDhOnxLZ0DMyzaG64Q==",
       "license": "ISC",
       "dependencies": {
-        "@stablelib/ed25519": "^2.0.2",
+        "@stablelib/ed25519": "^2.1.0",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/random": "^2.0.1",
-        "@stablelib/utf8": "^2.0.1",
+        "@stablelib/utf8": "^2.1.0",
         "bs58check": "4.0.0"
       }
     },
@@ -3649,214 +3249,6 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@ethersproject/address": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
-      "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0",
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/keccak256": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/rlp": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/bignumber": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
-      "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "bn.js": "^5.2.1"
-      }
-    },
-    "node_modules/@ethersproject/bytes": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
-      "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/constants": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
-      "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/keccak256": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
-      "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "js-sha3": "0.8.0"
-      }
-    },
-    "node_modules/@ethersproject/logger": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
-      "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/@ethersproject/properties": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
-      "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/rlp": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
-      "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0"
-      }
-    },
-    "node_modules/@ethersproject/signing-key": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
-      "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.8.0",
-        "@ethersproject/logger": "^5.8.0",
-        "@ethersproject/properties": "^5.8.0",
-        "bn.js": "^5.2.1",
-        "elliptic": "6.6.1",
-        "hash.js": "1.1.7"
-      }
-    },
-    "node_modules/@ethersproject/transactions": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.7.0.tgz",
-      "integrity": "sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/address": "^5.7.0",
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/properties": "^5.7.0",
-        "@ethersproject/rlp": "^5.7.0",
-        "@ethersproject/signing-key": "^5.7.0"
       }
     },
     "node_modules/@gerrit0/mini-shiki": {
@@ -5119,7 +4511,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5329,7 +4720,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5555,12 +4945,6 @@
         "@stablelib/int": "^2.0.1"
       }
     },
-    "node_modules/@stablelib/blake2b/node_modules/@stablelib/hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-2.0.0.tgz",
-      "integrity": "sha512-u3WPSqGido8lwJuMcrBgM5K54LrPGhkWAdtsyccf7dGsLixAZUds77zOAbu7bvKPwQlmoByH0txBi5rTmEKuHg==",
-      "license": "MIT"
-    },
     "node_modules/@stablelib/blake2b/node_modules/@stablelib/int": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-2.0.1.tgz",
@@ -5586,9 +4970,9 @@
       "license": "MIT"
     },
     "node_modules/@stablelib/ed25519": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-2.0.2.tgz",
-      "integrity": "sha512-d/lJ5sgzhtmpMIbKFWfev+i6WebBdIzzBpMzXtZdvUijoksjXosYFNqytoMj7cRshNj+/XTLYnnVMdZfd+penw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/ed25519/-/ed25519-2.1.0.tgz",
+      "integrity": "sha512-8GLWoJur9nJiErABKHs5MjceSiYJJ2n8QP9k8Q5x6GWU2y5oAQ6qzPh8kCgQy5aHlUxcmRA1frQ5Gu2bHoIDPw==",
       "license": "MIT",
       "dependencies": {
         "@stablelib/random": "^2.0.1",
@@ -5625,6 +5009,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-2.0.1.tgz",
       "integrity": "sha512-1eU2K9EgOcV4qc9jcP6G72xxZxEm5PfeI5H55l08W95b4oRJaqhmlWRc4xZAm6IVSKhVNxMi66V67hCzzuMTAg==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/hash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-2.0.0.tgz",
+      "integrity": "sha512-u3WPSqGido8lwJuMcrBgM5K54LrPGhkWAdtsyccf7dGsLixAZUds77zOAbu7bvKPwQlmoByH0txBi5rTmEKuHg==",
       "license": "MIT"
     },
     "node_modules/@stablelib/int": {
@@ -5705,12 +5095,6 @@
       "dependencies": {
         "@stablelib/int": "^2.0.1"
       }
-    },
-    "node_modules/@stablelib/sha512/node_modules/@stablelib/hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@stablelib/hash/-/hash-2.0.0.tgz",
-      "integrity": "sha512-u3WPSqGido8lwJuMcrBgM5K54LrPGhkWAdtsyccf7dGsLixAZUds77zOAbu7bvKPwQlmoByH0txBi5rTmEKuHg==",
-      "license": "MIT"
     },
     "node_modules/@stablelib/sha512/node_modules/@stablelib/int": {
       "version": "2.0.1",
@@ -5996,6 +5380,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/chrome": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.40.tgz",
+      "integrity": "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/filesystem": "*",
+        "@types/har-format": "*"
       }
     },
     "node_modules/@types/conventional-commits-parser": {
@@ -9034,15 +8428,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decode-uri-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -9319,18 +8704,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/duplexify": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
-      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
-      "license": "MIT",
-      "dependencies": {
-        "end-of-stream": "^1.4.1",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1",
-        "stream-shift": "^1.0.2"
       }
     },
     "node_modules/ejs": {
@@ -10518,15 +9891,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-redact": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
-      "integrity": "sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/fast-text-encoding": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.6.tgz",
@@ -10684,15 +10048,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/filter-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
-      "integrity": "sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/find-cache-dir": {
@@ -12312,12 +11667,6 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -12897,13 +12246,6 @@
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
       "integrity": "sha512-rnYUdIo6xRCJnQmbVFEwcxF144erlD+M3YcJUVesflU9paQaE8p+fJDcIQrlMYbxoANFL+AB9hZrzSBBk5PL+g==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
@@ -15105,24 +14447,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/query-string": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz",
-      "integrity": "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==",
-      "license": "MIT",
-      "dependencies": {
-        "decode-uri-component": "^0.2.2",
-        "filter-obj": "^1.1.0",
-        "split-on-first": "^1.0.0",
-        "strict-uri-encode": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -16713,15 +16037,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/split-on-first": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
-      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -16808,21 +16123,6 @@
       "dependencies": {
         "inherits": "~2.0.4",
         "readable-stream": "^3.5.0"
-      }
-    },
-    "node_modules/stream-shift": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
-      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT"
-    },
-    "node_modules/strict-uri-encode": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
-      "integrity": "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/string_decoder": {
@@ -19050,17 +18350,6 @@
         "node": ">=22"
       }
     },
-    "packages/taquito-beacon-wallet/node_modules/@types/chrome": {
-      "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.40.tgz",
-      "integrity": "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/filesystem": "*",
-        "@types/har-format": "*"
-      }
-    },
     "packages/taquito-beacon-wallet/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -20236,17 +19525,6 @@
       },
       "engines": {
         "node": ">=22"
-      }
-    },
-    "packages/taquito-wallet-connect/node_modules/@types/chrome": {
-      "version": "0.1.40",
-      "resolved": "https://registry.npmjs.org/@types/chrome/-/chrome-0.1.40.tgz",
-      "integrity": "sha512-UnfyRAe8ORu9HSuTH0EqyOEUin3JrWW9Nl/gDXezNfTUrfIoxw+WRZgKOxGz0t5BnjbfXBnS2eCYfW2PxH1wcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/filesystem": "*",
-        "@types/har-format": "*"
       }
     },
     "packages/taquito/node_modules/@babel/types": {

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
     ]
   },
   "overrides": {
-    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@^4.8.1-ecad",
-    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@^4.8.1-ecad",
-    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@^4.8.1-ecad",
-    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@^4.8.1-ecad",
-    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@^4.8.1-ecad",
-    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@^4.8.1-ecad",
-    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@^4.8.1-ecad",
-    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@^4.8.1-ecad",
+    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.1-ecad.4",
+    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.1-ecad.4",
+    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.1-ecad.4",
+    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.1-ecad.4",
+    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.1-ecad.4",
+    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.1-ecad.4",
+    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.1-ecad.4",
+    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.1-ecad.4",
     "axios": "1.15.0",
     "lodash": "4.18.1",
     "anymatch": {

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -15,14 +15,14 @@
   "typings": "dist/types/taquito-beacon-wallet.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/taquito-beacon-wallet.d.ts",
       "import": "./dist/taquito-beacon-wallet.es6.js",
-      "require": "./dist/taquito-beacon-wallet.umd.js",
-      "types": "./dist/types/taquito-beacon-wallet.d.ts"
+      "require": "./dist/taquito-beacon-wallet.umd.js"
     },
     "./types": {
+      "types": "./dist/types/beacon-types.d.ts",
       "import": "./dist/beacon-types.es6.js",
-      "require": "./dist/beacon-types.umd.js",
-      "types": "./dist/types/beacon-types.d.ts"
+      "require": "./dist/beacon-types.umd.js"
     },
     "./package.json": "./package.json"
   },

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -70,8 +70,8 @@
     ]
   },
   "dependencies": {
-    "@ecadlabs/beacon-dapp": "^4.8.1-ecad",
-    "@ecadlabs/beacon-types": "^4.8.1-ecad",
+    "@ecadlabs/beacon-dapp": "4.8.1-ecad.4",
+    "@ecadlabs/beacon-types": "4.8.1-ecad.4",
     "@taquito/core": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
@@ -80,8 +80,8 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@ecadlabs/beacon-transport-postmessage": "^4.8.1-ecad",
-    "@ecadlabs/beacon-ui": "^4.8.1-ecad",
+    "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
+    "@ecadlabs/beacon-ui": "4.8.1-ecad.4",
     "@types/bluebird": "^3.5.42",
     "@types/chrome": "0.1.40",
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- pin Taquito Beacon dependencies and root Beacon overrides to `4.8.1-ecad.4`
- refresh `package-lock.json` against the published `@ecadlabs/beacon-*` `.4` tarballs
- capture the transitive dependency updates that come with the published Beacon fork

## Verification
- `npm -w @taquito/beacon-wallet run build`
- `npm -w @taquito/beacon-wallet run test`

