### PR TITLE
fix: validate stamped release dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - run: npm ci
-
       - name: Resolve release mode
         run: |
           set -euo pipefail
@@ -62,6 +60,9 @@ jobs:
 
       - name: Set release version
         run: node scripts/sync-workspace-deps.js "${VERSION}"
+
+      - name: Install stamped dependency graph
+        run: npm ci
 
       - name: Version stamp
         run: npm run version-stamp

--- a/.github/workflows/release_rehearsal.yml
+++ b/.github/workflows/release_rehearsal.yml
@@ -32,8 +32,6 @@ jobs:
           registry-url: https://registry.npmjs.org
           package-manager-cache: false
 
-      - run: npm ci
-
       - name: Resolve release mode
         run: |
           set -euo pipefail
@@ -60,6 +58,9 @@ jobs:
 
       - name: Set rehearsal version
         run: node scripts/sync-workspace-deps.js "${VERSION}"
+
+      - name: Install stamped dependency graph
+        run: npm ci
 
       - name: Version stamp
         run: npm run version-stamp

--- a/scripts/sync-workspace-deps.js
+++ b/scripts/sync-workspace-deps.js
@@ -1,77 +1,101 @@
 #!/usr/bin/env node
 // Sets the version in workspace package.json files and syncs cross-workspace
-// @taquito/* dependency ranges.
+// dependency ranges without touching external packages that happen to share
+// the @taquito scope.
 
 const { existsSync, readdirSync, readFileSync, writeFileSync } = require('fs');
 const { join } = require('path');
 
-const version = process.argv[2];
+function collectWorkspacePackageJsonPaths(root, workspaces) {
+  const packageJsonPaths = [];
 
-if (!version) {
-  console.error('Usage: sync-workspace-deps.js <version>');
-  process.exit(1);
-}
-
-const root = join(__dirname, '..');
-const rootPkgPath = join(root, 'package.json');
-const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf8'));
-const range = `^${version}`;
-
-rootPkg.version = version;
-writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + '\n');
-
-const packageJsonPaths = [];
-
-for (const workspace of rootPkg.workspaces || []) {
-  if (workspace.endsWith('/*')) {
-    const dir = join(root, workspace.slice(0, -2));
-    if (!existsSync(dir)) {
-      continue;
-    }
-
-    for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) {
+  for (const workspace of workspaces || []) {
+    if (workspace.endsWith('/*')) {
+      const dir = join(root, workspace.slice(0, -2));
+      if (!existsSync(dir)) {
         continue;
       }
 
-      const packageJsonPath = join(dir, entry.name, 'package.json');
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (!entry.isDirectory()) {
+          continue;
+        }
+
+        const packageJsonPath = join(dir, entry.name, 'package.json');
+        if (existsSync(packageJsonPath)) {
+          packageJsonPaths.push(packageJsonPath);
+        }
+      }
+    } else {
+      const packageJsonPath = join(root, workspace, 'package.json');
       if (existsSync(packageJsonPath)) {
         packageJsonPaths.push(packageJsonPath);
       }
     }
-  } else {
-    const packageJsonPath = join(root, workspace, 'package.json');
-    if (existsSync(packageJsonPath)) {
-      packageJsonPaths.push(packageJsonPath);
-    }
   }
+
+  return packageJsonPaths;
 }
 
-for (const packageJsonPath of packageJsonPaths) {
-  const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-  let changed = false;
+function syncWorkspaceDeps(root, version) {
+  const rootPkgPath = join(root, 'package.json');
+  const rootPkg = JSON.parse(readFileSync(rootPkgPath, 'utf8'));
+  const range = `^${version}`;
+  const packageJsonPaths = collectWorkspacePackageJsonPaths(root, rootPkg.workspaces);
+  const workspacePackageNames = new Set();
 
-  if (pkg.version !== version) {
-    pkg.version = version;
-    changed = true;
+  rootPkg.version = version;
+  writeFileSync(rootPkgPath, JSON.stringify(rootPkg, null, 2) + '\n');
+
+  for (const packageJsonPath of packageJsonPaths) {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    if (pkg.name) {
+      workspacePackageNames.add(pkg.name);
+    }
   }
 
-  for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
-    const deps = pkg[field];
-    if (!deps) {
-      continue;
+  for (const packageJsonPath of packageJsonPaths) {
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+    let changed = false;
+
+    if (pkg.version !== version) {
+      pkg.version = version;
+      changed = true;
     }
 
-    for (const name of Object.keys(deps)) {
-      if (name.startsWith('@taquito/') && deps[name] !== range) {
-        deps[name] = range;
-        changed = true;
+    for (const field of ['dependencies', 'devDependencies', 'peerDependencies']) {
+      const deps = pkg[field];
+      if (!deps) {
+        continue;
+      }
+
+      for (const name of Object.keys(deps)) {
+        if (workspacePackageNames.has(name) && deps[name] !== range) {
+          deps[name] = range;
+          changed = true;
+        }
       }
     }
-  }
 
-  if (changed) {
-    writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
-    console.log(`${pkg.name}@${version}`);
+    if (changed) {
+      writeFileSync(packageJsonPath, JSON.stringify(pkg, null, 2) + '\n');
+      console.log(`${pkg.name}@${version}`);
+    }
   }
 }
+
+if (require.main === module) {
+  const version = process.argv[2];
+
+  if (!version) {
+    console.error('Usage: sync-workspace-deps.js <version>');
+    process.exit(1);
+  }
+
+  syncWorkspaceDeps(join(__dirname, '..'), version);
+}
+
+module.exports = {
+  collectWorkspacePackageJsonPaths,
+  syncWorkspaceDeps,
+};

--- a/scripts/sync-workspace-deps.test.js
+++ b/scripts/sync-workspace-deps.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const { mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } = require('node:fs');
+const { join } = require('node:path');
+
+const { syncWorkspaceDeps } = require('./sync-workspace-deps.js');
+
+function writeJson(path, data) {
+  writeFileSync(path, JSON.stringify(data, null, 2) + '\n');
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+test('syncWorkspaceDeps only rewrites versions for workspace packages', () => {
+  const root = mkdtempSync(join(os.tmpdir(), 'sync-workspace-deps-'));
+
+  try {
+    mkdirSync(join(root, 'packages', 'taquito'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'taquito-core'), { recursive: true });
+    mkdirSync(join(root, 'packages', 'taquito-sapling'), { recursive: true });
+    mkdirSync(join(root, 'integration-tests'), { recursive: true });
+
+    writeJson(join(root, 'package.json'), {
+      name: 'taquito-monorepo',
+      version: '24.2.0',
+      workspaces: ['packages/*', 'integration-tests'],
+    });
+
+    writeJson(join(root, 'packages', 'taquito', 'package.json'), {
+      name: '@taquito/taquito',
+      version: '24.2.0',
+      dependencies: {
+        '@taquito/core': '^24.2.0',
+      },
+    });
+
+    writeJson(join(root, 'packages', 'taquito-core', 'package.json'), {
+      name: '@taquito/core',
+      version: '24.2.0',
+    });
+
+    writeJson(join(root, 'packages', 'taquito-sapling', 'package.json'), {
+      name: '@taquito/sapling',
+      version: '24.2.0',
+      dependencies: {
+        '@taquito/core': '^24.2.0',
+        '@taquito/sapling-wasm': '0.1.1',
+      },
+    });
+
+    writeJson(join(root, 'integration-tests', 'package.json'), {
+      name: 'integration-tests',
+      version: '24.2.0',
+      dependencies: {
+        '@taquito/taquito': '^24.2.0',
+      },
+    });
+
+    syncWorkspaceDeps(root, '24.3.0-beta.3');
+
+    assert.equal(readJson(join(root, 'package.json')).version, '24.3.0-beta.3');
+    assert.equal(
+      readJson(join(root, 'packages', 'taquito', 'package.json')).dependencies['@taquito/core'],
+      '^24.3.0-beta.3'
+    );
+    assert.equal(
+      readJson(join(root, 'packages', 'taquito-sapling', 'package.json')).dependencies['@taquito/core'],
+      '^24.3.0-beta.3'
+    );
+    assert.equal(
+      readJson(join(root, 'packages', 'taquito-sapling', 'package.json')).dependencies['@taquito/sapling-wasm'],
+      '0.1.1'
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- only rewrite dependency ranges for actual workspace packages during release version sync
- preserve external scoped packages like @taquito/sapling-wasm when stamping prerelease versions
- install the stamped dependency graph in release and rehearsal workflows before version-stamp, build, test, and publish

## Testing
- node --test scripts/sync-workspace-deps.test.js
- stamped 24.3.0-beta.3 in a disposable checkout and verified @taquito/sapling-wasm stayed pinned at 0.1.1
- npm ci in that stamped checkout