### PR TITLE
docs: clarify WalletConnect session restore flow

### DIFF
--- a/packages/taquito-wallet-connect/README.md
+++ b/packages/taquito-wallet-connect/README.md
@@ -26,7 +26,11 @@ Create a wallet instance with defined option parameters and set the wallet provi
 
 ```ts
 import { TezosToolkit } from '@taquito/taquito';
-import { WalletConnect } from '@taquito/wallet-connect';
+import {
+  NetworkType,
+  PermissionScopeMethods,
+  WalletConnect,
+} from '@taquito/wallet-connect';
 
 const wallet = await WalletConnect.init({
   projectId: "YOUR_PROJECT_ID", // can get YOUR_PROJECT_ID from [Reown Cloud](https://cloud.reown.com)
@@ -55,6 +59,16 @@ Tezos.setWalletProvider(wallet);
 ```
 
 Existing sessions can be restored with `configureWithExistingSessionKey()`. Restored sessions are validated before activation, so invalid or stale non-Tezos session data may be rejected during restore.
+
+```ts
+const existingSessionKey = wallet.getAllExistingSessionKeys()[0];
+
+if (existingSessionKey) {
+  wallet.configureWithExistingSessionKey(existingSessionKey);
+}
+```
+
+Both session restore helpers are synchronous.
 
 ## Additional Info
 

--- a/packages/taquito-wallet-connect/test/taquito-wallet-connect.spec.ts
+++ b/packages/taquito-wallet-connect/test/taquito-wallet-connect.spec.ts
@@ -1,4 +1,4 @@
-import { vi, type Mock } from 'vitest';
+import { expectTypeOf, vi, type Mock } from 'vitest';
 import { OpKind } from '@taquito/taquito';
 import {
   NetworkType,
@@ -183,6 +183,26 @@ describe('Wallet connect tests', () => {
       walletConnect.configureWithExistingSessionKey(sessionMultipleChains.topic);
 
       expect(mockSignClient.session.get).toHaveBeenCalledWith(sessionMultipleChains.topic);
+      expect(walletConnect.getSession().topic).toEqual(sessionMultipleChains.topic);
+    });
+
+    it('should support the synchronous consumer restore flow', () => {
+      expectTypeOf(walletConnect.getAllExistingSessionKeys()).toEqualTypeOf<string[]>();
+
+      mockSignClient.session.get.mockReturnValue(sessionMultipleChains);
+
+      const existingSessionKey = walletConnect.getAllExistingSessionKeys()[0];
+
+      if (!existingSessionKey) {
+        throw new Error('Expected an existing session key in the test fixture');
+      }
+
+      expectTypeOf(
+        walletConnect.configureWithExistingSessionKey(existingSessionKey)
+      ).toEqualTypeOf<void>();
+      walletConnect.configureWithExistingSessionKey(existingSessionKey);
+
+      expect(mockSignClient.session.get).toHaveBeenCalledWith(existingSessionKey);
       expect(walletConnect.getSession().topic).toEqual(sessionMultipleChains.topic);
     });
 

--- a/website/src/content/docs/next/walletconnect.mdx
+++ b/website/src/content/docs/next/walletconnect.mdx
@@ -48,7 +48,17 @@ It has an optional `pairingTopic` property, which allows connecting to an existi
 
 If no connection can be established with a wallet, the error `ConnectionFailed` will be thrown.
 
-Suppose there is a need to restore a session in the dApp rather than using the `requestPermissions` method, which would establish a new session. In that case, it is possible to configure the `WalletConnect` class with an existing session using the `configureWithExistingSessionKey` method. The session will be immediately restored without a prompt in the wallet to accept/decline it. The list of existing sessions can be retrieved with the `getAllExistingSessionKeys` method. An `InvalidSessionKey` error will be thrown if the provided session key doesn't exist. Restored sessions are also validated before activation, so invalid or stale non-Tezos session data may be rejected during restore.
+Suppose there is a need to restore a session in the dApp rather than using the `requestPermissions` method, which would establish a new session. In that case, it is possible to configure the `WalletConnect` class with an existing session using the `configureWithExistingSessionKey` method. The session will be immediately restored without a prompt in the wallet to accept or decline it. The list of existing sessions can be retrieved with the `getAllExistingSessionKeys` method. An `InvalidSessionKey` error will be thrown if the provided session key doesn't exist. Restored sessions are also validated before activation, so invalid or stale non-Tezos session data may be rejected during restore.
+
+```ts
+const existingSessionKey = walletConnect.getAllExistingSessionKeys()[0];
+
+if (existingSessionKey) {
+  walletConnect.configureWithExistingSessionKey(existingSessionKey);
+}
+```
+
+Both session restore helpers are synchronous.
 
 ## Send Tezos operation with `WalletConnect` and `TezosToolkit`
 


### PR DESCRIPTION
## Summary
- document the synchronous WalletConnect session restore helpers in the package README
- add the same restore example to the next website WalletConnect docs page
- add a consumer-oriented test that exercises the sync restore flow and asserts its type surface

## Testing
- npm -C repos/taquito -w @taquito/wallet-connect test
- npm -C repos/taquito -w @taquito/wallet-connect run lint
