### PR TITLE
Update Beacon SDK to 4.8.1-ecad.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2254,13 +2254,13 @@
       }
     },
     "node_modules/@ecadlabs/beacon-core": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-VNOT9bBuxQn1cTQZoqQ4WEPE/BGEGBukBA7eKQGDoFA8WUxtv5HoqNS2GEeyuSvm/mija/R5nxD+DKcEuCmSLw==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-RF9LviCVOgGc4OFFPzaLd/BsgI3ab0qyoEJtSHrOD7XqsmlOhJ8/1tziesmn9doQ5hgTXM/TWJlePWxGGz3uvw==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.1.0",
         "@stablelib/x25519-session": "^2.0.1",
@@ -2402,74 +2402,76 @@
       }
     },
     "node_modules/@ecadlabs/beacon-dapp": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-Oz8RxfEDIsDy0lRy3VjGTQ5yqaQH+ctn7x3bjBDfPWiEJRYYHwRnBXEu+lRhzxhmsWBduH2B1zyY6HWmsWx6LQ==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-VAv1p4Mjyr93Dx3RA8eed+wvJkXgXfrkeQUpA4xiZhNdwJ0xOnSVelCePY7/cFqGLYS61H8c+b6kJC53Eu/DqQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
+        "@walletconnect/types": "^2.23.9",
         "broadcast-channel": "^7.3.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-matrix": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-CiiUvZGhN4Yd4/B9GHH2k/c3x3WHuL5aZigT/2Y8kQiaAZZ2Mc00LCFgnFY0fLGiAXr9izSZ+nJrHBIBwk5ARg==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-/FIQjIoLfNjpR28zb0eH6pAUW85dZ5pE6GwhYbAzuFaW+gFSachKSShjHjwWML3dU+ckgPJ3XauE6GcnzQWaCw==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
         "axios": "^1.15.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-postmessage": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-h/87eBPnxyGt2eu//xiHc5IKUcfUWwU4Z/hpWMnAckd9ibOWqzpOgUmwkaXZL7U5HA/NUyUbfckRTKDadZc3MA==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-+bftYCNbhwBGZgz06ge7lmjLIXCPNLItap5au2zp9nwtxlv30vepIqSV6JlelKi3dcgbTFezJIN7smu3eQ1NNg==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.4"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.6"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-walletconnect": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-JIPwynvnbF2gM1ZmdAw+vWl5NJzPnxRGLBOQrLvdMFLQ7Q1gk4yoLsA+GIwWL1fugExGJZqCiMe/t6ZtmyeIxA==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-9tmsySa44YjCiYxvsq8KRMTB+HlRBFvQXvewiSRRutfWX+YG4USyuGa8ol4vXDPGLxDE6AndARPCkNY+rV1jqg==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
         "@walletconnect/sign-client": "^2.23.9",
-        "elliptic": "^6.6.1"
+        "@walletconnect/types": "^2.23.9",
+        "@walletconnect/utils": "^2.23.9"
       }
     },
     "node_modules/@ecadlabs/beacon-types": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-NnA8O7FKAs7AQBB93+nMZnxw1Hz/tO+NIt5pP8wOLFBogpFNYp72LOJLKhkYZiePTU71EMGI8FmYrEZLqRYoxw==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-OUXWCHgkRZim6DEtTIHXiqroArigB4qWBAgFGqFZWcYZUFwcXWTtqNwqNQ4BNxERXkS4FQRMEDo5sXatCX+n6A==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "^0.1.40"
       }
     },
     "node_modules/@ecadlabs/beacon-ui": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-0xV28UL0DkOGZiaAC+8Lpin17RWuiIT0X5PcB+8cZ3c8yyRJeYoMlk9pepTqj9NftzY/WjDTWrEuej6jumkiBw==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-CrLk0B6GN3Sm+spE7HlLCCuIrKN71swjhl18lTNBX1jx9RRk0FC0+kKszeMqZUbJ7k3juoK/aJMTNlhVn11A5Q==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
         "@walletconnect/utils": "^2.23.9",
         "qrcode-svg": "^1.1.0",
         "react": "^19.2.5",
@@ -2502,9 +2504,9 @@
       }
     },
     "node_modules/@ecadlabs/beacon-utils": {
-      "version": "4.8.1-ecad.4",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.4.tgz",
-      "integrity": "sha512-voe1wzJCTuHW3PukN2PL8j+uPKfeeVDKI1B8S9bKk98b5VhUOl6aL82Fpm47aqdCc45aoDhOnxLZ0DMyzaG64Q==",
+      "version": "4.8.1-ecad.6",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.6.tgz",
+      "integrity": "sha512-OpwbQaZ/WILdguw86UWuRnzKHHt7XQfDNzFRFMAwrryJ0qCKLJq1eic1ibn3JpE8Foh4p+TlIwJNVjk8RqTPQg==",
       "license": "ISC",
       "dependencies": {
         "@stablelib/ed25519": "^2.1.0",
@@ -7109,25 +7111,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-      "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -7436,128 +7419,6 @@
         "url": "https://github.com/sponsors/pubkey"
       }
     },
-    "node_modules/brorand": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-      "license": "MIT"
-    },
-    "node_modules/browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "node_modules/browserify-cipher": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
-      "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserify-aes": "^1.0.4",
-        "browserify-des": "^1.0.0",
-        "evp_bytestokey": "^1.0.0"
-      }
-    },
-    "node_modules/browserify-des": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
-      "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "des.js": "^1.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/browserify-rsa": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.1.1.tgz",
-      "integrity": "sha512-YBjSAiTqM04ZVei6sXighu679a3SqWORA3qZTEqZImnlkDIFtKc6pNutpjyZ8RJTjQtuYfeetkxM11GwoYXMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^5.2.1",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/browserify-sign": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.5.tgz",
-      "integrity": "sha512-C2AUdAJg6rlM2W5QMp2Q4KGQMVBwR1lIimTsUnutJ8bMpW5B52pGpR2gEnNBNwijumDo5FojQ0L9JrXA8m4YEw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "bn.js": "^5.2.2",
-        "browserify-rsa": "^4.1.1",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.6.1",
-        "inherits": "^2.0.4",
-        "parse-asn1": "^5.1.9",
-        "readable-stream": "^2.3.8",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/browserify-sign/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/browserify-sign/node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/browserify-sign/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/browserify-sign/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -7639,13 +7500,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7821,21 +7675,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/cipher-base": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
-      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.10"
       }
     },
     "node_modules/cli-cursor": {
@@ -8142,13 +7981,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
@@ -8214,53 +8046,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/create-ecdh": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
-      "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "elliptic": "^6.5.3"
-      }
-    },
-    "node_modules/create-ecdh/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/create-hash": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
-      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
-      }
-    },
-    "node_modules/create-hmac": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
-      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
-      }
-    },
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
@@ -8309,33 +8094,6 @@
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
-      }
-    },
-    "node_modules/crypto-browserify": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.1.tgz",
-      "integrity": "sha512-r4ESw/IlusD17lgQi1O20Fa3qNnsckR126TdUuBgAu7GBYSIPvdNyONd3Zrxh0xCwA4+6w/TDArBPsMvhur+KQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "browserify-cipher": "^1.0.1",
-        "browserify-sign": "^4.2.3",
-        "create-ecdh": "^4.0.4",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "diffie-hellman": "^5.0.3",
-        "hash-base": "~3.0.4",
-        "inherits": "^2.0.4",
-        "pbkdf2": "^3.1.2",
-        "public-encrypt": "^4.0.3",
-        "randombytes": "^2.1.0",
-        "randomfill": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/crypto-js": {
@@ -8561,17 +8319,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/des.js": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
-      "integrity": "sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0"
-      }
-    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -8620,25 +8367,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/diffie-hellman": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
-      "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "miller-rabin": "^4.0.0",
-        "randombytes": "^2.0.0"
-      }
-    },
-    "node_modules/diffie-hellman/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/dijkstrajs": {
       "version": "1.0.3",
@@ -8750,27 +8478,6 @@
       "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/elliptic": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-      "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
     },
     "node_modules/email-addresses": {
       "version": "5.0.0",
@@ -9838,17 +9545,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -10746,30 +10442,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hash-base": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.5.tgz",
-      "integrity": "sha512-vXm0l45VbcHEVlTCzs8M+s0VeYsB2lnlAaThoLKGXr3bE/VWDOelNUnycUPEhKEaXARL2TEFjBOyUiM6+55KBg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/hash.js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
-      }
-    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -10787,17 +10459,6 @@
       "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
       "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
       "license": "MIT"
-    },
-    "node_modules/hmac-drbg": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-      "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-      "license": "MIT",
-      "dependencies": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -11546,13 +11207,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -12714,18 +12368,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/md5.js": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
-      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -12776,27 +12418,6 @@
       "engines": {
         "node": ">=8.6"
       }
-    },
-    "node_modules/miller-rabin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
-      "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
-      },
-      "bin": {
-        "miller-rabin": "bin/miller-rabin"
-      }
-    },
-    "node_modules/miller-rabin/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
@@ -12853,18 +12474,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-      "license": "ISC"
-    },
-    "node_modules/minimalistic-crypto-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-      "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "9.0.9",
@@ -13779,23 +13388,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/parse-asn1": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.9.tgz",
-      "integrity": "sha512-fIYNuZ/HastSb80baGOuPRo1O9cf4baWw5WsAp7dBuUzeTD/BoaG8sVTdlPFksBE2lF21dN+A1AnrpIjSWqHHg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "asn1.js": "^4.10.1",
-        "browserify-aes": "^1.2.0",
-        "evp_bytestokey": "^1.0.3",
-        "pbkdf2": "^3.1.5",
-        "safe-buffer": "^5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -13902,24 +13494,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pbkdf2": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.5.tgz",
-      "integrity": "sha512-Q3CG/cYvCO1ye4QKkuH7EXxs3VC/rI1/trd+qX2+PolbaKG0H+bgcZzrTt96mMyRtejk+JMCiLUn3y29W8qmFQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "ripemd160": "^2.0.3",
-        "safe-buffer": "^5.2.1",
-        "sha.js": "^2.4.12",
-        "to-buffer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -14184,13 +13758,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/process-warning": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
@@ -14258,28 +13825,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/public-encrypt": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
-      "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.1.0",
-        "browserify-rsa": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "parse-asn1": "^5.0.0",
-        "randombytes": "^2.0.1",
-        "safe-buffer": "^5.1.2"
-      }
-    },
-    "node_modules/public-encrypt/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/pump": {
       "version": "3.0.4",
@@ -14512,27 +14057,6 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/randomfill": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
-      "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "randombytes": "^2.0.5",
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/rc": {
       "version": "1.2.8",
@@ -15135,76 +14659,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/ripemd160": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
-      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hash-base": "^3.1.2",
-        "inherits": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/ripemd160/node_modules/hash-base": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
-      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^2.3.8",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/ripemd160/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/ripemd160/node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ripemd160/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/ripemd160/node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
@@ -15766,27 +15220,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/sha.js": {
-      "version": "2.4.12",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
-      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
-      "dev": true,
-      "license": "(MIT AND BSD-3-Clause)",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "safe-buffer": "^5.2.1",
-        "to-buffer": "^1.2.0"
-      },
-      "bin": {
-        "sha.js": "bin.js"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/shallow-clone": {
@@ -16591,28 +16024,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/to-buffer": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
-      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "isarray": "^2.0.5",
-        "safe-buffer": "^5.2.1",
-        "typed-array-buffer": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/to-buffer/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -18351,8 +17762,8 @@
       "version": "24.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ecadlabs/beacon-dapp": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-dapp": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
         "@taquito/core": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
@@ -18360,8 +17771,8 @@
         "util": "^0.12.5"
       },
       "devDependencies": {
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.4",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.6",
         "@types/bluebird": "^3.5.42",
         "@types/chrome": "0.1.40",
         "@types/node": "^22.0.0",
@@ -18370,7 +17781,6 @@
         "@typescript-eslint/parser": "^6.21.0",
         "colors": "^1.4.0",
         "cross-env": "^7.0.3",
-        "crypto-browserify": "^3.12.1",
         "eslint": "^8.57.0",
         "fake-indexeddb": "^6.2.5",
         "lint-staged": "^15.2.7",

--- a/package.json
+++ b/package.json
@@ -94,14 +94,14 @@
     ]
   },
   "overrides": {
-    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.1-ecad.4",
-    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.1-ecad.4",
-    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.1-ecad.4",
-    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.1-ecad.4",
-    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.1-ecad.4",
-    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.1-ecad.4",
-    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.1-ecad.4",
-    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.1-ecad.4",
+    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.1-ecad.6",
+    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.1-ecad.6",
+    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.1-ecad.6",
+    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.1-ecad.6",
+    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.1-ecad.6",
+    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.1-ecad.6",
+    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.1-ecad.6",
+    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.1-ecad.6",
     "axios": "1.15.0",
     "lodash": "4.18.1",
     "anymatch": {

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -70,8 +70,8 @@
     ]
   },
   "dependencies": {
-    "@ecadlabs/beacon-dapp": "4.8.1-ecad.4",
-    "@ecadlabs/beacon-types": "4.8.1-ecad.4",
+    "@ecadlabs/beacon-dapp": "4.8.1-ecad.6",
+    "@ecadlabs/beacon-types": "4.8.1-ecad.6",
     "@taquito/core": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
@@ -79,8 +79,8 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.4",
-    "@ecadlabs/beacon-ui": "4.8.1-ecad.4",
+    "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
+    "@ecadlabs/beacon-ui": "4.8.1-ecad.6",
     "@types/bluebird": "^3.5.42",
     "@types/chrome": "0.1.40",
     "@types/node": "^22.0.0",
@@ -88,7 +88,6 @@
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "colors": "^1.4.0",
-    "crypto-browserify": "^3.12.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.0",
     "fake-indexeddb": "^6.2.5",

--- a/packages/taquito-beacon-wallet/webpack.config.js
+++ b/packages/taquito-beacon-wallet/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
       fs: false,
       stream: require.resolve("stream-browserify"),
       util: require.resolve("util"),
-      crypto: require.resolve("crypto-browserify")
+      crypto: false
     },
     conditionNames: ['import', 'module', 'browser', 'default'],
     alias: {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -84,7 +84,7 @@ export default defineConfig({
       polyfillShimsResolver(),
       tailwindcss(),
       nodePolyfills({
-        include: ['buffer', 'stream', 'crypto', 'path', 'http', 'https'],
+        include: ['buffer', 'stream', 'crypto', 'http', 'https'],
         globals: {
           Buffer: true,
           global: true,

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -34,9 +34,6 @@
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "@types/prismjs": "^1.26.5",
-        "crypto-browserify": "^3.12.1",
-        "os-browserify": "^0.3.0",
-        "path-browserify": "^1.0.1",
         "tailwindcss": "^4.2.2",
         "vite-plugin-node-polyfills": "^0.24.0"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -39,9 +39,6 @@
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.2",
     "@types/prismjs": "^1.26.5",
-    "crypto-browserify": "^3.12.1",
-    "os-browserify": "^0.3.0",
-    "path-browserify": "^1.0.1",
     "tailwindcss": "^4.2.2",
     "vite-plugin-node-polyfills": "^0.24.0"
   },


### PR DESCRIPTION
## Summary
- update Taquito Beacon dependencies and root overrides to `@ecadlabs/beacon-*` `4.8.1-ecad.6`
- remove the direct `crypto-browserify` carry-over from `@taquito/beacon-wallet` and align its webpack fallback with the cleaned Beacon bundle behavior
- remove redundant direct website polyfill package declarations and refresh the affected lockfiles

## Testing
- npm install
- npm -w packages/taquito-beacon-wallet run build
- npm -w packages/taquito-beacon-wallet run test
- cd website && npm run build