### PR TITLE
docs: clarify trusted publishing in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     environment: release
     permissions:
       contents: write
+      # Required for npm trusted publishing. Official Taquito npm releases do not use
+      # a long-lived CI npm token secret.
       id-token: write
       pull-requests: write
     env:
@@ -78,10 +80,14 @@ jobs:
 
       - name: Publish prerelease packages
         if: ${{ inputs.prerelease }}
+        # npm publication relies on the GitHub Actions <-> npm trusted publishing
+        # connection plus provenance, not on a repo-held npm automation token.
         run: npm publish --workspaces --tag "${DIST_TAG}" --provenance --access public
 
       - name: Publish stable packages
         if: ${{ !inputs.prerelease }}
+        # npm publication relies on the GitHub Actions <-> npm trusted publishing
+        # connection plus provenance, not on a repo-held npm automation token.
         run: npm publish --workspaces --tag "${DIST_TAG}" --provenance --access public
 
       - name: Create GitHub Release


### PR DESCRIPTION
## Summary
Clarifies in the release workflow that Taquito publishes to npm via GitHub Actions trusted publishing with OIDC and provenance, not a long-lived CI npm token.

## Why
We just debugged a release failure caused by a missing trusted publisher on one package. Making the auth model explicit in the workflow should reduce future confusion when npm emits token-style auth errors during trusted publishing failures.

## Testing
- No code-path changes
- Workflow comments only