### PR TITLE
Fix next docs WalletConnect runner and add /docs/next redirect

### DIFF
--- a/website/src/components/SimpleCodeRunner.astro
+++ b/website/src/components/SimpleCodeRunner.astro
@@ -8,14 +8,20 @@ interface Props {
   language?: string;
   title?: string;
   wallet?: boolean;
+  noConfig?: boolean;
 }
 
-const { code, language = 'javascript', title, wallet = false } = Astro.props;
+const { code, language = 'javascript', title, wallet = false, noConfig = false } = Astro.props;
 
 const html = Prism.highlight(code, Prism.languages[language] || Prism.languages.javascript, language);
 ---
 
-<live-code-runner data-code={code} data-wallet={wallet ? "true" : "false"} class="pre">
+<live-code-runner
+  data-code={code}
+  data-wallet={wallet ? "true" : "false"}
+  data-no-config={noConfig ? "true" : "false"}
+  class="pre"
+>
   <div class="mb-4">
       <pre class={`language-${language} m-0 p-4 overflow-x-auto code`} set:html={html} />
       <button class="run-button bg-green-600 text-white border-none py-2 px-4 rounded text-sm font-medium cursor-pointer transition-colors duration-200 hover:bg-green-700 disabled:bg-gray-300 disabled:cursor-not-allowed">
@@ -76,6 +82,7 @@ const html = Prism.highlight(code, Prism.languages[language] || Prism.languages.
       // Get code from data attribute
       const sourceCodeContent = this.getAttribute('data-code') || '';
       const isWalletMode = this.getAttribute('data-wallet') === 'true';
+      const shouldSkipConfig = this.getAttribute('data-no-config') === 'true';
 
       if (!sourceCodeContent) {
         outputContent.textContent = "Error: No code to execute";
@@ -120,7 +127,7 @@ const html = Prism.highlight(code, Prism.languages[language] || Prism.languages.
               console.error("Wallet connection failed:", error);
             }
           }
-        } else {
+        } else if (!shouldSkipConfig) {
           // Automatically configure signer if not already configured
           if (win.configureSigner && !win.__signerConfigured) {
             try {

--- a/website/src/pages/docs/next.astro
+++ b/website/src/pages/docs/next.astro
@@ -1,0 +1,3 @@
+---
+return Astro.redirect('/docs/next/quick_start', 301);
+---

--- a/website/src/utils/remark-live-code.mjs
+++ b/website/src/utils/remark-live-code.mjs
@@ -14,8 +14,9 @@ export function remarkLiveCode() {
       // Get the language (default to 'javascript')
       const language = node.lang || 'javascript';
 
-      // Check if the code block has 'wallet' in its meta
+      // Check if the code block has 'wallet' or 'noConfig' in its meta
       const isWallet = node.meta.includes('wallet');
+      const noConfig = node.meta.includes('noConfig');
 
       // Use the code as-is - Astro will handle proper escaping for JSX attributes
       const escapedCode = node.value;
@@ -43,6 +44,14 @@ export function remarkLiveCode() {
         });
       }
 
+      if (noConfig) {
+        attributes.push({
+          type: 'mdxJsxAttribute',
+          name: 'noConfig',
+          value: null // boolean attribute (presence = true)
+        });
+      }
+
       const jsxNode = {
         type: 'mdxJsxFlowElement',
         name: 'SimpleCodeRunner',
@@ -55,4 +64,3 @@ export function remarkLiveCode() {
     });
   };
 }
-


### PR DESCRIPTION
## Summary
- preserve the `noConfig` live-code flag so WalletConnect examples skip automatic signer setup
- teach the live runner to honor `noConfig` at runtime
- add a permanent redirect from `/docs/next` to `/docs/next/quick_start`

## Testing
- npm run build (in `website/`)
- confirmed built `walletconnect` output includes `data-no-config="true"`
- confirmed built `/docs/next/index.html` redirects to `/docs/next/quick_start`
