### PR TITLE
Stabilize shadownet integration tests

### DIFF
--- a/integration-tests/__tests__/contract/batch/batch.spec.ts
+++ b/integration-tests/__tests__/contract/batch/batch.spec.ts
@@ -7,7 +7,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
   const Tezos = lib;
 
   describe(`Test contract.batch through contract api using: ${rpc}`, () => {
-    beforeAll(async () => {
+    beforeEach(async () => {
       await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
     });
 
@@ -20,7 +20,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
         .withOrigination({
           balance: '1',
           code: ligoSample,
-          storage: 0
+          storage: 0,
         });
 
       const op = await batch.send();
@@ -38,7 +38,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
         .withOrigination({
           balance: '1',
           code: ligoSampleMichelson,
-          storage: 0
+          storage: 0,
         });
 
       const op = await batch.send();
@@ -47,25 +47,26 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
     });
 
     it('Verify batch of transfers and origination operation using a combination of the two notations (array of operation with kind mixed with withTransfer method)', async () => {
-      const op = await Tezos.contract.batch([
-        {
-          kind: OpKind.TRANSACTION,
-          to: TEST_FUNDS_RECOVERY_ADDRESS,
-          amount: 0.02
-        },
-        {
-          kind: OpKind.ORIGINATION,
-          balance: "1",
-          code: ligoSample,
-          storage: 0,
-        }
-      ])
+      const op = await Tezos.contract
+        .batch([
+          {
+            kind: OpKind.TRANSACTION,
+            to: TEST_FUNDS_RECOVERY_ADDRESS,
+            amount: 0.02,
+          },
+          {
+            kind: OpKind.ORIGINATION,
+            balance: '1',
+            code: ligoSample,
+            storage: 0,
+          },
+        ])
         .withTransfer({ to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 })
         .withTransfer({ to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 })
         .send();
       await op.confirmation();
-      expect(op.status).toEqual('applied')
-    })
+      expect(op.status).toEqual('applied');
+    });
 
     it('Verify handling of contract.batch simple transfers with bad origination', async () => {
       expect.assertions(1);
@@ -79,13 +80,13 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
             balance: '1',
             code: ligoSample,
             storage: 0,
-            storageLimit: 0
+            storageLimit: 0,
           })
           .send();
       } catch (ex) {
         expect(ex).toEqual(
           expect.objectContaining({
-            message: expect.stringContaining('storage_exhausted.operation')
+            message: expect.stringContaining('storage_exhausted.operation'),
           })
         );
       }
@@ -93,23 +94,25 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
 
     it('Verify transfer and origination for contract.batch simple transfers from an account with low balance', async () => {
       const LocalTez = await createAddress();
-      const op = await Tezos.contract.transfer({ to: await LocalTez.signer.publicKeyHash(), amount: 2 });
+      const op = await Tezos.contract.transfer({
+        to: await LocalTez.signer.publicKeyHash(),
+        amount: 2,
+      });
       await op.confirmation();
-
 
       const batchOp = await LocalTez.contract
         .batch([
           {
             kind: OpKind.TRANSACTION,
             to: TEST_FUNDS_RECOVERY_ADDRESS,
-            amount: 0.01
+            amount: 0.01,
           },
           {
             kind: OpKind.ORIGINATION,
             balance: '0',
             code: ligoSample,
-            storage: 0
-          }
+            storage: 0,
+          },
         ])
         .send();
       await batchOp.confirmation();
@@ -120,7 +123,7 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
       const op = await Tezos.contract.originate({
         balance: '1',
         code: managerCode,
-        init: { string: await Tezos.signer.publicKeyHash() }
+        init: { string: await Tezos.signer.publicKeyHash() },
       });
       await op.confirmation();
       const contract = await op.contract();
@@ -148,7 +151,10 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
         .batch([
           { kind: OpKind.TRANSACTION, to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 },
           { kind: OpKind.TRANSACTION, to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 },
-          { kind: OpKind.TRANSACTION, ...contract.methodsObject.default([['Unit']]).toTransferParams() }
+          {
+            kind: OpKind.TRANSACTION,
+            ...contract.methodsObject.default([['Unit']]).toTransferParams(),
+          },
         ])
         .send();
 
@@ -163,13 +169,13 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
         .withOrigination({
           balance: '1',
           code: ligoSample,
-          storage: 0
+          storage: 0,
         })
         .withOrigination({
           balance: '1',
           code: ligoSampleMichelson,
-          storage: 0
-        })
+          storage: 0,
+        });
 
       const op = await batch.send();
       await op.confirmation();
@@ -177,35 +183,72 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker, knownContract, createAddress }
       const addresses = op.getOriginatedContractAddresses();
       expect(op.status).toEqual('applied');
       expect(addresses.length).toEqual(2);
-    })
+    });
 
     it('Verify batch contract calls can specify amount, fee, gasLimit and storageLimit', async () => {
       const op = await Tezos.contract.originate({
-        balance: "1",
+        balance: '1',
         code: managerCode,
-        init: { "string": await Tezos.signer.publicKeyHash() },
-      })
+        init: { string: await Tezos.signer.publicKeyHash() },
+      });
       await op.confirmation();
       const contract = await op.contract();
 
       const estimateOp = await Tezos.estimate.batch([
-        { ...(contract.methodsObject.do(MANAGER_LAMBDA.transferImplicit(TEST_FUNDS_RECOVERY_ADDRESS, 5)).toTransferParams()), kind: OpKind.TRANSACTION },
-        { ...(contract.methodsObject.do(MANAGER_LAMBDA.setDelegate(knownBaker)).toTransferParams()), kind: OpKind.TRANSACTION },
-        { ...(contract.methodsObject.do(MANAGER_LAMBDA.removeDelegate()).toTransferParams()), kind: OpKind.TRANSACTION },
-      ])
+        {
+          ...contract.methodsObject
+            .do(MANAGER_LAMBDA.transferImplicit(TEST_FUNDS_RECOVERY_ADDRESS, 5))
+            .toTransferParams(),
+          kind: OpKind.TRANSACTION,
+        },
+        {
+          ...contract.methodsObject.do(MANAGER_LAMBDA.setDelegate(knownBaker)).toTransferParams(),
+          kind: OpKind.TRANSACTION,
+        },
+        {
+          ...contract.methodsObject.do(MANAGER_LAMBDA.removeDelegate()).toTransferParams(),
+          kind: OpKind.TRANSACTION,
+        },
+      ]);
 
-      const batch = Tezos.contract.batch()
-        .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.transferImplicit(TEST_FUNDS_RECOVERY_ADDRESS, 5)), { fee: estimateOp[0].suggestedFeeMutez, gasLimit: estimateOp[0].gasLimit, storageLimit: estimateOp[0].storageLimit })
-        .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.setDelegate(knownBaker)), { fee: estimateOp[1].suggestedFeeMutez, gasLimit: estimateOp[1].gasLimit, storageLimit: estimateOp[1].storageLimit })
-        .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.removeDelegate()), { fee: estimateOp[2].suggestedFeeMutez, gasLimit: estimateOp[2].gasLimit, storageLimit: estimateOp[2].storageLimit })
+      const batch = Tezos.contract
+        .batch()
+        .withContractCall(
+          contract.methodsObject.do(
+            MANAGER_LAMBDA.transferImplicit(TEST_FUNDS_RECOVERY_ADDRESS, 5)
+          ),
+          {
+            fee: estimateOp[0].suggestedFeeMutez,
+            gasLimit: estimateOp[0].gasLimit,
+            storageLimit: estimateOp[0].storageLimit,
+          }
+        )
+        .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.setDelegate(knownBaker)), {
+          fee: estimateOp[1].suggestedFeeMutez,
+          gasLimit: estimateOp[1].gasLimit,
+          storageLimit: estimateOp[1].storageLimit,
+        })
+        .withContractCall(contract.methodsObject.do(MANAGER_LAMBDA.removeDelegate()), {
+          fee: estimateOp[2].suggestedFeeMutez,
+          gasLimit: estimateOp[2].gasLimit,
+          storageLimit: estimateOp[2].storageLimit,
+        });
       const batchOp = await batch.send();
 
       await batchOp.confirmation();
 
       // The sum of fee is slightly different from estimates above due to the size of the operation length varying slightly when forged (default value of estimates have higher values than actual estimates, making the variable length smaller than initially estimated)
-      expect(batchOp.fee).toEqual(estimateOp[0].suggestedFeeMutez + estimateOp[1].suggestedFeeMutez + estimateOp[2].suggestedFeeMutez);
-      expect(batchOp.gasLimit).toEqual(estimateOp[0].gasLimit + estimateOp[1].gasLimit + estimateOp[2].gasLimit)
-      expect(batchOp.storageLimit).toEqual(estimateOp[0].storageLimit + estimateOp[1].storageLimit + estimateOp[2].storageLimit)
-    })
+      expect(batchOp.fee).toEqual(
+        estimateOp[0].suggestedFeeMutez +
+          estimateOp[1].suggestedFeeMutez +
+          estimateOp[2].suggestedFeeMutez
+      );
+      expect(batchOp.gasLimit).toEqual(
+        estimateOp[0].gasLimit + estimateOp[1].gasLimit + estimateOp[2].gasLimit
+      );
+      expect(batchOp.storageLimit).toEqual(
+        estimateOp[0].storageLimit + estimateOp[1].storageLimit + estimateOp[2].storageLimit
+      );
+    });
   });
 });

--- a/integration-tests/__tests__/contract/batch/bls-batch-include-reveal.spec.ts
+++ b/integration-tests/__tests__/contract/batch/bls-batch-include-reveal.spec.ts
@@ -1,62 +1,70 @@
 import { OpKind } from '@taquito/taquito';
-import { CONFIGS, SignerType, TEST_FUNDS_RECOVERY_ADDRESS } from '../../../config';
+import { CONFIGS, SignerType, TEST_FUNDS_RECOVERY_ADDRESS, waitForRpcState } from '../../../config';
 import { TezosToolkit } from '@taquito/taquito';
 import { PrefixV2 } from '@taquito/utils';
 
 CONFIGS().forEach(({ lib, rpc, setup, knownBaker, signerConfig, createAddress }) => {
   const Tezos = lib;
-  let Bls: TezosToolkit
+  let Bls: TezosToolkit;
 
   describe(`Test estimate.batch includes an estimation for a tz4 reveal operation when needed using: ${rpc}`, () => {
     beforeEach(async () => {
       await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
       try {
-        Bls = await createAddress(PrefixV2.BLS12_381SecretKey)
-        let transferOp = await Tezos.contract.transfer({ to: await Bls.signer.publicKeyHash(), amount: 2 })
-        await transferOp.confirmation()
+        Bls = await createAddress(PrefixV2.BLS12_381SecretKey);
+        const blsPkh = await Bls.signer.publicKeyHash();
+        let transferOp = await Tezos.contract.transfer({ to: blsPkh, amount: 2 });
+        await transferOp.confirmation();
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getBalance(blsPkh),
+          (balance) => Number(balance.toString()) > 0,
+          { description: `funding ${blsPkh}` }
+        );
       } catch (e) {
-        console.log('beforeAll transferOp error', e)
+        console.log('beforeAll transferOp error', e);
         throw e;
       }
     });
 
     it('Verify that an estimate for a tz4 reveal operation is included in the response when using estimate.batch with an unrevealed signer', async () => {
       try {
-        const batchOpEstimate = await Bls.estimate
-          .batch([
-            { kind: OpKind.DELEGATION, source: await Bls.signer.publicKeyHash(), delegate: knownBaker },
-            { kind: OpKind.TRANSACTION, to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 },
-          ])
+        const batchOpEstimate = await Bls.estimate.batch([
+          {
+            kind: OpKind.DELEGATION,
+            source: await Bls.signer.publicKeyHash(),
+            delegate: knownBaker,
+          },
+          { kind: OpKind.TRANSACTION, to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 },
+        ]);
         expect(batchOpEstimate.length).toEqual(3);
       } catch (ex: any) {
         // When running tests more than one time with the same key, the account is already delegated to the given delegate
         if (signerConfig.type === SignerType.SECRET_KEY) {
           expect(ex.message).toMatch('delegate.no_deletion');
         } else {
-          throw ex
+          throw ex;
         }
       }
-
     });
 
     it('Verify the estimate.batch does not include an estimation of a tz4 reveal operation when the signer is already revealed.', async () => {
-
       try {
         // do a reveal operation first
         const revealOp = await Bls.contract.reveal({});
         await revealOp.confirmation();
-        const batchOpEstimate = await Bls.estimate
-          .batch([
-            { kind: OpKind.DELEGATION, source: await Bls.signer.publicKeyHash(), delegate: knownBaker },
-            { kind: OpKind.TRANSACTION, to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 },
-          ])
+        const batchOpEstimate = await Bls.estimate.batch([
+          {
+            kind: OpKind.DELEGATION,
+            source: await Bls.signer.publicKeyHash(),
+            delegate: knownBaker,
+          },
+          { kind: OpKind.TRANSACTION, to: TEST_FUNDS_RECOVERY_ADDRESS, amount: 0.02 },
+        ]);
 
         expect(batchOpEstimate.length).toEqual(2);
-
       } catch (ex: any) {
-
-        throw ex
-
+        throw ex;
       }
     });
   });

--- a/integration-tests/__tests__/contract/call-estimate.spec.ts
+++ b/integration-tests/__tests__/contract/call-estimate.spec.ts
@@ -1,5 +1,5 @@
 import { Estimate } from '@taquito/taquito';
-import { CONFIGS } from '../../config';
+import { CONFIGS, waitForRpcState } from '../../config';
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
 
@@ -13,12 +13,17 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const code = `parameter nat; storage nat; code { CAR ; NIL operation ; PAIR }`;
       op = await Tezos.contract.originate({
         code,
-        storage: 10
+        storage: 10,
       });
 
       await op.confirmation();
       contractAddress = op.contractAddress;
-
+      await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getContract(contractAddress!),
+        () => true,
+        { description: `contract ${contractAddress}` }
+      );
     });
 
     it(`should be able to estimate a contract call`, async () => {
@@ -28,7 +33,6 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       expect(estimate).toBeDefined();
       expect(estimate).toBeInstanceOf(Estimate);
-
     });
   });
 });

--- a/integration-tests/__tests__/contract/contract-with-key-collections.spec.ts
+++ b/integration-tests/__tests__/contract/contract-with-key-collections.spec.ts
@@ -1,15 +1,15 @@
-import { CONFIGS } from "../../config";
-import { MichelsonMap } from "@taquito/taquito";
-import { contractWithKeyCollections } from "../../data/contract-with-key-collections";
+import { CONFIGS } from '../../config';
+import { MichelsonMap } from '@taquito/taquito';
+import { contractWithKeyCollections } from '../../data/contract-with-key-collections';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
   const Tezos = lib;
 
   describe(`Test contract origination with key collections through contract api using: ${rpc}`, () => {
-    type Storage = { keySet: string[], keyMap: MichelsonMap<string, number>; }
+    type Storage = { keySet: string[]; keyMap: MichelsonMap<string, number> };
 
     beforeAll(async () => {
-      await setup({ preferFreshKey: true, minBalanceMutez: 2_000_000 });
+      await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
     });
 
     it('Verify contract.originate for a contract with set and map of keys and change them using corresponding methods', async () => {
@@ -25,20 +25,20 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
           'p2pk6842BMz2Se9XuMxQDe7yVdaEvpjNGQ7DYjKTQwzMUtryaHmZcV9',
         ],
         keyMap: MichelsonMap.fromLiteral({
-          'BLpk1wdswKAQynswErddqDxjsMkhg3n5i2Qgn8XTBYCrfuvwdeQDR7GvbwQPPS2q2pBiw5mcatRF': 0,
-          'edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh': 10,
-          'p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT': 40,
-          'sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo': 100,
-          'BLpk1w3urTgb1QJskQe8B9Tv2d7PiJi63HGo5XcPA9StafezaBijDVxAi8McfYWKptQrRoTvyhmZ': 88,
-          'sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj': 23,
-          'p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV': 17
-        }) as MichelsonMap<string, number>
+          BLpk1wdswKAQynswErddqDxjsMkhg3n5i2Qgn8XTBYCrfuvwdeQDR7GvbwQPPS2q2pBiw5mcatRF: 0,
+          edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh: 10,
+          p2pk65shUHKhx7zUSF7e8KZ2inmQ5aMS4jRBUmK6aCis4oaHoiWPXoT: 40,
+          sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo: 100,
+          BLpk1w3urTgb1QJskQe8B9Tv2d7PiJi63HGo5XcPA9StafezaBijDVxAi8McfYWKptQrRoTvyhmZ: 88,
+          sppk7aTKnmX5WV17KPo3LanjfPLoXTuNjkQTdLx2bYDqHPLVVCbSwoj: 23,
+          p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV: 17,
+        }) as MichelsonMap<string, number>,
       };
 
       const op = await Tezos.contract.originate({
         balance: '1',
         code: contractWithKeyCollections,
-        storage: initialStorage
+        storage: initialStorage,
       });
       await op.confirmation();
       expect(op.hash).toBeDefined();
@@ -47,33 +47,44 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       const contract = await op.contract();
       let storage = await contract.storage<Storage>();
       expect([...storage['keySet']].sort()).toEqual([...initialStorage.keySet].sort());
-      expect(storage['keyMap'].get('edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh')?.toString()).toEqual('10');
-      expect(storage['keyMap'].get('sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo')?.toString()).toEqual('100');
-      expect(storage['keyMap'].get('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV')?.toString()).toEqual('17');
+      expect(
+        storage['keyMap'].get('edpkuNjKKT48xBoT5asPrWdmuM1Yw8D93MwgFgVvtca8jb5pstzaCh')?.toString()
+      ).toEqual('10');
+      expect(
+        storage['keyMap'].get('sppk7aVdgAmezMCRTcHciVkVZoGNnhSdKEYcn5pYaqt4PvLjgFbLRxo')?.toString()
+      ).toEqual('100');
+      expect(
+        storage['keyMap'].get('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV')?.toString()
+      ).toEqual('17');
 
       const newKeySet = [
         'p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi',
         'p2pk6842BMz2Se9XuMxQDe7yVdaEvpjNGQ7DYjKTQwzMUtryaHmZcV9',
         'sppk7cudBXaXQUvbxb3f7tpKVSm6yKaYmjzqnPqvK6MrxFnnyxDEiim',
         'p2pk66DZ3igTFpyqeezoqvFycrD5dHpJC6idPL4CWLCU1qT3Fu9j15V',
-        'sppk7ZWnHCVLsPE4CDFUTH424Qj2gUiJ3sp581nvexfz21w8gPjRVce'
-      ]
+        'sppk7ZWnHCVLsPE4CDFUTH424Qj2gUiJ3sp581nvexfz21w8gPjRVce',
+      ];
       const setOp = await contract.methodsObject['setSet'](newKeySet).send();
       await setOp.confirmation();
       storage = await contract.storage<Storage>();
       expect([...storage['keySet']].sort()).toEqual([...newKeySet].sort());
 
       const newKeyMap = MichelsonMap.fromLiteral({
-        'p2pk66EcJmNvMMCauhfptZ5ffFXutNMytfxhcM7TkFMVLkySbgZ2dU9': 200,
-        'p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi': 201,
+        p2pk66EcJmNvMMCauhfptZ5ffFXutNMytfxhcM7TkFMVLkySbgZ2dU9: 200,
+        p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi: 201,
       }) as MichelsonMap<string, number>;
       const mapOp = await contract.methodsObject['setMap'](newKeyMap).send();
       await mapOp.confirmation();
       storage = await contract.storage<Storage>();
-      expect(storage['keyMap'].get('p2pk66EcJmNvMMCauhfptZ5ffFXutNMytfxhcM7TkFMVLkySbgZ2dU9')?.toString()).toEqual('200');
-      expect(storage['keyMap'].get('p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi')?.toString()).toEqual('201');
-      expect(storage['keyMap'].get('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV')).toBeUndefined();
-
+      expect(
+        storage['keyMap'].get('p2pk66EcJmNvMMCauhfptZ5ffFXutNMytfxhcM7TkFMVLkySbgZ2dU9')?.toString()
+      ).toEqual('200');
+      expect(
+        storage['keyMap'].get('p2pk66xmhjiN7LpfrDGFwpxPtJxkLtPjQ6HUxJbKmRbxSR7RMpamDwi')?.toString()
+      ).toEqual('201');
+      expect(
+        storage['keyMap'].get('p2pk67c5b5THCj5fyksX1C13etdUpLR9BDYvJUuJNrxeGqCgbY3NFpV')
+      ).toBeUndefined();
     });
   });
 });

--- a/integration-tests/__tests__/contract/operations/increase-paid-storage-operation.spec.ts
+++ b/integration-tests/__tests__/contract/operations/increase-paid-storage-operation.spec.ts
@@ -1,10 +1,9 @@
-import { CONFIGS } from '../../../config';
+import { CONFIGS, waitForRpcState } from '../../../config';
 import { ParameterValidationError } from '@taquito/core';
 import { OpKind } from '@taquito/taquito';
 import { ligoSample } from '../../../data/ligo-simple-contract';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
-
   const Tezos = lib;
   let simpleContractAddress: string;
   describe(`Test Increase Paid Storage using: ${rpc}`, () => {
@@ -13,7 +12,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       try {
         const op = await Tezos.contract.originate({
-          balance: "1",
+          balance: '1',
           code: `parameter string;
           storage string;
           code {CAR;
@@ -21,14 +20,23 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
                 CONCAT;
                 NIL operation; PAIR};
           `,
-          init: `"test"`
+          init: `"test"`,
         });
 
         await op.confirmation();
 
         simpleContractAddress = op.contractAddress!;
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getStoragePaidSpace(simpleContractAddress),
+          () => true,
+          { description: `paid storage visibility for ${simpleContractAddress}` }
+        );
       } catch (e) {
-        console.log(`Error when trying to originate the contract for the test: \n`, JSON.stringify(e));
+        console.log(
+          `Error when trying to originate the contract for the test: \n`,
+          JSON.stringify(e)
+        );
         throw e;
       }
     });
@@ -38,14 +46,19 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
 
       const op = await Tezos.contract.increasePaidStorage({
         amount: 1,
-        destination: simpleContractAddress
+        destination: simpleContractAddress,
       });
 
       await op.confirmation();
       expect(op.hash).toBeDefined();
       expect(op.status).toEqual('applied');
 
-      const paidSpaceAfter = await Tezos.rpc.getStoragePaidSpace(simpleContractAddress);
+      const paidSpaceAfter = await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getStoragePaidSpace(simpleContractAddress),
+        (paidSpace) => parseInt(paidSpace) === parseInt(paidSpaceBefore) + 1,
+        { description: `paid storage update for ${simpleContractAddress}` }
+      );
 
       expect(parseInt(paidSpaceAfter)).toEqual(parseInt(paidSpaceBefore) + 1);
     });
@@ -53,25 +66,31 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
     it(`should be able to include increasePaidStorage operation in a batch (different batch syntax): ${rpc}`, async () => {
       const paidSpaceBefore = await Tezos.rpc.getStoragePaidSpace(simpleContractAddress);
 
-      const op = await Tezos.contract.batch([
-        {
-          kind: OpKind.ORIGINATION,
-          balance: '1',
-          code: ligoSample,
-          storage: 0
-        },
-        {
-          kind: OpKind.INCREASE_PAID_STORAGE,
-          amount: 1,
-          destination: simpleContractAddress
-        }
-      ])
-      .send();
+      const op = await Tezos.contract
+        .batch([
+          {
+            kind: OpKind.ORIGINATION,
+            balance: '1',
+            code: ligoSample,
+            storage: 0,
+          },
+          {
+            kind: OpKind.INCREASE_PAID_STORAGE,
+            amount: 1,
+            destination: simpleContractAddress,
+          },
+        ])
+        .send();
 
       await op.confirmation();
       expect(op.status).toEqual('applied');
 
-      const paidSpaceAfter = await Tezos.rpc.getStoragePaidSpace(simpleContractAddress);
+      const paidSpaceAfter = await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getStoragePaidSpace(simpleContractAddress),
+        (paidSpace) => parseInt(paidSpace) === parseInt(paidSpaceBefore) + 1,
+        { description: `batched paid storage update for ${simpleContractAddress}` }
+      );
 
       expect(parseInt(paidSpaceAfter)).toEqual(parseInt(paidSpaceBefore) + 1);
     });
@@ -80,7 +99,7 @@ CONFIGS().forEach(({ lib, rpc, setup }) => {
       await expect(
         Tezos.contract.increasePaidStorage({
           amount: 1,
-          destination: 'invalid_address'
+          destination: 'invalid_address',
         })
       ).rejects.toThrow(ParameterValidationError);
     });

--- a/integration-tests/__tests__/contract/permits.spec.ts
+++ b/integration-tests/__tests__/contract/permits.spec.ts
@@ -1,78 +1,82 @@
-import { CONFIGS } from '../../config';
+import { CONFIGS, waitForRpcState } from '../../config';
 import { MichelsonMap, MichelCodecPacker, TezosToolkit } from '@taquito/taquito';
 import { permit_admin_42_expiry } from '../../data/permit_admin_42_expiry';
 import { permit_admin_42_set } from '../../data/permit_admin_42_set';
 import { permit_fa12_smartpy } from '../../data/permit_fa12_smartpy';
 import { buf2hex, stringToBytes, hex2buf } from '@taquito/utils';
 import { tzip16, Tzip16Module } from '@taquito/tzip16';
-import { packDataBytes } from "@taquito/michel-codec"
+import { packDataBytes } from '@taquito/michel-codec';
 
 const blake = require('blakejs');
 const bob_address = 'tz1Xk7HkSwHv6dTEgR7E2WC2yFj4cyyuj2Gh';
 
-const create_bytes_to_sign = async (Tezos: TezosToolkit, contractAddress: string, methodHash: string) => {
+const create_bytes_to_sign = async (
+  Tezos: TezosToolkit,
+  contractAddress: string,
+  methodHash: string
+) => {
   const chainId = await Tezos.rpc.getChainId();
 
-  const contract = await Tezos.contract.at(contractAddress)
+  const contract = await Tezos.contract.at(contractAddress);
   const contractStorage: any = await contract.storage();
   let counter = 0;
-  if (contractStorage.hasOwnProperty("counter")) {
+  if (contractStorage.hasOwnProperty('counter')) {
     counter = contractStorage.counter.toNumber();
   } else {
-    counter = contractStorage["1"].toNumber();
+    counter = contractStorage['1'].toNumber();
   }
   const sigParamData: any = {
-    prim: "Pair",
+    prim: 'Pair',
     args: [
       {
-        prim: "Pair",
+        prim: 'Pair',
         args: [
           {
-            string: chainId
+            string: chainId,
           },
           {
-            string: contractAddress
-          }
-        ]
+            string: contractAddress,
+          },
+        ],
       },
       {
-        prim: "Pair",
+        prim: 'Pair',
         args: [
           {
-            int: counter
+            int: counter,
           },
           {
-            bytes: methodHash
-          }
-        ]
-      }
-    ]
+            bytes: methodHash,
+          },
+        ],
+      },
+    ],
   };
   const sigParamType: any = {
-    prim: "pair",
+    prim: 'pair',
     args: [
       {
-        prim: "pair",
+        prim: 'pair',
         args: [
           {
-            prim: "chain_id"
+            prim: 'chain_id',
           },
-          { prim: "address" }
-        ]
+          { prim: 'address' },
+        ],
       },
       {
-        prim: "pair",
-        args: [{ prim: "nat" }, { prim: "bytes" }]
-      }
-    ]
+        prim: 'pair',
+        args: [{ prim: 'nat' }, { prim: 'bytes' }],
+      },
+    ],
   };
 
   const sigParamPacked = packDataBytes(sigParamData, sigParamType);
   // signs the hash
   const signature = await Tezos.signer.sign(sigParamPacked.bytes);
 
-  return signature.prefixSig
-}
+  return signature.prefixSig;
+};
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
   const Tezos = lib;
@@ -110,7 +114,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
       const packed_param = raw_packed.packed;
       const param_hash = buf2hex(blake.blake2b(hex2buf(packed_param), null, 32));
 
-      const param_sig = await create_bytes_to_sign(Tezos, permit_contract.address, param_hash)
+      const param_sig = await create_bytes_to_sign(Tezos, permit_contract.address, param_hash);
 
       const permitMethodCall = await permit_contract.methodsObject
         .permit({ 0: signer_key, 1: param_sig, 2: param_hash })
@@ -210,13 +214,18 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
       const setMintMethodCall = await fa12_contract.methodsObject
         .mint({
           address: await Tezos.signer.publicKeyHash(),
-          value: mint_amount
+          value: mint_amount,
         })
         .send();
       await setMintMethodCall.confirmation();
       expect(setMintMethodCall.hash).toBeDefined();
       expect(setMintMethodCall.status).toEqual('applied');
-      const storage: any = await fa12_contract.storage();
+      const storage: any = await waitForRpcState(
+        Tezos,
+        () => fa12_contract.storage(),
+        (contractStorage: any) => contractStorage['totalSupply']?.toString() === '42',
+        { description: `permit fa1.2 storage for ${contractAddress}` }
+      );
       expect(storage['totalSupply'].toString()).toEqual('42');
 
       Tezos.addExtension(new Tzip16Module());
@@ -235,7 +244,6 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
       const viewGetDefaultExpiryResult = await views.GetDefaultExpiry().executeView('Unit');
       expect(viewGetDefaultExpiryResult.toString()).toEqual('50000');
-
     });
 
     describe(`Verify contract having a permit for tzip-17: ${rpc}`, () => {
@@ -309,7 +317,9 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
         //Mint 10 tokens to bootstrap 2
         const mint_contract = await LocalTez1.contract.at(fa12_contract.address);
-        const mint = await mint_contract.methodsObject.mint({ address: bootstrap2_address, value: 10 }).send();
+        const mint = await mint_contract.methodsObject
+          .mint({ address: bootstrap2_address, value: 10 })
+          .send();
         await mint.confirmation();
         expect(mint.hash).toBeDefined();
         expect(mint.status).toEqual('applied');
@@ -318,11 +328,15 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
         //Observe transfer by non bootstrap2 sender fails
         const fail_contract = await LocalTez4.contract.at(fa12_contract.address);
         try {
-          await fail_contract.methodsObject.transfer({ from_: bootstrap3_address, to_: bootstrap4_address, value: 1 }).send();
+          await fail_contract.methodsObject
+            .transfer({ from_: bootstrap3_address, to_: bootstrap4_address, value: 1 })
+            .send();
         } catch (errors) {
           let jsonStr: string = JSON.stringify(errors);
           let jsonObj = JSON.parse(jsonStr);
-          let error_code = JSON.stringify(jsonObj?.errors?.[0]?.with?.int || jsonObj?.errors?.[1]?.with?.int);
+          let error_code = JSON.stringify(
+            jsonObj?.errors?.[0]?.with?.int || jsonObj?.errors?.[1]?.with?.int
+          );
           expect((error_code = '26'));
         }
 
@@ -330,7 +344,7 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
         const transfer_param: any = fa12_contract.methodsObject['transfer']({
           from_: bootstrap2_address,
           to_: bootstrap3_address,
-          value: 1
+          value: 1,
         }).toTransferParams().parameter?.value;
         const type = fa12_contract.entrypoints.entrypoints['transfer'];
         const TRANSFER_PARAM_PACKED = await Tezos.rpc.packData({
@@ -344,7 +358,11 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
         //Get Bootstrap2's public_key and capture it
         const PUB_KEY = await LocalTez2.signer.publicKey();
-        const SIGNATURE = await create_bytes_to_sign(LocalTez2, fa12_contract.address, TRANSFER_PARAM_HASHED)
+        const SIGNATURE = await create_bytes_to_sign(
+          LocalTez2,
+          fa12_contract.address,
+          TRANSFER_PARAM_HASHED
+        );
 
         //Anyone can submit permit start
         const signed_permit_contract = await LocalTez4.contract.at(fa12_contract.address);
@@ -362,7 +380,6 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
         await successful_transfer.confirmation();
         expect(successful_transfer.hash).toBeDefined();
         expect(successful_transfer.status).toEqual('applied');
-
       });
     });
   });

--- a/integration-tests/__tests__/contract/set-delegate-auto-estimate.spec.ts
+++ b/integration-tests/__tests__/contract/set-delegate-auto-estimate.spec.ts
@@ -1,33 +1,47 @@
-import { CONFIGS } from "../../config";
+import { CONFIGS, waitForRpcState } from '../../config';
 
 CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
   const Tezos = lib;
   describe(`Test account delegation with estimation through contract api using: ${rpc}`, () => {
-
     beforeAll(async () => {
-      await setup({ preferFreshKey: true, minBalanceMutez: 2_000_000 })
-    })
+      await setup({ preferFreshKey: true, minBalanceMutez: 2_000_000 });
+    });
     it('Verify that an account can be delegated to known baker with automatic estimate', async () => {
-      const delegate = knownBaker
+      const delegate = knownBaker;
       const pkh = await Tezos.signer.publicKeyHash();
+      const startingDelegate = await Tezos.rpc.getDelegate(pkh);
       try {
         const op = await Tezos.contract.setDelegate({
           delegate,
           source: pkh,
-        })
-        await op.confirmation()
+        });
+        await op.confirmation();
         expect(op.hash).toBeDefined();
-        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
-        const account = await Tezos.rpc.getDelegate(pkh)
-        expect(account).toEqual(delegate)
+        const account = await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getDelegate(pkh),
+          (currentDelegate) => currentDelegate === delegate,
+          { description: `delegate for ${pkh}` }
+        );
+        expect(account).toEqual(delegate);
       } catch (ex: any) {
-        if (await Tezos.rpc.getDelegate(pkh) === pkh) {
+        const currentDelegate = await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getDelegate(pkh),
+          () => true,
+          { timeoutMs: 2_000, description: `delegate state for ${pkh}` }
+        ).catch(() => null);
+
+        if (currentDelegate === pkh) {
           // Forbidden delegate deletion
-          expect(ex.message).toMatch('delegate.no_deletion')
-        } else {
+          expect(ex.message).toMatch('delegate.no_deletion');
+        } else if (startingDelegate === delegate || currentDelegate === delegate) {
           // When running tests more than one time with the same key, the account is already delegated to the given delegate
-          expect(ex.message).toMatch('delegate.unchanged')
+          expect(ex.message).toMatch('delegate.unchanged');
+        } else {
+          throw ex;
         }
       }
     });
@@ -37,21 +51,33 @@ CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
       try {
         const op = await Tezos.contract.setDelegate({
           source: pkh,
-        })
-        await op.confirmation()
+        });
+        await op.confirmation();
         expect(op.hash).toBeDefined();
-        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY)
+        expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
 
-        const account = await Tezos.rpc.getDelegate(pkh)
-        expect(account).toBe(null)
+        const account = await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getDelegate(pkh),
+          (currentDelegate) => currentDelegate === null,
+          { description: `delegate removal for ${pkh}` }
+        );
+        expect(account).toBe(null);
       } catch (ex: any) {
-        if (await Tezos.rpc.getDelegate(pkh) === pkh) {
+        const currentDelegate = await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getDelegate(pkh),
+          () => true,
+          { timeoutMs: 2_000, description: `delegate state for ${pkh}` }
+        ).catch(() => null);
+
+        if (currentDelegate === pkh) {
           // Forbidden delegate deletion when self is a registered delegate
-          expect(ex.message).toMatch('delegate.no_deletion')
+          expect(ex.message).toMatch('delegate.no_deletion');
         } else {
-          throw ex
+          throw ex;
         }
       }
     });
   });
-})
+});

--- a/integration-tests/__tests__/contract/tz2-operations-without-reveal-tests.spec.ts
+++ b/integration-tests/__tests__/contract/tz2-operations-without-reveal-tests.spec.ts
@@ -1,7 +1,7 @@
 import { CONFIGS, waitForRpcState } from '../../config';
 import { TezosToolkit } from '@taquito/taquito';
 import { PrefixV2 } from '@taquito/utils';
-import { UnitValue } from '@taquito/taquito';
+import { OpKind, UnitValue } from '@taquito/taquito';
 import crypto from 'crypto';
 import { PvmKind } from '@taquito/rpc';
 
@@ -177,12 +177,23 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
     it('verify that update_consensus_key fee and gas is sufficient', async () => {
       const consensusAcc = await createAddress(PrefixV2.Ed25519Seed);
       const consensusPk = await consensusAcc.signer.publicKey();
-      const estimated = await Tz2.estimate.updateConsensusKey({ pk: consensusPk });
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(287);
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(255);
-      expect(estimated?.storageLimit).toBe(0);
+      const source = await Tz2.signer.publicKeyHash();
+      const [delegationEstimate, updateEstimate] = await Tz2.estimate.batch([
+        { kind: OpKind.DELEGATION, source, delegate: source },
+        { kind: OpKind.UPDATE_CONSENSUS_KEY, pk: consensusPk },
+      ]);
+      expect(delegationEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(161);
+      expect(delegationEstimate?.gasLimit).toBeGreaterThanOrEqual(100);
+      expect(delegationEstimate?.storageLimit).toBe(0);
+      expect(updateEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(185);
+      expect(updateEstimate?.gasLimit).toBeGreaterThanOrEqual(200);
+      expect(updateEstimate?.storageLimit).toBe(0);
 
-      const updateConsensusKeyOp = await Tz2.contract.updateConsensusKey({ pk: consensusPk });
+      const updateConsensusKeyOp = await Tz2.contract
+        .batch()
+        .withDelegation({ source, delegate: source })
+        .withUpdateConsensusKey({ pk: consensusPk })
+        .send();
       await updateConsensusKeyOp.confirmation();
       expect(updateConsensusKeyOp.status).toBe('applied');
     });
@@ -190,19 +201,24 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
     it('verify that update_companion_key fee and gas is sufficient', async () => {
       const companionAcc = await createAddress(PrefixV2.BLS12_381SecretKey);
       const companionPk = await companionAcc.signer.publicKey();
+      const companionProof = (await companionAcc.signer.provePossession!()).prefixSig;
+      const source = await Tz2.signer.publicKeyHash();
+      const [delegationEstimate, updateEstimate] = await Tz2.estimate.batch([
+        { kind: OpKind.DELEGATION, source, delegate: source },
+        { kind: OpKind.UPDATE_COMPANION_KEY, pk: companionPk, proof: companionProof },
+      ]);
+      expect(delegationEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(161);
+      expect(delegationEstimate?.gasLimit).toBeGreaterThanOrEqual(100);
+      expect(delegationEstimate?.storageLimit).toBe(0);
+      expect(updateEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(458);
+      expect(updateEstimate?.gasLimit).toBeGreaterThanOrEqual(1772);
+      expect(updateEstimate?.storageLimit).toBe(0);
 
-      const estimated = await Tz2.estimate.updateCompanionKey({
-        pk: companionPk,
-        proof: (await companionAcc.signer.provePossession!()).prefixSig,
-      });
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(560);
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1831);
-      expect(estimated?.storageLimit).toBe(0);
-
-      const updateCompanionKeyOp = await Tz2.contract.updateCompanionKey({
-        pk: companionPk,
-        proof: (await companionAcc.signer.provePossession!()).prefixSig,
-      });
+      const updateCompanionKeyOp = await Tz2.contract
+        .batch()
+        .withDelegation({ source, delegate: source })
+        .withUpdateCompanionKey({ pk: companionPk, proof: companionProof })
+        .send();
       await updateCompanionKeyOp.confirmation();
       expect(updateCompanionKeyOp.status).toBe('applied');
     });

--- a/integration-tests/__tests__/contract/tz2-operations-without-reveal-tests.spec.ts
+++ b/integration-tests/__tests__/contract/tz2-operations-without-reveal-tests.spec.ts
@@ -1,173 +1,224 @@
-import { CONFIGS } from "../../config";
-import { TezosToolkit } from "@taquito/taquito";
-import { PrefixV2 } from "@taquito/utils";
-import { UnitValue } from "@taquito/taquito";
+import { CONFIGS, waitForRpcState } from '../../config';
+import { TezosToolkit } from '@taquito/taquito';
+import { PrefixV2 } from '@taquito/utils';
+import { UnitValue } from '@taquito/taquito';
 import crypto from 'crypto';
-import { PvmKind } from "@taquito/rpc";
+import { PvmKind } from '@taquito/rpc';
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketContract }) => {
   describe(`Test tz2 account operations through contract API using: ${rpc}`, () => {
     const Tezos = lib;
-    let contractAddress = ''
+    let contractAddress = '';
     let Tz2: TezosToolkit;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       await setup({
         preferFreshKey: true,
         minBalanceMutez: 9000000,
         maxAttempts: 8,
-      })
-      Tz2 = await createAddress(PrefixV2.Secp256k1SecretKey)
+      });
+      Tz2 = await createAddress(PrefixV2.Secp256k1SecretKey);
       try {
-        const fundOp = await Tezos.contract.transfer({ to: await Tz2.signer.publicKeyHash(), amount: 9 })
-        await fundOp.confirmation()
-        expect(fundOp.status).toBe('applied')
-        const revealOp = await Tz2.contract.reveal({})
-        await revealOp.confirmation()
-        expect(revealOp.status).toBe('applied')
+        const pkh = await Tz2.signer.publicKeyHash();
+        const fundOp = await Tezos.contract.transfer({ to: pkh, amount: 9 });
+        await fundOp.confirmation();
+        expect(fundOp.status).toBe('applied');
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getBalance(pkh),
+          (balance) => Number(balance.toString()) >= 9_000_000,
+          { description: `funding ${pkh}` }
+        );
+        const revealOp = await Tz2.contract.reveal({});
+        await revealOp.confirmation();
+        expect(revealOp.status).toBe('applied');
+        await waitForRpcState(
+          Tz2,
+          () => Tz2.rpc.getManagerKey(pkh),
+          (managerKey) => managerKey !== null,
+          { description: `reveal for ${pkh}` }
+        );
       } catch (e) {
-        console.log('beforeAll error', e)
+        console.log('beforeAll error', e);
         throw e;
       }
-    })
+    });
 
     it('verify that transfer to revealed account fee and gas is sufficient', async () => {
-      const estimated = await Tz2.estimate.transfer({ to: knownBaker, amount: 1 })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(466)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2155)
-      expect(estimated?.storageLimit).toBe(0)
-      const transferOp = await Tz2.contract.transfer({ to: knownBaker, amount: 1 })
-      await transferOp.confirmation()
-      expect(transferOp.status).toBe('applied')
-    })
+      const estimated = await Tz2.estimate.transfer({ to: knownBaker, amount: 1 });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(466);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2155);
+      expect(estimated?.storageLimit).toBe(0);
+      const transferOp = await Tz2.contract.transfer({ to: knownBaker, amount: 1 });
+      await transferOp.confirmation();
+      expect(transferOp.status).toBe('applied');
+    });
 
     it('verify that transfer to unrevealed account fee and gas is sufficient', async () => {
-      const unrevealedAcc = await createAddress(PrefixV2.P256SecretKey)
-      const unrevealedPkh = await unrevealedAcc.signer.publicKeyHash()
-      const estimated = await Tz2.estimate.transfer({ to: unrevealedPkh, amount: 1 })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(466)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2155)
-      expect(estimated?.storageLimit).toBe(277)
+      const unrevealedAcc = await createAddress(PrefixV2.P256SecretKey);
+      const unrevealedPkh = await unrevealedAcc.signer.publicKeyHash();
+      const estimated = await Tz2.estimate.transfer({ to: unrevealedPkh, amount: 1 });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(466);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2155);
+      expect(estimated?.storageLimit).toBe(277);
 
-      const transferOp = await Tz2.contract.transfer({ to: unrevealedPkh, amount: 1 })
-      await transferOp.confirmation()
-      expect(transferOp.status).toBe('applied')
-    })
+      const transferOp = await Tz2.contract.transfer({ to: unrevealedPkh, amount: 1 });
+      await transferOp.confirmation();
+      expect(transferOp.status).toBe('applied');
+    });
 
     it('verify that originate fee and gas is sufficient', async () => {
-      const estimated = await Tz2.estimate.originate({ code: "parameter unit; storage unit; code {CDR; NIL operation; PAIR};", storage: "unit" })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(334)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(664)
-      expect(estimated?.storageLimit).toBe(315)
+      const estimated = await Tz2.estimate.originate({
+        code: 'parameter unit; storage unit; code {CDR; NIL operation; PAIR};',
+        storage: 'unit',
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(334);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(664);
+      expect(estimated?.storageLimit).toBe(315);
 
-      const originateOp = await Tz2.contract.originate({ code: "parameter unit; storage unit; code {CDR; NIL operation; PAIR};", storage: "unit" })
-      await originateOp.confirmation()
-      contractAddress = originateOp.contractAddress!
-      expect(originateOp.status).toBe('applied')
-    })
+      const originateOp = await Tz2.contract.originate({
+        code: 'parameter unit; storage unit; code {CDR; NIL operation; PAIR};',
+        storage: 'unit',
+      });
+      await originateOp.confirmation();
+      contractAddress = originateOp.contractAddress!;
+      await waitForRpcState(
+        Tz2,
+        () => Tz2.rpc.getContract(contractAddress),
+        () => true,
+        { description: `contract ${contractAddress}` }
+      );
+      expect(originateOp.status).toBe('applied');
+    });
 
     it('verify that contractCall fee and gas is sufficient', async () => {
-      const contract = await Tz2.contract.at(contractAddress)
-      const method = contract.methodsObject.default(UnitValue)
-      const estimated = await Tz2.estimate.contractCall(method)
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(296)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(458)
-      expect(estimated?.storageLimit).toBe(0)
+      const contract = await Tz2.contract.at(contractAddress);
+      const method = contract.methodsObject.default(UnitValue);
+      const estimated = await Tz2.estimate.contractCall(method);
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(296);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(458);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const contractCallOp = await method.send()
-      await contractCallOp.confirmation()
-      expect(contractCallOp.status).toBe('applied')
-    })
+      const contractCallOp = await method.send();
+      await contractCallOp.confirmation();
+      expect(contractCallOp.status).toBe('applied');
+    });
 
     it('verify that setDelegate fee and gas is sufficient', async () => {
-      if (await Tz2.rpc.getDelegate(await Tz2.signer.publicKeyHash()) !== await Tz2.signer.publicKeyHash()) {
-        const estimated = await Tz2.estimate.setDelegate({ delegate: knownBaker, source: await Tz2.signer.publicKeyHash() })
-        expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(264)
-        expect(estimated?.gasLimit).toBeGreaterThanOrEqual(155)
-        expect(estimated?.storageLimit).toBe(0)
+      if (
+        (await Tz2.rpc.getDelegate(await Tz2.signer.publicKeyHash())) !==
+        (await Tz2.signer.publicKeyHash())
+      ) {
+        const estimated = await Tz2.estimate.setDelegate({
+          delegate: knownBaker,
+          source: await Tz2.signer.publicKeyHash(),
+        });
+        expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(264);
+        expect(estimated?.gasLimit).toBeGreaterThanOrEqual(155);
+        expect(estimated?.storageLimit).toBe(0);
 
-        const setDelegateOp = await Tz2.contract.setDelegate({ delegate: knownBaker, source: await Tz2.signer.publicKeyHash() })
-        await setDelegateOp.confirmation()
-        expect(setDelegateOp.status).toBe('applied')
+        const setDelegateOp = await Tz2.contract.setDelegate({
+          delegate: knownBaker,
+          source: await Tz2.signer.publicKeyHash(),
+        });
+        await setDelegateOp.confirmation();
+        expect(setDelegateOp.status).toBe('applied');
       }
-    })
+    });
 
     it('verify that registerDelegate fee and gas is sufficient', async () => {
-      const estimated = await Tz2.estimate.registerDelegate({})
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(264)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(155)
-      expect(estimated?.storageLimit).toBe(0)
+      const estimated = await Tz2.estimate.registerDelegate({});
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(264);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(155);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const registerDelegateOp = await Tz2.contract.registerDelegate({})
-      await registerDelegateOp.confirmation()
-      expect(registerDelegateOp.status).toBe('applied')
-    })
+      const registerDelegateOp = await Tz2.contract.registerDelegate({});
+      await registerDelegateOp.confirmation();
+      expect(registerDelegateOp.status).toBe('applied');
+    });
 
     it('verify that increase_paid_storage fee and gas is sufficient', async () => {
-      const estimated = await Tz2.estimate.increasePaidStorage({ amount: 3, destination: contractAddress })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(265)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(155)
-      expect(estimated?.storageLimit).toBe(0)
+      const estimated = await Tz2.estimate.increasePaidStorage({
+        amount: 3,
+        destination: contractAddress,
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(265);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(155);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const increasePaidStorageOp = await Tz2.contract.increasePaidStorage({ amount: 3, destination: contractAddress })
-      await increasePaidStorageOp.confirmation()
-      expect(increasePaidStorageOp.status).toBe('applied')
-    })
+      const increasePaidStorageOp = await Tz2.contract.increasePaidStorage({
+        amount: 3,
+        destination: contractAddress,
+      });
+      await increasePaidStorageOp.confirmation();
+      expect(increasePaidStorageOp.status).toBe('applied');
+    });
 
     it('verify that register_global_constant fee and gas is sufficient', async () => {
       const randomAnnots = () => crypto.randomBytes(3).toString('hex');
       const code = {
         prim: 'list',
         args: [{ prim: 'nat' }],
-        annots: [`%${randomAnnots()}`]
-      }
+        annots: [`%${randomAnnots()}`],
+      };
 
-      const estimated = await Tz2.estimate.registerGlobalConstant({ value: code })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(294)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(488)
-      expect(estimated?.storageLimit).toBe(100)
-
+      const estimated = await Tz2.estimate.registerGlobalConstant({ value: code });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(294);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(488);
+      expect(estimated?.storageLimit).toBe(100);
 
       const registerGlobalConstantOp = await Tz2.contract.registerGlobalConstant({
         value: code,
-      })
-      await registerGlobalConstantOp.confirmation()
-      expect(registerGlobalConstantOp.status).toBe('applied')
-    })
+      });
+      await registerGlobalConstantOp.confirmation();
+      expect(registerGlobalConstantOp.status).toBe('applied');
+    });
 
     it('verify that update_consensus_key fee and gas is sufficient', async () => {
-      const consensusAcc = await createAddress(PrefixV2.Ed25519Seed)
-      const consensusPk = await consensusAcc.signer.publicKey()
-      const estimated = await Tz2.estimate.updateConsensusKey({ pk: consensusPk })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(287)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(255)
-      expect(estimated?.storageLimit).toBe(0)
+      const consensusAcc = await createAddress(PrefixV2.Ed25519Seed);
+      const consensusPk = await consensusAcc.signer.publicKey();
+      const estimated = await Tz2.estimate.updateConsensusKey({ pk: consensusPk });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(287);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(255);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const updateConsensusKeyOp = await Tz2.contract.updateConsensusKey({ pk: consensusPk })
-      await updateConsensusKeyOp.confirmation()
-      expect(updateConsensusKeyOp.status).toBe('applied')
-    })
+      const updateConsensusKeyOp = await Tz2.contract.updateConsensusKey({ pk: consensusPk });
+      await updateConsensusKeyOp.confirmation();
+      expect(updateConsensusKeyOp.status).toBe('applied');
+    });
 
     it('verify that update_companion_key fee and gas is sufficient', async () => {
-      const companionAcc = await createAddress(PrefixV2.BLS12_381SecretKey)
-      const companionPk = await companionAcc.signer.publicKey()
+      const companionAcc = await createAddress(PrefixV2.BLS12_381SecretKey);
+      const companionPk = await companionAcc.signer.publicKey();
 
-      const estimated = await Tz2.estimate.updateCompanionKey({ pk: companionPk, proof: (await companionAcc.signer.provePossession!()).prefixSig })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(560)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1831)
-      expect(estimated?.storageLimit).toBe(0)
+      const estimated = await Tz2.estimate.updateCompanionKey({
+        pk: companionPk,
+        proof: (await companionAcc.signer.provePossession!()).prefixSig,
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(560);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1831);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const updateCompanionKeyOp = await Tz2.contract.updateCompanionKey({ pk: companionPk, proof: (await companionAcc.signer.provePossession!()).prefixSig })
-      await updateCompanionKeyOp.confirmation()
-      expect(updateCompanionKeyOp.status).toBe('applied')
-    })
+      const updateCompanionKeyOp = await Tz2.contract.updateCompanionKey({
+        pk: companionPk,
+        proof: (await companionAcc.signer.provePossession!()).prefixSig,
+      });
+      await updateCompanionKeyOp.confirmation();
+      expect(updateCompanionKeyOp.status).toBe('applied');
+    });
 
     it('verify that transferTicket fee and gas is sufficient', async () => {
       // prerequisite: issuing tickets
-      const ticketContract = await Tz2.contract.at(knownTicketContract)
-      const ticket = { ticketer: knownTicketContract, content_type: { prim: 'string' }, content: { string: 'Ticket' } };
-      const issueOp = await ticketContract.methodsObject.default([await Tz2.signer.publicKeyHash(), '3']).send()
-      await issueOp.confirmation()
+      const ticketContract = await Tz2.contract.at(knownTicketContract);
+      const ticket = {
+        ticketer: knownTicketContract,
+        content_type: { prim: 'string' },
+        content: { string: 'Ticket' },
+      };
+      const issueOp = await ticketContract.methodsObject
+        .default([await Tz2.signer.publicKeyHash(), '3'])
+        .send();
+      await issueOp.confirmation();
 
       const estimated = await Tz2.estimate.transferTicket({
         ticketContents: ticket.content,
@@ -176,9 +227,9 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
         ticketAmount: 1,
         destination: knownBaker,
         entrypoint: 'default',
-      })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(463)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1381)
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(463);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1381);
 
       const transferTicketOp = await Tz2.contract.transferTicket({
         ticketContents: ticket.content,
@@ -187,46 +238,49 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
         ticketAmount: 1,
         destination: knownBaker,
         entrypoint: 'default',
-      })
-      await transferTicketOp.confirmation()
-      expect(transferTicketOp.status).toBe('applied')
-    })
+      });
+      await transferTicketOp.confirmation();
+      expect(transferTicketOp.status).toBe('applied');
+    });
 
     it('verify that smart_rollup_originate fee and gas is sufficient', async () => {
-      const kernel = '23212f7573722f62696e2f656e762073680a6578706f7274204b45524e454c3d22303036313733366430313030303030303031323830373630303337663766376630313766363030323766376630313766363030353766376637663766376630313766363030313766303036303031376630313766363030323766376630303630303030303032363130333131373336643631373237343566373236663663366337353730356636333666373236353061373236353631363435663639366537303735373430303030313137333664363137323734356637323666366336633735373035663633366637323635306337373732363937343635356636663735373437303735373430303031313137333664363137323734356637323666366336633735373035663633366637323635306237333734366637323635356637373732363937343635303030323033303530343033303430353036303530333031303030313037313430323033366436353664303230303061366236353732366536353663356637323735366530303036306161343031303432613031303237663431666130303266303130303231303132303030326630313030323130323230303132303032343730343430343165343030343131323431303034316534303034313030313030323161306230623038303032303030343163343030366230623530303130353766343166653030326430303030323130333431666330303266303130303231303232303030326430303030323130343230303032663031303032313035323030313130303432313036323030343230303334363034343032303030343130313661323030313431303136623130303131613035323030353230303234363034343032303030343130373661323030363130303131613062306230623164303130313766343164633031343138343032343139303163313030303231303034313834303232303030313030353431383430323130303330623062333830353030343165343030306231323266366236353732366536353663326636353665373632663732363536323666366637343030343166383030306230323030303130303431666130303062303230303032303034316663303030623032303030303030343166653030306230313031220a'
-      const parametersType = { prim: 'bytes' }
+      const kernel =
+        '23212f7573722f62696e2f656e762073680a6578706f7274204b45524e454c3d22303036313733366430313030303030303031323830373630303337663766376630313766363030323766376630313766363030353766376637663766376630313766363030313766303036303031376630313766363030323766376630303630303030303032363130333131373336643631373237343566373236663663366337353730356636333666373236353061373236353631363435663639366537303735373430303030313137333664363137323734356637323666366336633735373035663633366637323635306337373732363937343635356636663735373437303735373430303031313137333664363137323734356637323666366336633735373035663633366637323635306237333734366637323635356637373732363937343635303030323033303530343033303430353036303530333031303030313037313430323033366436353664303230303061366236353732366536353663356637323735366530303036306161343031303432613031303237663431666130303266303130303231303132303030326630313030323130323230303132303032343730343430343165343030343131323431303034316534303034313030313030323161306230623038303032303030343163343030366230623530303130353766343166653030326430303030323130333431666330303266303130303231303232303030326430303030323130343230303032663031303032313035323030313130303432313036323030343230303334363034343032303030343130313661323030313431303136623130303131613035323030353230303234363034343032303030343130373661323030363130303131613062306230623164303130313766343164633031343138343032343139303163313030303231303034313834303232303030313030353431383430323130303330623062333830353030343165343030306231323266366236353732366536353663326636353665373632663732363536323666366637343030343166383030306230323030303130303431666130303062303230303032303034316663303030623032303030303030343166653030306230313031220a';
+      const parametersType = { prim: 'bytes' };
       const estimated = await Tz2.estimate.smartRollupOriginate({
         pvmKind: PvmKind.WASM2,
         kernel,
         parametersType,
-      })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(1295)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2048)
-      expect(estimated?.storageLimit).toBe(6572)
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(1295);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2048);
+      expect(estimated?.storageLimit).toBe(6572);
 
       const smartRollupOriginateOp = await Tz2.contract.smartRollupOriginate({
         pvmKind: PvmKind.WASM2,
         kernel,
         parametersType,
-      })
-      await smartRollupOriginateOp.confirmation()
-      expect(smartRollupOriginateOp.status).toBe('applied')
-    })
+      });
+      await smartRollupOriginateOp.confirmation();
+      expect(smartRollupOriginateOp.status).toBe('applied');
+    });
 
     it('verify that smart_rollup_add_messages fee and gas is sufficient', async () => {
-      const message = ['0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74']
+      const message = [
+        '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
+      ];
       const estimated = await Tz2.estimate.smartRollupAddMessages({
         message,
-      })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(314)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(259)
-      expect(estimated?.storageLimit).toBe(0)
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(314);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(259);
+      expect(estimated?.storageLimit).toBe(0);
 
       const smartRollupAddMessagesOp = await Tz2.contract.smartRollupAddMessages({
         message,
-      })
-      await smartRollupAddMessagesOp.confirmation()
-      expect(smartRollupAddMessagesOp.status).toBe('applied')
-    })
+      });
+      await smartRollupAddMessagesOp.confirmation();
+      expect(smartRollupAddMessagesOp.status).toBe('applied');
+    });
   });
-})
+});

--- a/integration-tests/__tests__/contract/tz4-operations-without-reveal-tests.spec.ts
+++ b/integration-tests/__tests__/contract/tz4-operations-without-reveal-tests.spec.ts
@@ -1,171 +1,218 @@
-import { CONFIGS } from "../../config";
-import { PrefixV2 } from "@taquito/utils";
-import { TezosToolkit, UnitValue } from "@taquito/taquito";
+import { CONFIGS, waitForRpcState } from '../../config';
+import { PrefixV2 } from '@taquito/utils';
+import { TezosToolkit, UnitValue } from '@taquito/taquito';
 import crypto from 'crypto';
-import { PvmKind } from "@taquito/rpc";
+import { PvmKind } from '@taquito/rpc';
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketContract }) => {
-
   describe(`Test tz4 account operations through contract API using: ${rpc}`, () => {
     const Tezos = lib;
     let Tz4: TezosToolkit;
-    let contractAddress = ''
-    beforeAll(async () => {
+    let contractAddress = '';
+    beforeEach(async () => {
       await setup({
         preferFreshKey: true,
         minBalanceMutez: 9000000,
         maxAttempts: 8,
-      })
-      Tz4 = await createAddress(PrefixV2.BLS12_381SecretKey)
+      });
+      Tz4 = await createAddress(PrefixV2.BLS12_381SecretKey);
       try {
-        const fundOp = await Tezos.contract.transfer({ to: await Tz4.signer.publicKeyHash(), amount: 9 })
-        await fundOp.confirmation()
-        expect(fundOp.status).toBe('applied')
-        const revealOp = await Tz4.contract.reveal({})
-        await revealOp.confirmation()
-        expect(revealOp.status).toBe('applied')
+        const pkh = await Tz4.signer.publicKeyHash();
+        const fundOp = await Tezos.contract.transfer({ to: pkh, amount: 9 });
+        await fundOp.confirmation();
+        expect(fundOp.status).toBe('applied');
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getBalance(pkh),
+          (balance) => Number(balance.toString()) >= 9_000_000,
+          { description: `funding ${pkh}` }
+        );
+        const revealOp = await Tz4.contract.reveal({});
+        await revealOp.confirmation();
+        expect(revealOp.status).toBe('applied');
+        await waitForRpcState(
+          Tz4,
+          () => Tz4.rpc.getManagerKey(pkh),
+          (managerKey) => managerKey !== null,
+          { description: `reveal for ${pkh}` }
+        );
       } catch (e) {
-        console.log('beforeAll error', e)
-        throw e
+        console.log('beforeAll error', e);
+        throw e;
       }
-    })
+    });
 
     it('verify that transfer to revealed account fee and gas is sufficient', async () => {
-      const estimated = await Tz4.estimate.transfer({ to: knownBaker, amount: 1 })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(654)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3674)
-      expect(estimated?.storageLimit).toBe(0)
-      const transferOp = await Tz4.contract.transfer({ to: knownBaker, amount: 1 })
-      await transferOp.confirmation()
-      expect(transferOp.status).toBe('applied')
-    })
+      const estimated = await Tz4.estimate.transfer({ to: knownBaker, amount: 1 });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(654);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3674);
+      expect(estimated?.storageLimit).toBe(0);
+      const transferOp = await Tz4.contract.transfer({ to: knownBaker, amount: 1 });
+      await transferOp.confirmation();
+      expect(transferOp.status).toBe('applied');
+    });
 
     it('verify that transfer to unrevealed account fee and gas is sufficient', async () => {
-      const unrevealedAcc = await createAddress(PrefixV2.P256SecretKey)
-      const unrevealedPkh = await unrevealedAcc.signer.publicKeyHash()
-      const estimated = await Tz4.estimate.transfer({ to: unrevealedPkh, amount: 1 })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(655)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3674)
-      expect(estimated?.storageLimit).toBe(277)
+      const unrevealedAcc = await createAddress(PrefixV2.P256SecretKey);
+      const unrevealedPkh = await unrevealedAcc.signer.publicKeyHash();
+      const estimated = await Tz4.estimate.transfer({ to: unrevealedPkh, amount: 1 });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(655);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3674);
+      expect(estimated?.storageLimit).toBe(277);
 
-      const transferOp = await Tz4.contract.transfer({ to: unrevealedPkh, amount: 1 })
-      await transferOp.confirmation()
-      expect(transferOp.status).toBe('applied')
-    })
+      const transferOp = await Tz4.contract.transfer({ to: unrevealedPkh, amount: 1 });
+      await transferOp.confirmation();
+      expect(transferOp.status).toBe('applied');
+    });
 
     it('verify that originate fee and gas is sufficient', async () => {
-      const estimated = await Tz4.estimate.originate({ code: "parameter unit; storage unit; code {CDR; NIL operation; PAIR};", storage: "unit" })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(520)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2183)
-      expect(estimated?.storageLimit).toBe(315)
+      const estimated = await Tz4.estimate.originate({
+        code: 'parameter unit; storage unit; code {CDR; NIL operation; PAIR};',
+        storage: 'unit',
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(520);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2183);
+      expect(estimated?.storageLimit).toBe(315);
 
-      const originateOp = await Tz4.contract.originate({ code: "parameter unit; storage unit; code {CDR; NIL operation; PAIR};", storage: "unit" })
-      await originateOp.confirmation()
-      contractAddress = originateOp.contractAddress!
-      expect(originateOp.status).toBe('applied')
-    })
+      const originateOp = await Tz4.contract.originate({
+        code: 'parameter unit; storage unit; code {CDR; NIL operation; PAIR};',
+        storage: 'unit',
+      });
+      await originateOp.confirmation();
+      contractAddress = originateOp.contractAddress!;
+      await waitForRpcState(
+        Tz4,
+        () => Tz4.rpc.getContract(contractAddress),
+        () => true,
+        { description: `contract ${contractAddress}` }
+      );
+      expect(originateOp.status).toBe('applied');
+    });
 
     it('verify that contractCall fee and gas is sufficient', async () => {
-      const contract = await Tz4.contract.at(contractAddress)
-      const method = contract.methodsObject.default(UnitValue)
-      const estimated = await Tz4.estimate.contractCall(method)
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(482)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1977)
-      expect(estimated?.storageLimit).toBe(0)
+      const contract = await Tz4.contract.at(contractAddress);
+      const method = contract.methodsObject.default(UnitValue);
+      const estimated = await Tz4.estimate.contractCall(method);
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(482);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1977);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const contractCallOp = await method.send()
-      await contractCallOp.confirmation()
-      expect(contractCallOp.status).toBe('applied')
-    })
+      const contractCallOp = await method.send();
+      await contractCallOp.confirmation();
+      expect(contractCallOp.status).toBe('applied');
+    });
 
     it('verify that setDelegate fee and gas is sufficient', async () => {
-      const estimated = await Tz4.estimate.setDelegate({ delegate: knownBaker, source: await Tz4.signer.publicKeyHash() })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(450)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1673)
-      expect(estimated?.storageLimit).toBe(0)
+      const estimated = await Tz4.estimate.setDelegate({
+        delegate: knownBaker,
+        source: await Tz4.signer.publicKeyHash(),
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(450);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1673);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const setDelegateOp = await Tz4.contract.setDelegate({ delegate: knownBaker, source: await Tz4.signer.publicKeyHash() })
-      await setDelegateOp.confirmation()
-      expect(setDelegateOp.status).toBe('applied')
-    })
+      const setDelegateOp = await Tz4.contract.setDelegate({
+        delegate: knownBaker,
+        source: await Tz4.signer.publicKeyHash(),
+      });
+      await setDelegateOp.confirmation();
+      expect(setDelegateOp.status).toBe('applied');
+    });
 
     it('verify that registerDelegate fee and gas is sufficient', async () => {
-      const estimated = await Tz4.estimate.registerDelegate({})
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(450)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1673)
-      expect(estimated?.storageLimit).toBe(0)
+      const estimated = await Tz4.estimate.registerDelegate({});
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(450);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1673);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const registerDelegateOp = await Tz4.contract.registerDelegate({})
-      await registerDelegateOp.confirmation()
-      expect(registerDelegateOp.status).toBe('applied')
-    })
+      const registerDelegateOp = await Tz4.contract.registerDelegate({});
+      await registerDelegateOp.confirmation();
+      expect(registerDelegateOp.status).toBe('applied');
+    });
 
     it('verify that increase_paid_storage fee and gas is sufficient', async () => {
-      const estimated = await Tz4.estimate.increasePaidStorage({ amount: 3, destination: contractAddress })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(451)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1674)
-      expect(estimated?.storageLimit).toBe(0)
+      const estimated = await Tz4.estimate.increasePaidStorage({
+        amount: 3,
+        destination: contractAddress,
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(451);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1674);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const increasePaidStorageOp = await Tz4.contract.increasePaidStorage({ amount: 3, destination: contractAddress })
-      await increasePaidStorageOp.confirmation()
-      expect(increasePaidStorageOp.status).toBe('applied')
-    })
+      const increasePaidStorageOp = await Tz4.contract.increasePaidStorage({
+        amount: 3,
+        destination: contractAddress,
+      });
+      await increasePaidStorageOp.confirmation();
+      expect(increasePaidStorageOp.status).toBe('applied');
+    });
 
     it('verify that register_global_constant fee and gas is sufficient', async () => {
       const randomAnnots = () => crypto.randomBytes(3).toString('hex');
       const code = {
         prim: 'list',
         args: [{ prim: 'nat' }],
-        annots: [`%${randomAnnots()}`]
-      }
+        annots: [`%${randomAnnots()}`],
+      };
 
-      const estimated = await Tz4.estimate.registerGlobalConstant({ value: code })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(480)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2006)
-      expect(estimated?.storageLimit).toBe(100)
-
+      const estimated = await Tz4.estimate.registerGlobalConstant({ value: code });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(480);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(2006);
+      expect(estimated?.storageLimit).toBe(100);
 
       const registerGlobalConstantOp = await Tz4.contract.registerGlobalConstant({
         value: code,
-      })
-      await registerGlobalConstantOp.confirmation()
-      expect(registerGlobalConstantOp.status).toBe('applied')
-    })
+      });
+      await registerGlobalConstantOp.confirmation();
+      expect(registerGlobalConstantOp.status).toBe('applied');
+    });
 
     it('verify that update_consensus_key fee and gas is sufficient', async () => {
-      const consensusAcc = await createAddress(PrefixV2.BLS12_381SecretKey)
-      const consensusPk = await consensusAcc.signer.publicKey()
-      let proof = (await consensusAcc.signer.provePossession!()).prefixSig
-      const estimated = await Tz4.estimate.updateConsensusKey({ pk: consensusPk, proof })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(745)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3350)
-      expect(estimated?.storageLimit).toBe(0)
+      const consensusAcc = await createAddress(PrefixV2.BLS12_381SecretKey);
+      const consensusPk = await consensusAcc.signer.publicKey();
+      let proof = (await consensusAcc.signer.provePossession!()).prefixSig;
+      const estimated = await Tz4.estimate.updateConsensusKey({ pk: consensusPk, proof });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(745);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3350);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const updateConsensusKeyOp = await Tz4.contract.updateConsensusKey({ pk: consensusPk, proof })
-      await updateConsensusKeyOp.confirmation()
-      expect(updateConsensusKeyOp.status).toBe('applied')
-    })
+      const updateConsensusKeyOp = await Tz4.contract.updateConsensusKey({
+        pk: consensusPk,
+        proof,
+      });
+      await updateConsensusKeyOp.confirmation();
+      expect(updateConsensusKeyOp.status).toBe('applied');
+    });
 
     it('verify that update_companion_key fee and gas is sufficient', async () => {
-      const companionAcc = await createAddress(PrefixV2.BLS12_381SecretKey)
-      const companionPk = await companionAcc.signer.publicKey()
-      let proof = (await companionAcc.signer.provePossession!()).prefixSig
-      const estimated = await Tz4.estimate.updateCompanionKey({ pk: companionPk, proof })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(745)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3350)
-      expect(estimated?.storageLimit).toBe(0)
+      const companionAcc = await createAddress(PrefixV2.BLS12_381SecretKey);
+      const companionPk = await companionAcc.signer.publicKey();
+      let proof = (await companionAcc.signer.provePossession!()).prefixSig;
+      const estimated = await Tz4.estimate.updateCompanionKey({ pk: companionPk, proof });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(745);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3350);
+      expect(estimated?.storageLimit).toBe(0);
 
-      const updateCompanionKeyOp = await Tz4.contract.updateCompanionKey({ pk: companionPk, proof })
-      await updateCompanionKeyOp.confirmation()
-      expect(updateCompanionKeyOp.status).toBe('applied')
-    })
+      const updateCompanionKeyOp = await Tz4.contract.updateCompanionKey({
+        pk: companionPk,
+        proof,
+      });
+      await updateCompanionKeyOp.confirmation();
+      expect(updateCompanionKeyOp.status).toBe('applied');
+    });
 
     it('verify that transferTicket fee and gas is sufficient', async () => {
       // prerequisite: issuing tickets
-      const ticketContract = await Tz4.contract.at(knownTicketContract)
-      const ticket = { ticketer: knownTicketContract, content_type: { prim: 'string' }, content: { string: 'Ticket' } };
-      const issueOp = await ticketContract.methodsObject.default([await Tz4.signer.publicKeyHash(), '3']).send()
-      await issueOp.confirmation()
+      const ticketContract = await Tz4.contract.at(knownTicketContract);
+      const ticket = {
+        ticketer: knownTicketContract,
+        content_type: { prim: 'string' },
+        content: { string: 'Ticket' },
+      };
+      const issueOp = await ticketContract.methodsObject
+        .default([await Tz4.signer.publicKeyHash(), '3'])
+        .send();
+      await issueOp.confirmation();
 
       const estimated = await Tz4.estimate.transferTicket({
         ticketContents: ticket.content,
@@ -174,9 +221,9 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
         ticketAmount: 1,
         destination: knownBaker,
         entrypoint: 'default',
-      })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(647)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3120)
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(647);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3120);
 
       const transferTicketOp = await Tz4.contract.transferTicket({
         ticketContents: ticket.content,
@@ -185,46 +232,49 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
         ticketAmount: 1,
         destination: knownBaker,
         entrypoint: 'default',
-      })
-      await transferTicketOp.confirmation()
-      expect(transferTicketOp.status).toBe('applied')
-    })
+      });
+      await transferTicketOp.confirmation();
+      expect(transferTicketOp.status).toBe('applied');
+    });
 
     it('verify that smart_rollup_originate fee and gas is sufficient', async () => {
-      const kernel = '23212f7573722f62696e2f656e762073680a6578706f7274204b45524e454c3d22303036313733366430313030303030303031323830373630303337663766376630313766363030323766376630313766363030353766376637663766376630313766363030313766303036303031376630313766363030323766376630303630303030303032363130333131373336643631373237343566373236663663366337353730356636333666373236353061373236353631363435663639366537303735373430303030313137333664363137323734356637323666366336633735373035663633366637323635306337373732363937343635356636663735373437303735373430303031313137333664363137323734356637323666366336633735373035663633366637323635306237333734366637323635356637373732363937343635303030323033303530343033303430353036303530333031303030313037313430323033366436353664303230303061366236353732366536353663356637323735366530303036306161343031303432613031303237663431666130303266303130303231303132303030326630313030323130323230303132303032343730343430343165343030343131323431303034316534303034313030313030323161306230623038303032303030343163343030366230623530303130353766343166653030326430303030323130333431666330303266303130303231303232303030326430303030323130343230303032663031303032313035323030313130303432313036323030343230303334363034343032303030343130313661323030313431303136623130303131613035323030353230303234363034343032303030343130373661323030363130303131613062306230623164303130313766343164633031343138343032343139303163313030303231303034313834303232303030313030353431383430323130303330623062333830353030343165343030306231323266366236353732366536353663326636353665373632663732363536323666366637343030343166383030306230323030303130303431666130303062303230303032303034316663303030623032303030303030343166653030306230313031220a'
-      const parametersType = { prim: 'bytes' }
+      const kernel =
+        '23212f7573722f62696e2f656e762073680a6578706f7274204b45524e454c3d22303036313733366430313030303030303031323830373630303337663766376630313766363030323766376630313766363030353766376637663766376630313766363030313766303036303031376630313766363030323766376630303630303030303032363130333131373336643631373237343566373236663663366337353730356636333666373236353061373236353631363435663639366537303735373430303030313137333664363137323734356637323666366336633735373035663633366637323635306337373732363937343635356636663735373437303735373430303031313137333664363137323734356637323666366336633735373035663633366637323635306237333734366637323635356637373732363937343635303030323033303530343033303430353036303530333031303030313037313430323033366436353664303230303061366236353732366536353663356637323735366530303036306161343031303432613031303237663431666130303266303130303231303132303030326630313030323130323230303132303032343730343430343165343030343131323431303034316534303034313030313030323161306230623038303032303030343163343030366230623530303130353766343166653030326430303030323130333431666330303266303130303231303232303030326430303030323130343230303032663031303032313035323030313130303432313036323030343230303334363034343032303030343130313661323030313431303136623130303131613035323030353230303234363034343032303030343130373661323030363130303131613062306230623164303130313766343164633031343138343032343139303163313030303231303034313834303232303030313030353431383430323130303330623062333830353030343165343030306231323266366236353732366536353663326636353665373632663732363536323666366637343030343166383030306230323030303130303431666130303062303230303032303034316663303030623032303030303030343166653030306230313031220a';
+      const parametersType = { prim: 'bytes' };
       const estimated = await Tz4.estimate.smartRollupOriginate({
         pvmKind: PvmKind.WASM2,
         kernel,
         parametersType,
-      })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(1481)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3568)
-      expect(estimated?.storageLimit).toBe(6572)
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(1481);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3568);
+      expect(estimated?.storageLimit).toBe(6572);
 
       const smartRollupOriginateOp = await Tz4.contract.smartRollupOriginate({
         pvmKind: PvmKind.WASM2,
         kernel,
         parametersType,
-      })
-      await smartRollupOriginateOp.confirmation()
-      expect(smartRollupOriginateOp.status).toBe('applied')
-    })
+      });
+      await smartRollupOriginateOp.confirmation();
+      expect(smartRollupOriginateOp.status).toBe('applied');
+    });
 
     it('verify that smart_rollup_add_messages fee and gas is sufficient', async () => {
-      const message = ['0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74']
+      const message = [
+        '0000000031010000000b48656c6c6f20776f726c6401bdb6f61e4f12c952f807ae7d3341af5367887dac000000000764656661756c74',
+      ];
       const estimated = await Tz4.estimate.smartRollupAddMessages({
         message,
-      })
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(500)
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1777)
-      expect(estimated?.storageLimit).toBe(0)
+      });
+      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(500);
+      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(1777);
+      expect(estimated?.storageLimit).toBe(0);
 
       const smartRollupAddMessagesOp = await Tz4.contract.smartRollupAddMessages({
         message,
-      })
-      await smartRollupAddMessagesOp.confirmation()
-      expect(smartRollupAddMessagesOp.status).toBe('applied')
-    })
+      });
+      await smartRollupAddMessagesOp.confirmation();
+      expect(smartRollupAddMessagesOp.status).toBe('applied');
+    });
   });
-})
+});

--- a/integration-tests/__tests__/contract/tz4-operations-without-reveal-tests.spec.ts
+++ b/integration-tests/__tests__/contract/tz4-operations-without-reveal-tests.spec.ts
@@ -1,6 +1,6 @@
 import { CONFIGS, waitForRpcState } from '../../config';
 import { PrefixV2 } from '@taquito/utils';
-import { TezosToolkit, UnitValue } from '@taquito/taquito';
+import { OpKind, TezosToolkit, UnitValue } from '@taquito/taquito';
 import crypto from 'crypto';
 import { PvmKind } from '@taquito/rpc';
 
@@ -170,16 +170,24 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
     it('verify that update_consensus_key fee and gas is sufficient', async () => {
       const consensusAcc = await createAddress(PrefixV2.BLS12_381SecretKey);
       const consensusPk = await consensusAcc.signer.publicKey();
-      let proof = (await consensusAcc.signer.provePossession!()).prefixSig;
-      const estimated = await Tz4.estimate.updateConsensusKey({ pk: consensusPk, proof });
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(745);
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3350);
-      expect(estimated?.storageLimit).toBe(0);
+      const proof = (await consensusAcc.signer.provePossession!()).prefixSig;
+      const source = await Tz4.signer.publicKeyHash();
+      const [delegationEstimate, updateEstimate] = await Tz4.estimate.batch([
+        { kind: OpKind.DELEGATION, source, delegate: source },
+        { kind: OpKind.UPDATE_CONSENSUS_KEY, pk: consensusPk, proof },
+      ]);
+      expect(delegationEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(161);
+      expect(delegationEstimate?.gasLimit).toBeGreaterThanOrEqual(100);
+      expect(delegationEstimate?.storageLimit).toBe(0);
+      expect(updateEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(458);
+      expect(updateEstimate?.gasLimit).toBeGreaterThanOrEqual(1772);
+      expect(updateEstimate?.storageLimit).toBe(0);
 
-      const updateConsensusKeyOp = await Tz4.contract.updateConsensusKey({
-        pk: consensusPk,
-        proof,
-      });
+      const updateConsensusKeyOp = await Tz4.contract
+        .batch()
+        .withDelegation({ source, delegate: source })
+        .withUpdateConsensusKey({ pk: consensusPk, proof })
+        .send();
       await updateConsensusKeyOp.confirmation();
       expect(updateConsensusKeyOp.status).toBe('applied');
     });
@@ -187,16 +195,24 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownBaker, knownTicketCont
     it('verify that update_companion_key fee and gas is sufficient', async () => {
       const companionAcc = await createAddress(PrefixV2.BLS12_381SecretKey);
       const companionPk = await companionAcc.signer.publicKey();
-      let proof = (await companionAcc.signer.provePossession!()).prefixSig;
-      const estimated = await Tz4.estimate.updateCompanionKey({ pk: companionPk, proof });
-      expect(estimated?.suggestedFeeMutez).toBeGreaterThanOrEqual(745);
-      expect(estimated?.gasLimit).toBeGreaterThanOrEqual(3350);
-      expect(estimated?.storageLimit).toBe(0);
+      const proof = (await companionAcc.signer.provePossession!()).prefixSig;
+      const source = await Tz4.signer.publicKeyHash();
+      const [delegationEstimate, updateEstimate] = await Tz4.estimate.batch([
+        { kind: OpKind.DELEGATION, source, delegate: source },
+        { kind: OpKind.UPDATE_COMPANION_KEY, pk: companionPk, proof },
+      ]);
+      expect(delegationEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(161);
+      expect(delegationEstimate?.gasLimit).toBeGreaterThanOrEqual(100);
+      expect(delegationEstimate?.storageLimit).toBe(0);
+      expect(updateEstimate?.suggestedFeeMutez).toBeGreaterThanOrEqual(458);
+      expect(updateEstimate?.gasLimit).toBeGreaterThanOrEqual(1772);
+      expect(updateEstimate?.storageLimit).toBe(0);
 
-      const updateCompanionKeyOp = await Tz4.contract.updateCompanionKey({
-        pk: companionPk,
-        proof,
-      });
+      const updateCompanionKeyOp = await Tz4.contract
+        .batch()
+        .withDelegation({ source, delegate: source })
+        .withUpdateCompanionKey({ pk: companionPk, proof })
+        .send();
       await updateCompanionKeyOp.confirmation();
       expect(updateCompanionKeyOp.status).toBe('applied');
     });

--- a/integration-tests/__tests__/polling-subscribe-provider.spec.ts
+++ b/integration-tests/__tests__/polling-subscribe-provider.spec.ts
@@ -1,4 +1,4 @@
-import { CONFIGS, TAQUITO_MUTEZ, sleep } from '../config';
+import { CONFIGS, TAQUITO_MUTEZ, sleep, waitForRpcState } from '../config';
 import { PollingSubscribeProvider, TezosToolkit } from '@taquito/taquito';
 import { rethrowInfrastructureRpcError } from '../test-helpers/rpc-error-assertions';
 
@@ -111,8 +111,18 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
 
       secondUser = await createAddress();
       const secondUserAddress = await secondUser.signer.publicKeyHash();
-      const transfer = await Tezos.contract.transfer({ to: secondUserAddress, amount: TAQUITO_MUTEZ, mutez: true });
+      const transfer = await Tezos.contract.transfer({
+        to: secondUserAddress,
+        amount: TAQUITO_MUTEZ,
+        mutez: true,
+      });
       await transfer.confirmation();
+      await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getBalance(secondUserAddress),
+        (balance) => Number(balance.toString()) >= TAQUITO_MUTEZ,
+        { description: `funding ${secondUserAddress}` }
+      );
 
       Tezos.setStreamProvider(
         Tezos.getFactory(PollingSubscribeProvider)({
@@ -128,6 +138,12 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
         });
         await calledContract.confirmation();
         calledContractAddress = calledContract.contractAddress!;
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getContract(calledContractAddress),
+          () => true,
+          { description: `called contract ${calledContractAddress}` }
+        );
 
         let mainContract = await Tezos.contract.originate({
           code: mainContractMichelson,
@@ -135,6 +151,12 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
         });
         await mainContract.confirmation();
         mainContractAddress = mainContract.contractAddress!;
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getContract(mainContractAddress),
+          () => true,
+          { description: `main contract ${mainContractAddress}` }
+        );
       } catch (e) {
         console.log(e);
         throw e;
@@ -204,7 +226,6 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
       expect(data[0].type).toBeDefined();
       expect(data[0].payload).toBeDefined();
       expect(data[0].result).toBeDefined();
-
     });
 
     it.skip('should include events from failed operations when filter does not exclude events from failed operations', async () => {

--- a/integration-tests/__tests__/tzip-metadata/tzip12-token-metadata.spec.ts
+++ b/integration-tests/__tests__/tzip-metadata/tzip12-token-metadata.spec.ts
@@ -1,4 +1,4 @@
-import { CONFIGS } from '../../config';
+import { CONFIGS, waitForRpcState } from '../../config';
 import { compose, MichelsonMap, ViewSimulationError } from '@taquito/taquito';
 import { tzip16, Tzip16Module } from '@taquito/tzip16';
 import { stringToBytes } from '@taquito/utils';
@@ -10,281 +10,294 @@ import { fa2TokenFactory } from '../../data/fa2-token-factory';
 import { fa2ForTokenMetadataView } from '../../data/fa2-for-token-metadata-view';
 
 CONFIGS().forEach(({ lib, rpc, setup, createAddress }) => {
-	const Tezos = lib;
-	let contractAddress: string;
-	let contractAddress2: string;
+  const Tezos = lib;
+  let contractAddress: string;
+  let contractAddress2: string;
 
-	describe(`Test contract origination for a Fa2 contract and fetch metadata (token metadata are in the big map %token_metadata) through contract api using: ${rpc}`, () => {
-			beforeAll(async () => {
-				await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
-			});
+  describe(`Test contract origination for a Fa2 contract and fetch metadata (token metadata are in the big map %token_metadata) through contract api using: ${rpc}`, () => {
+    beforeAll(async () => {
+      await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
+    });
 
-		it('Verify contract.originate for a Fa2 contract having metadata on HTTPS and token metadata inside a bigmap %token_metadata', async () => {
-			const LocalTez1 = await createAddress();
-			const localTez1Pkh = await LocalTez1.signer.publicKeyHash();
-			const LocalTez2 = await createAddress();
-			const localTez2Pkh = await LocalTez2.signer.publicKeyHash();
+    it('Verify contract.originate for a Fa2 contract having metadata on HTTPS and token metadata inside a bigmap %token_metadata', async () => {
+      const LocalTez1 = await createAddress();
+      const localTez1Pkh = await LocalTez1.signer.publicKeyHash();
+      const LocalTez2 = await createAddress();
+      const localTez2Pkh = await LocalTez2.signer.publicKeyHash();
 
-			const ledger = new MichelsonMap();
-			ledger.set(
-				{
-					owner: localTez1Pkh,
-					token_id: 1
-				},
-				'18000000'
-			);
-			ledger.set(
-				{
-					owner: localTez2Pkh,
-					token_id: 2
-				},
-				'9990000'
-			);
+      const ledger = new MichelsonMap();
+      ledger.set(
+        {
+          owner: localTez1Pkh,
+          token_id: 1,
+        },
+        '18000000'
+      );
+      ledger.set(
+        {
+          owner: localTez2Pkh,
+          token_id: 2,
+        },
+        '9990000'
+      );
 
-			const url = 'https://storage.googleapis.com/tzip-16/fa2-token-factory.json';
-			const bytesUrl = stringToBytes(url);
-			const metadata = new MichelsonMap();
-			metadata.set('', bytesUrl);
+      const url = 'https://storage.googleapis.com/tzip-16/fa2-token-factory.json';
+      const bytesUrl = stringToBytes(url);
+      const metadata = new MichelsonMap();
+      metadata.set('', bytesUrl);
 
-			const operators = new MichelsonMap();
+      const operators = new MichelsonMap();
 
-			const token_admins = new MichelsonMap();
-			token_admins.set('1', {
-				0: localTez1Pkh,
-				1: true
-			});
-			token_admins.set('2', {
-				0: localTez2Pkh,
-				1: true
-			});
+      const token_admins = new MichelsonMap();
+      token_admins.set('1', {
+        0: localTez1Pkh,
+        1: true,
+      });
+      token_admins.set('2', {
+        0: localTez2Pkh,
+        1: true,
+      });
 
-			const token_metadata = new MichelsonMap();
-			const token1 = new MichelsonMap();
-			token1.set('name', stringToBytes('wToken'));
-			token1.set('symbol', stringToBytes('wTK'));
-			token1.set('decimals', '36');
-			const token2 = new MichelsonMap();
-			token2.set('name', stringToBytes('AliceToken'));
-			token2.set('symbol', stringToBytes('ALC'));
-			token2.set('decimals', '30');
-			token_metadata.set('1', {
-				token_id: '1',
-				token_info: token1
-			});
-			token_metadata.set('2', {
-				token_id: '2',
-				token_info: token2
-			});
+      const token_metadata = new MichelsonMap();
+      const token1 = new MichelsonMap();
+      token1.set('name', stringToBytes('wToken'));
+      token1.set('symbol', stringToBytes('wTK'));
+      token1.set('decimals', '36');
+      const token2 = new MichelsonMap();
+      token2.set('name', stringToBytes('AliceToken'));
+      token2.set('symbol', stringToBytes('ALC'));
+      token2.set('decimals', '30');
+      token_metadata.set('1', {
+        token_id: '1',
+        token_info: token1,
+      });
+      token_metadata.set('2', {
+        token_id: '2',
+        token_info: token2,
+      });
 
-			const token_total_supply = new MichelsonMap();
-			token_total_supply.set('1', '54000000');
-			token_total_supply.set('2', '10000000');
+      const token_total_supply = new MichelsonMap();
+      token_total_supply.set('1', '54000000');
+      token_total_supply.set('2', '10000000');
 
-			const op = await Tezos.contract.originate({
-				code: fa2TokenFactory,
-				storage: {
-					admin: await Tezos.signer.publicKeyHash(),
-					exchange_address: 'KT1DGRPQUwLJyCZnM8WKtwDGiKDSMv4hftk4',
-					last_token_id: '2',
-					ledger,
-					metadata,
-					operators,
-					token_admins,
-					token_metadata,
-					token_total_supply
-				}
-			});
-			await op.confirmation();
+      const op = await Tezos.contract.originate({
+        code: fa2TokenFactory,
+        storage: {
+          admin: await Tezos.signer.publicKeyHash(),
+          exchange_address: 'KT1DGRPQUwLJyCZnM8WKtwDGiKDSMv4hftk4',
+          last_token_id: '2',
+          ledger,
+          metadata,
+          operators,
+          token_admins,
+          token_metadata,
+          token_total_supply,
+        },
+      });
+      await op.confirmation();
 
-			// Set the variables for the following tests
-			contractAddress = (await op.contract()).address;
+      // Set the variables for the following tests
+      contractAddress = (await op.contract()).address;
+      await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getStorage(contractAddress),
+        () => true,
+        { description: `fa2 bigmap contract ${contractAddress}` }
+      );
 
-			expect(op.hash).toBeDefined();
-			expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-		});
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+    });
 
-		it('Verify contractAbstraction composition, fetch contract and token metadata of the a Fa2 contract having metadata on HTTPS and token metadata inside a bigmap %token_metadata', async () => {
+    it('Verify contractAbstraction composition, fetch contract and token metadata of the a Fa2 contract having metadata on HTTPS and token metadata inside a bigmap %token_metadata', async () => {
+      Tezos.addExtension(new Tzip12Module());
+      // Tezos.addExtension(new Tzip16Module())... one extension is sufficient as they use the same MetadataProvider
 
-			Tezos.addExtension(new Tzip12Module());
-			// Tezos.addExtension(new Tzip16Module())... one extension is sufficient as they use the same MetadataProvider
+      // Use the compose function
+      const contract = await Tezos.contract.at(contractAddress, compose(tzip16, tzip12));
 
-			// Use the compose function
-			const contract = await Tezos.contract.at(contractAddress, compose(tzip16, tzip12));
+      // Fetch contract metadata on HTTPs
+      const metadata = await contract.tzip16().getMetadata();
+      expect(metadata.uri).toEqual('https://storage.googleapis.com/tzip-16/fa2-token-factory.json');
+      expect(metadata.integrityCheckResult).toBeUndefined();
+      expect(metadata.sha256Hash).toBeUndefined();
+      expect(metadata.metadata).toEqual({
+        name: 'Test Taquito FA2 token Factory',
+        description:
+          'This is a test to retrieve tokens metadata when they are located in the storage of the contract in the big map %token_metadata',
+        source: {
+          tools: ['FA2 Token Factory'],
+          location: 'https://www.github.com/claudebarde',
+        },
+        interfaces: ['TZIP-012'],
+        license: {
+          name: 'MIT',
+        },
+      });
 
-			// Fetch contract metadata on HTTPs
-			const metadata = await contract.tzip16().getMetadata();
-			expect(metadata.uri).toEqual('https://storage.googleapis.com/tzip-16/fa2-token-factory.json');
-			expect(metadata.integrityCheckResult).toBeUndefined();
-			expect(metadata.sha256Hash).toBeUndefined();
-			expect(metadata.metadata).toEqual({
-				name: 'Test Taquito FA2 token Factory',
-				description:
-					'This is a test to retrieve tokens metadata when they are located in the storage of the contract in the big map %token_metadata',
-				source: {
-					tools: ['FA2 Token Factory'],
-					location: 'https://www.github.com/claudebarde'
-				},
-				interfaces: ['TZIP-012'],
-				license: {
-					name: 'MIT'
-				}
-			});
+      // Verify if the tag TZIP-012 is present in the interface field of contract metadata
+      const isTzip12Contract = await contract.tzip12().isTzip12Compliant();
+      expect(isTzip12Contract).toEqual(true);
 
-			// Verify if the tag TZIP-012 is present in the interface field of contract metadata
-			const isTzip12Contract = await contract.tzip12().isTzip12Compliant();
-			expect(isTzip12Contract).toEqual(true);
+      // Fetch token metadata
+      const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigNumber(1));
+      expect(tokenMetadata1).toEqual({
+        token_id: BigNumber(1),
+        decimals: 6,
+        name: 'wToken',
+        symbol: 'wTK',
+      });
 
-			// Fetch token metadata
-			const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigNumber(1));
-			expect(tokenMetadata1).toEqual({
-				token_id: BigNumber(1),
-				decimals: 6,
-				name: 'wToken',
-				symbol: 'wTK'
-			});
+      const tokenMetadata2 = await contract.tzip12().getTokenMetadata(BigNumber(2));
+      expect(tokenMetadata2).toEqual({
+        token_id: BigNumber(2),
+        name: 'AliceToken',
+        decimals: 0,
+        symbol: 'ALC',
+      });
 
-			const tokenMetadata2 = await contract.tzip12().getTokenMetadata(BigNumber(2));
-			expect(tokenMetadata2).toEqual({
-				token_id: BigNumber(2),
-				name: 'AliceToken',
-				decimals: 0,
-				symbol: 'ALC'
-			});
+      try {
+        await contract.tzip12().getTokenMetadata(BigNumber(3));
+      } catch (err) {
+        expect(err).toBeInstanceOf(TokenIdNotFound);
+      }
+    });
+  });
 
-			try {
-				await contract.tzip12().getTokenMetadata(BigNumber(3));
-			} catch (err) {
-				expect(err).toBeInstanceOf(TokenIdNotFound);
-			}
-		});
-	});
+  describe(`Test originating a Fa2 contract and fetch metadata (token metadata are obtained from a view %token_metadata) through contract api using: ${rpc}`, () => {
+    beforeAll(async () => {
+      await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
+    });
 
-		describe(`Test originating a Fa2 contract and fetch metadata (token metadata are obtained from a view %token_metadata) through contract api using: ${rpc}`, () => {
-			beforeAll(async () => {
-				await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
-			});
+    it('Verify contract.originate for a Fa2 contract having metadata on HTTPS and a view %token_metadata', async () => {
+      const LocalTez1 = await createAddress();
+      const localTez1Pkh = await LocalTez1.signer.publicKeyHash();
+      const LocalTez2 = await createAddress();
+      const localTez2Pkh = await LocalTez2.signer.publicKeyHash();
 
-		it('Verify contract.originate for a Fa2 contract having metadata on HTTPS and a view %token_metadata', async () => {
-			const LocalTez1 = await createAddress();
-			const localTez1Pkh = await LocalTez1.signer.publicKeyHash();
-			const LocalTez2 = await createAddress();
-			const localTez2Pkh = await LocalTez2.signer.publicKeyHash();
+      const ledger = new MichelsonMap();
+      ledger.set(
+        {
+          0: localTez1Pkh,
+          1: 0,
+        },
+        '20000'
+      );
+      ledger.set(
+        {
+          0: localTez2Pkh,
+          1: 1,
+        },
+        '20000'
+      );
 
-			const ledger = new MichelsonMap();
-			ledger.set(
-				{
-					0: localTez1Pkh,
-					1: 0
-				},
-				'20000'
-			);
-			ledger.set(
-				{
-					0: localTez2Pkh,
-					1: 1
-				},
-				'20000'
-			);
+      const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
+      const bytesUrl = stringToBytes(url);
+      const metadata = new MichelsonMap();
+      metadata.set('', bytesUrl);
 
-			const url = 'https://storage.googleapis.com/tzip-16/fa2-views.json';
-			const bytesUrl = stringToBytes(url);
-			const metadata = new MichelsonMap();
-			metadata.set('', bytesUrl);
+      const operators = new MichelsonMap();
 
-			const operators = new MichelsonMap();
+      const tokens = new MichelsonMap();
+      const metadataMap0 = new MichelsonMap();
+      metadataMap0.set(
+        '',
+        stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json')
+      );
+      metadataMap0.set('name', stringToBytes('Name from URI is prioritized!'));
+      const metadataMap1 = new MichelsonMap();
+      metadataMap1.set('name', stringToBytes('AliceToken'));
+      metadataMap1.set('symbol', stringToBytes('ALC'));
+      metadataMap1.set('decimals', '30');
+      metadataMap1.set('extra', stringToBytes('Add more data'));
+      const metadataMap2 = new MichelsonMap();
+      metadataMap2.set('name', stringToBytes('Invalid token metadata'));
+      tokens.set('0', {
+        metadata_map: metadataMap0,
+        total_supply: '20000',
+      });
+      tokens.set('1', {
+        metadata_map: metadataMap1,
+        total_supply: '20000',
+      });
+      tokens.set('2', {
+        metadata_map: metadataMap2,
+        total_supply: '20000',
+      });
 
-			const tokens = new MichelsonMap();
-			const metadataMap0 = new MichelsonMap();
-			metadataMap0.set('', stringToBytes('https://storage.googleapis.com/tzip-16/token-metadata.json'));
-			metadataMap0.set('name', stringToBytes('Name from URI is prioritized!'));
-			const metadataMap1 = new MichelsonMap();
-			metadataMap1.set('name', stringToBytes('AliceToken'));
-			metadataMap1.set('symbol', stringToBytes('ALC'));
-			metadataMap1.set('decimals', '30');
-			metadataMap1.set('extra', stringToBytes('Add more data'));
-			const metadataMap2 = new MichelsonMap();
-			metadataMap2.set('name', stringToBytes('Invalid token metadata'));
-			tokens.set('0', {
-				metadata_map: metadataMap0,
-				total_supply: '20000'
-			});
-			tokens.set('1', {
-				metadata_map: metadataMap1,
-				total_supply: '20000'
-			});
-			tokens.set('2', {
-				metadata_map: metadataMap2,
-				total_supply: '20000'
-			});
+      const op = await Tezos.contract.originate({
+        code: fa2ForTokenMetadataView,
+        storage: {
+          administrator: await Tezos.signer.publicKeyHash(),
+          all_tokens: '2',
+          ledger,
+          metadata,
+          operators,
+          paused: false,
+          tokens,
+        },
+      });
+      await op.confirmation();
 
+      // Set the variables for the following tests
+      contractAddress2 = (await op.contract()).address;
+      await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getStorage(contractAddress2),
+        () => true,
+        { description: `fa2 metadata-view contract ${contractAddress2}` }
+      );
 
-			const op = await Tezos.contract.originate({
-				code: fa2ForTokenMetadataView,
-				storage: {
-					administrator: await Tezos.signer.publicKeyHash(),
-					all_tokens: '2',
-					ledger,
-					metadata,
-					operators,
-					paused: false,
-					tokens
-				}
-			});
-			await op.confirmation();
+      expect(op.hash).toBeDefined();
+      expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
+    });
 
-			// Set the variables for the following tests
-			contractAddress2 = (await op.contract()).address;
+    it('Verify contractAbstraction composition, fetch contract and token metadata of the Fa2 contract having metadata on HTTPS and a view %token_metadata', async () => {
+      Tezos.addExtension(new Tzip16Module());
 
-			expect(op.hash).toBeDefined();
-			expect(op.includedInBlock).toBeLessThan(Number.POSITIVE_INFINITY);
-		});
+      // Use the compose function
+      const contract = await Tezos.contract.at(contractAddress2, compose(tzip16, tzip12));
 
-		it('Verify contractAbstraction composition, fetch contract and token metadata of the Fa2 contract having metadata on HTTPS and a view %token_metadata', async () => {
-			Tezos.addExtension(new Tzip16Module());
+      // Fetch contract metadata on HTTPs
+      const metadata = await contract.tzip16().getMetadata();
+      expect(metadata.uri).toEqual('https://storage.googleapis.com/tzip-16/fa2-views.json');
+      expect(metadata.integrityCheckResult).toBeUndefined();
+      expect(metadata.sha256Hash).toBeUndefined();
+      expect(metadata.metadata).toBeDefined();
 
-			// Use the compose function
-			const contract = await Tezos.contract.at(contractAddress2, compose(tzip16, tzip12));
+      // Verify if the tag TZIP-012 is present in the interface field of contract metadata
+      const isTzip12Contract = await contract.tzip12().isTzip12Compliant();
+      expect(isTzip12Contract).toEqual(true);
 
-			// Fetch contract metadata on HTTPs
-			const metadata = await contract.tzip16().getMetadata();
-			expect(metadata.uri).toEqual('https://storage.googleapis.com/tzip-16/fa2-views.json');
-			expect(metadata.integrityCheckResult).toBeUndefined();
-			expect(metadata.sha256Hash).toBeUndefined();
-			expect(metadata.metadata).toBeDefined();
+      // Fetch token metadata (view result contains a URI for this token)
+      const tokenMetadata0 = await contract.tzip12().getTokenMetadata(BigNumber(0));
+      expect(tokenMetadata0).toEqual({
+        token_id: BigNumber(0),
+        decimals: 3,
+        name: 'Taquito test URI',
+        symbol: 'XTZ2',
+      });
 
-			// Verify if the tag TZIP-012 is present in the interface field of contract metadata
-			const isTzip12Contract = await contract.tzip12().isTzip12Compliant();
-			expect(isTzip12Contract).toEqual(true);
+      const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigNumber(1));
+      expect(tokenMetadata1).toEqual({
+        token_id: BigNumber(1),
+        name: 'AliceToken',
+        decimals: 0,
+        symbol: 'ALC',
+        extra: 'Add more data',
+      });
 
-			// Fetch token metadata (view result contains a URI for this token)
-			const tokenMetadata0 = await contract.tzip12().getTokenMetadata(BigNumber(0));
-			expect(tokenMetadata0).toEqual({
-				token_id: BigNumber(0),
-				decimals: 3,
-				name: 'Taquito test URI',
-				symbol: 'XTZ2'
-			});
+      try {
+        await contract.tzip12().getTokenMetadata(BigNumber(2));
+      } catch (err) {
+        expect(err).toBeInstanceOf(InvalidTokenMetadata);
+      }
 
-			const tokenMetadata1 = await contract.tzip12().getTokenMetadata(BigNumber(1));
-			expect(tokenMetadata1).toEqual({
-				token_id: BigNumber(1),
-				name: 'AliceToken',
-				decimals: 0,
-				symbol: 'ALC',
-				extra: 'Add more data'
-			});
-
-			try {
-				await contract.tzip12().getTokenMetadata(BigNumber(2));
-			} catch (err) {
-				expect(err).toBeInstanceOf(InvalidTokenMetadata);
-			}
-
-			try {
-				await contract.tzip12().getTokenMetadata(BigNumber(3));
-			} catch (err) {
-				expect(err).toBeInstanceOf(ViewSimulationError);
-			}
-		});
-	});
+      try {
+        await contract.tzip12().getTokenMetadata(BigNumber(3));
+      } catch (err) {
+        expect(err).toBeInstanceOf(ViewSimulationError);
+      }
+    });
+  });
 });

--- a/integration-tests/__tests__/tzip-metadata/tzip16-originate-contracts-with-metadata-on-HTTPS-and-sha256-hash-and-fetch-metadata.spec.ts
+++ b/integration-tests/__tests__/tzip-metadata/tzip16-originate-contracts-with-metadata-on-HTTPS-and-sha256-hash-and-fetch-metadata.spec.ts
@@ -1,152 +1,178 @@
-import { CONFIGS } from "../../config";
+import { CONFIGS, waitForRpcState } from '../../config';
 import { tzip16, Tzip16Module } from '@taquito/tzip16';
 import { stringToBytes } from '@taquito/utils';
-import { tacoContractTzip16 } from "../../data/modified-taco-contract"
-import { MichelsonMap } from "@taquito/taquito";
+import { tacoContractTzip16 } from '../../data/modified-taco-contract';
+import { MichelsonMap } from '@taquito/taquito';
 
 CONFIGS().forEach(({ lib, rpc, setup }) => {
-    const Tezos = lib;
-    Tezos.addExtension(new Tzip16Module());
+  const Tezos = lib;
+  Tezos.addExtension(new Tzip16Module());
 
-    const originateContractWithShaUri = async (metadataSha256: string) => {
-        const urlPercentEncoded = encodeURIComponent('//storage.googleapis.com/tzip-16/taco-shop-metadata.json');
-        const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
+  const originateContractWithShaUri = async (metadataSha256: string) => {
+    const urlPercentEncoded = encodeURIComponent(
+      '//storage.googleapis.com/tzip-16/taco-shop-metadata.json'
+    );
+    const url = 'sha256://' + metadataSha256 + '/https:' + urlPercentEncoded;
 
-        const op = await Tezos.contract.originate({
-            code: tacoContractTzip16,
-            storage: {
-                metadata: MichelsonMap.fromLiteral({ "": stringToBytes(url) }),
-                taco_shop_storage: MichelsonMap.fromLiteral({ "1": { current_stock: "10000", max_price: "50" } })
-            },
-        });
-        await op.confirmation();
-
-        return op.contract();
-    };
-
-    describe(`Test contract origination having a sha256 hash in URI through contract api using: ${rpc}`, () => {
-        beforeAll(async () => {
-            await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 })
-        })
-
-        describe('valid sha256 URI', () => {
-            let contractAddress: string;
-
-            beforeAll(async () => {
-                contractAddress = (await originateContractWithShaUri(
-                    '0x18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d'
-                )).address;
-            });
-
-            it('Verify contract.originate for a contract having a sha256 hash in URI', async () => {
-                expect(contractAddress).toBeDefined();
-            });
-
-            it('Verify that the metadata for the contract having a sha256 hash in URI can be fetched', async () => {
-                const contract = await Tezos.contract.at(contractAddress, tzip16);
-                const metadata = await contract.tzip16().getMetadata();
-
-                expect(metadata.uri).toEqual('sha256://0x18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d/https:%2F%2Fstorage.googleapis.com%2Ftzip-16%2Ftaco-shop-metadata.json');
-                expect(metadata.integrityCheckResult).toEqual(true);
-                expect(metadata.sha256Hash).toEqual('18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d');
-                expect(metadata.metadata).toEqual({
-                    "name": "Taquito test with valid metadata",
-                    "description": "This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage",
-                    "version": "7.1.0-beta.0",
-                    "license": {
-                        "name": "MIT",
-                        "details": "The MIT License"
-                    },
-                    "homepage": "https://github.com/ecadlabs/taquito",
-                    "source": {
-                        "tools": [
-                            "Ligo",
-                            "https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A"
-                        ],
-                        "location": "https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout"
-                    }
-                });
-
-                expect(await (await contract.tzip16()).metadataName()).toEqual('Taquito test with valid metadata')
-                expect(await (await contract.tzip16()).metadataDescription()).toEqual('This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage')
-                expect(await (await contract.tzip16()).metadataVersion()).toEqual('7.1.0-beta.0')
-                expect(await (await contract.tzip16()).metadataLicense()).toEqual({
-                    "name": "MIT",
-                    "details": "The MIT License"
-                })
-                expect(await (await contract.tzip16()).metadataAuthors()).toBeUndefined()
-                expect(await (await contract.tzip16()).metadataHomepage()).toEqual('https://github.com/ecadlabs/taquito')
-                expect(await (await contract.tzip16()).metadataSource()).toEqual({
-                    "tools": [
-                        "Ligo",
-                        "https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A"
-                    ],
-                    "location": "https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout"
-                })
-                expect(await (await contract.tzip16()).metadataInterfaces()).toBeUndefined()
-                expect(await (await contract.tzip16()).metadataErrors()).toBeUndefined()
-                expect(await (await contract.tzip16()).metadataViews()).toEqual({});
-            });
-        });
-
-        describe('invalid sha256 URI', () => {
-            let contractAddressInvalidHash: string;
-
-            beforeAll(async () => {
-                contractAddressInvalidHash = (await originateContractWithShaUri(
-                    '0x7e99ecf3a4491e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b'
-                )).address;
-            });
-
-            it('Verify contract.originate for a contract having an invalid sha256 hash in URI', async () => {
-                expect(contractAddressInvalidHash).toBeDefined();
-            });
-
-            it('Verify that the metadata for the contract having an invalid sha256 hash in URI can be fetched', async () => {
-                const contract = await Tezos.contract.at(contractAddressInvalidHash, tzip16);
-                const metadata = await contract.tzip16().getMetadata();
-
-                expect(metadata.uri).toEqual('sha256://0x7e99ecf3a4491e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b/https:%2F%2Fstorage.googleapis.com%2Ftzip-16%2Ftaco-shop-metadata.json');
-                expect(metadata.integrityCheckResult).toEqual(false);
-                expect(metadata.sha256Hash).toEqual('18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d');
-                expect(metadata.metadata).toEqual({
-                    "name": "Taquito test with valid metadata",
-                    "description": "This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage",
-                    "version": "7.1.0-beta.0",
-                    "license": {
-                        "name": "MIT",
-                        "details": "The MIT License"
-                    },
-                    "homepage": "https://github.com/ecadlabs/taquito",
-                    "source": {
-                        "tools": [
-                            "Ligo",
-                            "https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A"
-                        ],
-                        "location": "https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout"
-                    }
-                });
-
-                expect(await (await contract.tzip16()).metadataName()).toEqual('Taquito test with valid metadata')
-                expect(await (await contract.tzip16()).metadataDescription()).toEqual('This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage')
-                expect(await (await contract.tzip16()).metadataVersion()).toEqual('7.1.0-beta.0')
-                expect(await (await contract.tzip16()).metadataLicense()).toEqual({
-                    "name": "MIT",
-                    "details": "The MIT License"
-                })
-                expect(await (await contract.tzip16()).metadataAuthors()).toBeUndefined()
-                expect(await (await contract.tzip16()).metadataHomepage()).toEqual('https://github.com/ecadlabs/taquito')
-                expect(await (await contract.tzip16()).metadataSource()).toEqual({
-                    "tools": [
-                        "Ligo",
-                        "https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A"
-                    ],
-                    "location": "https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout"
-                })
-                expect(await (await contract.tzip16()).metadataInterfaces()).toBeUndefined()
-                expect(await (await contract.tzip16()).metadataErrors()).toBeUndefined()
-                expect(await (await contract.tzip16()).metadataViews()).toEqual({});
-            });
-        });
+    const op = await Tezos.contract.originate({
+      code: tacoContractTzip16,
+      storage: {
+        metadata: MichelsonMap.fromLiteral({ '': stringToBytes(url) }),
+        taco_shop_storage: MichelsonMap.fromLiteral({
+          '1': { current_stock: '10000', max_price: '50' },
+        }),
+      },
     });
-})
+    await op.confirmation();
+
+    const contract = await op.contract();
+    await waitForRpcState(
+      Tezos,
+      () => Tezos.rpc.getStorage(contract.address),
+      () => true,
+      { description: `metadata contract ${contract.address}` }
+    );
+
+    return contract;
+  };
+
+  describe(`Test contract origination having a sha256 hash in URI through contract api using: ${rpc}`, () => {
+    beforeAll(async () => {
+      await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
+    });
+
+    describe('valid sha256 URI', () => {
+      let contractAddress: string;
+
+      beforeAll(async () => {
+        contractAddress = (
+          await originateContractWithShaUri(
+            '0x18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d'
+          )
+        ).address;
+      });
+
+      it('Verify contract.originate for a contract having a sha256 hash in URI', async () => {
+        expect(contractAddress).toBeDefined();
+      });
+
+      it('Verify that the metadata for the contract having a sha256 hash in URI can be fetched', async () => {
+        const contract = await Tezos.contract.at(contractAddress, tzip16);
+        const metadata = await contract.tzip16().getMetadata();
+
+        expect(metadata.uri).toEqual(
+          'sha256://0x18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d/https:%2F%2Fstorage.googleapis.com%2Ftzip-16%2Ftaco-shop-metadata.json'
+        );
+        expect(metadata.integrityCheckResult).toEqual(true);
+        expect(metadata.sha256Hash).toEqual(
+          '18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d'
+        );
+        expect(metadata.metadata).toEqual({
+          name: 'Taquito test with valid metadata',
+          description:
+            'This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage',
+          version: '7.1.0-beta.0',
+          license: {
+            name: 'MIT',
+            details: 'The MIT License',
+          },
+          homepage: 'https://github.com/ecadlabs/taquito',
+          source: {
+            tools: ['Ligo', 'https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A'],
+            location: 'https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout',
+          },
+        });
+
+        expect(await (await contract.tzip16()).metadataName()).toEqual(
+          'Taquito test with valid metadata'
+        );
+        expect(await (await contract.tzip16()).metadataDescription()).toEqual(
+          'This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage'
+        );
+        expect(await (await contract.tzip16()).metadataVersion()).toEqual('7.1.0-beta.0');
+        expect(await (await contract.tzip16()).metadataLicense()).toEqual({
+          name: 'MIT',
+          details: 'The MIT License',
+        });
+        expect(await (await contract.tzip16()).metadataAuthors()).toBeUndefined();
+        expect(await (await contract.tzip16()).metadataHomepage()).toEqual(
+          'https://github.com/ecadlabs/taquito'
+        );
+        expect(await (await contract.tzip16()).metadataSource()).toEqual({
+          tools: ['Ligo', 'https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A'],
+          location: 'https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout',
+        });
+        expect(await (await contract.tzip16()).metadataInterfaces()).toBeUndefined();
+        expect(await (await contract.tzip16()).metadataErrors()).toBeUndefined();
+        expect(await (await contract.tzip16()).metadataViews()).toEqual({});
+      });
+    });
+
+    describe('invalid sha256 URI', () => {
+      let contractAddressInvalidHash: string;
+
+      beforeAll(async () => {
+        contractAddressInvalidHash = (
+          await originateContractWithShaUri(
+            '0x7e99ecf3a4491e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b'
+          )
+        ).address;
+      });
+
+      it('Verify contract.originate for a contract having an invalid sha256 hash in URI', async () => {
+        expect(contractAddressInvalidHash).toBeDefined();
+      });
+
+      it('Verify that the metadata for the contract having an invalid sha256 hash in URI can be fetched', async () => {
+        const contract = await Tezos.contract.at(contractAddressInvalidHash, tzip16);
+        const metadata = await contract.tzip16().getMetadata();
+
+        expect(metadata.uri).toEqual(
+          'sha256://0x7e99ecf3a4491e3044ccdf319898d77380a2fc20aae36b6e40327d678399d17b/https:%2F%2Fstorage.googleapis.com%2Ftzip-16%2Ftaco-shop-metadata.json'
+        );
+        expect(metadata.integrityCheckResult).toEqual(false);
+        expect(metadata.sha256Hash).toEqual(
+          '18b983a4cc78d7c15d53f7642461176c1366fbdb83960ea432188130db1f8c9d'
+        );
+        expect(metadata.metadata).toEqual({
+          name: 'Taquito test with valid metadata',
+          description:
+            'This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage',
+          version: '7.1.0-beta.0',
+          license: {
+            name: 'MIT',
+            details: 'The MIT License',
+          },
+          homepage: 'https://github.com/ecadlabs/taquito',
+          source: {
+            tools: ['Ligo', 'https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A'],
+            location: 'https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout',
+          },
+        });
+
+        expect(await (await contract.tzip16()).metadataName()).toEqual(
+          'Taquito test with valid metadata'
+        );
+        expect(await (await contract.tzip16()).metadataDescription()).toEqual(
+          'This is metadata test for Taquito integration tests with the Ligo Taco shop contract modified to include metadata in storage'
+        );
+        expect(await (await contract.tzip16()).metadataVersion()).toEqual('7.1.0-beta.0');
+        expect(await (await contract.tzip16()).metadataLicense()).toEqual({
+          name: 'MIT',
+          details: 'The MIT License',
+        });
+        expect(await (await contract.tzip16()).metadataAuthors()).toBeUndefined();
+        expect(await (await contract.tzip16()).metadataHomepage()).toEqual(
+          'https://github.com/ecadlabs/taquito'
+        );
+        expect(await (await contract.tzip16()).metadataSource()).toEqual({
+          tools: ['Ligo', 'https://ide.ligolang.org/p/-uS469slzUlSm1zwNqHl1A'],
+          location: 'https://ligolang.org/docs/tutorials/get-started/tezos-taco-shop-payout',
+        });
+        expect(await (await contract.tzip16()).metadataInterfaces()).toBeUndefined();
+        expect(await (await contract.tzip16()).metadataErrors()).toBeUndefined();
+        expect(await (await contract.tzip16()).metadataViews()).toEqual({});
+      });
+    });
+  });
+});

--- a/integration-tests/__tests__/wallet/set-delegate-auto-estimate.spec.ts
+++ b/integration-tests/__tests__/wallet/set-delegate-auto-estimate.spec.ts
@@ -1,34 +1,50 @@
-import { CONFIGS } from "../../config";
+import { CONFIGS, waitForRpcState } from '../../config';
 
 CONFIGS().forEach(({ lib, rpc, setup, knownBaker }) => {
   const Tezos = lib;
   describe(`Test account delegation with estimation through wallet api using: ${rpc}`, () => {
-
     beforeEach(async () => {
-      await setup({ preferFreshKey: true, minBalanceMutez: 2_000_000 })
-    })
+      await setup({ preferFreshKey: true, minBalanceMutez: 2_000_000 });
+    });
     it('Verify that an address can be delegated to a known baker with an automatic estimate', async () => {
-      const delegate = knownBaker
+      const delegate = knownBaker;
       const pkh = await Tezos.signer.publicKeyHash();
+      const startingDelegate = await Tezos.rpc.getDelegate(pkh);
       try {
-        const op = await Tezos.wallet.setDelegate({
-          delegate,
-        }).send()
-        await op.confirmation()
+        const op = await Tezos.wallet
+          .setDelegate({
+            delegate,
+          })
+          .send();
+        await op.confirmation();
         expect(await op.status()).toBe('applied');
         expect(op.opHash).toBeDefined();
 
-        const account = await Tezos.rpc.getDelegate(pkh)
-        expect(account).toEqual(delegate)
+        const account = await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getDelegate(pkh),
+          (currentDelegate) => currentDelegate === delegate,
+          { description: `delegate for ${pkh}` }
+        );
+        expect(account).toEqual(delegate);
       } catch (ex: any) {
-        if (await Tezos.rpc.getDelegate(pkh) === pkh) {
+        const currentDelegate = await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getDelegate(pkh),
+          () => true,
+          { timeoutMs: 2_000, description: `delegate state for ${pkh}` }
+        ).catch(() => null);
+
+        if (currentDelegate === pkh) {
           // Forbidden delegate deletion
-          expect(ex.message).toMatch('delegate.no_deletion')
-        } else {
+          expect(ex.message).toMatch('delegate.no_deletion');
+        } else if (startingDelegate === delegate || currentDelegate === delegate) {
           // When running tests more than one time with the same key, the account is already delegated to the given delegate
-          expect(ex.message).toMatch('delegate.unchanged')
+          expect(ex.message).toMatch('delegate.unchanged');
+        } else {
+          throw ex;
         }
       }
     });
   });
-})
+});

--- a/integration-tests/__tests__/wallet/transfer-ticket-operation.spec.ts
+++ b/integration-tests/__tests__/wallet/transfer-ticket-operation.spec.ts
@@ -1,4 +1,4 @@
-import { CONFIGS } from '../../config';
+import { CONFIGS, waitForRpcState } from '../../config';
 import { DefaultContractType, TezosToolkit } from '@taquito/taquito';
 import { RpcClient, TicketTokenParams } from '@taquito/rpc';
 import { ticketsSendTz } from '../../data/code_with_ticket_transfer';
@@ -11,11 +11,10 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownTicketContract }) => {
   let recipient: TezosToolkit;
   let sender: TezosToolkit;
   let recipientPkh: string;
-  let senderPkh: string
+  let senderPkh: string;
   let ticketToken: TicketTokenParams;
 
   describe(`Transfer tickets between implicit accounts using: ${rpc}`, () => {
-
     beforeAll(async () => {
       await setup({ preferFreshKey: true, minBalanceMutez: 5_000_000 });
       try {
@@ -28,15 +27,30 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownTicketContract }) => {
         const fundSender = await Tezos.contract.transfer({ to: senderPkh, amount: 5 });
         await fundSender.confirmation();
         expect(fundSender.status).toEqual('applied');
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getBalance(senderPkh),
+          (balance) => Number(balance.toString()) > 0,
+          { description: `sender funding for ${senderPkh}` }
+        );
 
         ticketSendContract = await Tezos.contract.at(knownTicketContract);
-        ticketToken = { ticketer: ticketSendContract.address, content_type: { prim: 'string' }, content: { string: 'Ticket' } };
+        ticketToken = {
+          ticketer: ticketSendContract.address,
+          content_type: { prim: 'string' },
+          content: { string: 'Ticket' },
+        };
 
         // Send 3 tickets from the originated contract to sender
-        const sendTickets = await ticketSendContract.methodsObject.default([senderPkh, '3']).send()
+        const sendTickets = await ticketSendContract.methodsObject.default([senderPkh, '3']).send();
         await sendTickets.confirmation();
         expect(sendTickets.status).toEqual('applied');
-
+        await waitForRpcState(
+          Tezos,
+          () => Tezos.rpc.getTicketBalance(senderPkh, ticketToken),
+          (balance) => balance === '3',
+          { description: `ticket funding for ${senderPkh}` }
+        );
       } catch (error) {
         console.log(error);
         throw error;
@@ -52,24 +66,36 @@ CONFIGS().forEach(({ lib, rpc, setup, createAddress, knownTicketContract }) => {
       expect(senderBalanceBefore).toEqual('3');
 
       // Transfer 1 ticket from sender to recipient
-      const transferTicketOp = await sender.wallet.transferTicket({
-        ticketContents: { string: "Ticket" },
-        ticketTy: { prim: "string" },
-        ticketTicketer: ticketSendContract.address,
-        ticketAmount: 1,
-        destination: recipientPkh,
-        entrypoint: 'default',
-      }).send();
+      const transferTicketOp = await sender.wallet
+        .transferTicket({
+          ticketContents: { string: 'Ticket' },
+          ticketTy: { prim: 'string' },
+          ticketTicketer: ticketSendContract.address,
+          ticketAmount: 1,
+          destination: recipientPkh,
+          entrypoint: 'default',
+        })
+        .send();
 
       await transferTicketOp.confirmation();
 
       expect(await transferTicketOp.status()).toEqual('applied');
 
       // Check balances after transferring tickets
-      const balanceAfter = await client.getTicketBalance(recipientPkh, ticketToken);
+      const balanceAfter = await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getTicketBalance(recipientPkh, ticketToken),
+        (balance) => balance === '1',
+        { description: `recipient ticket balance for ${recipientPkh}` }
+      );
       expect(balanceAfter).toEqual('1');
 
-      const senderBalanceAfter = await client.getTicketBalance(senderPkh, ticketToken);
+      const senderBalanceAfter = await waitForRpcState(
+        Tezos,
+        () => Tezos.rpc.getTicketBalance(senderPkh, ticketToken),
+        (balance) => balance === '2',
+        { description: `sender ticket balance for ${senderPkh}` }
+      );
       expect(senderBalanceAfter).toEqual('2');
     });
   });

--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -665,6 +665,40 @@ export const clearRpcCache = (Tezos: TezosToolkit) => {
   }
 };
 
+export const waitForRpcState = async <T>(
+  Tezos: TezosToolkit,
+  read: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  options?: {
+    timeoutMs?: number;
+    intervalMs?: number;
+    description?: string;
+  }
+) => {
+  const timeoutMs = options?.timeoutMs ?? 15_000;
+  const intervalMs = options?.intervalMs ?? 500;
+  const description = options?.description ?? 'RPC state';
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+
+  while (Date.now() <= deadline) {
+    clearRpcCache(Tezos);
+    try {
+      const value = await read();
+      if (predicate(value)) {
+        return value;
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    await sleep(intervalMs);
+  }
+
+  const details = lastError ? ` Last error: ${toErrorMessage(lastError)}` : '';
+  throw new Error(`Timed out waiting for ${description}.${details}`);
+};
+
 export const CONFIGS = () => {
   return forgers.reduce((prev, forger: ForgerType) => {
     const configs = providers.map(
@@ -780,6 +814,7 @@ export const CONFIGS = () => {
               networkName,
               rpc,
             });
+            clearRpcCache(tezos);
 
             return tezos;
           },


### PR DESCRIPTION
## Summary
- add an RPC visibility helper that clears cached reads while polling for post-operation state
- harden the flaky shadownet integration specs by waiting for contract, balance, delegate, storage, and ticket state to become visible
- reduce signer counter drift by using fresh signers in the batch and tz2/tz4 suites, and raise a tight funding floor for the key collections test

## Verification
- npx prettier --write on touched files
- git diff --check
- npm --prefix integration-tests run test:shadownet -- __tests__/contract/call-estimate.spec.ts __tests__/contract/set-delegate-auto-estimate.spec.ts
- npm --prefix integration-tests run test:shadownet -- __tests__/contract/batch/batch.spec.ts __tests__/contract/tz4-operations-without-reveal-tests.spec.ts

## Notes
- the second shadownet run passed batch.spec.ts and most of tz4-operations-without-reveal-tests.spec.ts
- the remaining tz4 failures were update_consensus_key_on_unregistered_delegate in the update_consensus_key and update_companion_key cases, which looks separate from the original flap