### PR TITLE
fix(sapling): externalize packaged params in release bundle

### DIFF
--- a/browser-tests/smoke-app/src/shims/sapling-output-params.ts
+++ b/browser-tests/smoke-app/src/shims/sapling-output-params.ts
@@ -1,0 +1,14 @@
+type GlobalWithVendoredParams = typeof globalThis & {
+  __taquitoVendoredParams?: {
+    saplingOutputParams?: {
+      saplingOutputParams: string;
+    };
+  };
+};
+
+const globalWithVendoredParams = globalThis as GlobalWithVendoredParams;
+
+globalWithVendoredParams.__taquitoVendoredParams = globalWithVendoredParams.__taquitoVendoredParams ?? {};
+globalWithVendoredParams.__taquitoVendoredParams.saplingOutputParams = {
+  saplingOutputParams: '',
+};

--- a/browser-tests/smoke-app/src/shims/sapling-spend-params.ts
+++ b/browser-tests/smoke-app/src/shims/sapling-spend-params.ts
@@ -1,0 +1,5 @@
+const saplingSpendParams = {
+  saplingSpendParams: '',
+};
+
+export default saplingSpendParams;

--- a/browser-tests/vite.config.mts
+++ b/browser-tests/vite.config.mts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 const browserTestsDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(browserTestsDir, '..');
 const packagesDir = join(repoRoot, 'packages');
+const browserTestShimsDir = join(browserTestsDir, 'smoke-app', 'src', 'shims');
 
 const taquitoAliases = Object.fromEntries(
   readdirSync(packagesDir, { withFileTypes: true })
@@ -38,7 +39,11 @@ export default defineConfig({
     ),
   },
   resolve: {
-    alias: taquitoAliases,
+    alias: {
+      ...taquitoAliases,
+      '@taquito/sapling-spend-params': join(browserTestShimsDir, 'sapling-spend-params.ts'),
+      '../saplingOutputParams.js': join(browserTestShimsDir, 'sapling-output-params.ts'),
+    },
   },
   optimizeDeps: {
     entries: [join(browserTestsDir, 'smoke-app', 'src', 'prewarm-packages.ts')],

--- a/packages/taquito-sapling/fetch-sapling-params.js
+++ b/packages/taquito-sapling/fetch-sapling-params.js
@@ -24,14 +24,17 @@ const PARAMS = [
 
 function formatModule(moduleName, encoded) {
   return `(function (root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define([], factory);
-  } else if (typeof module === 'object' && module.exports) {
-    module.exports = factory();
-  } else {
-    root.returnExports = factory();
+  var value = factory();
+  if (root) {
+    root.__taquitoVendoredParams = root.__taquitoVendoredParams || {};
+    root.__taquitoVendoredParams["${moduleName}"] = value;
   }
-}(this, function () {
+  if (typeof define === 'function' && define.amd) {
+    define([], function () { return value; });
+  } else if (typeof module === 'object' && module.exports) {
+    module.exports = value;
+  }
+}(typeof globalThis !== 'undefined' ? globalThis : this, function () {
   return {
     "${moduleName}": "${encoded}"
   };

--- a/packages/taquito-sapling/rollup.config.ts
+++ b/packages/taquito-sapling/rollup.config.ts
@@ -22,6 +22,8 @@ export default {
         "@taquito/utils": "utils",
         "@taquito/core": "core",
         "@taquito/sapling-wasm": "sapling",
+        "../saplingOutputParams.js": "saplingOutputParams",
+        "@taquito/sapling-spend-params": "saplingSpendParams",
         "blakejs": "blake",
         "@stablelib/nacl": "nacl",
         "@stablelib/random": "random",
@@ -34,6 +36,9 @@ export default {
   external: [
     'typedarray-to-buffer',
     'blakejs',
+    '../saplingOutputParams',
+    '../saplingOutputParams.js',
+    '@taquito/sapling-spend-params',
     '@taquito/core',
     '@taquito/utils',
     'bignumber.js',

--- a/packages/taquito-sapling/src/sapling-module-wrapper.ts
+++ b/packages/taquito-sapling/src/sapling-module-wrapper.ts
@@ -1,7 +1,7 @@
 import { Buffer } from 'buffer';
 import * as sapling from './sapling-wasm';
 import { ParametersOutputProof } from './types';
-import saplingOutputParams from '../saplingOutputParams.js';
+import saplingOutputParams from './sapling-output-params';
 import saplingSpendParams from '@taquito/sapling-spend-params';
 
 let cachedParams: { spend: Buffer; output: Buffer } | undefined;

--- a/packages/taquito-sapling/src/sapling-output-params.ts
+++ b/packages/taquito-sapling/src/sapling-output-params.ts
@@ -1,0 +1,24 @@
+import '../saplingOutputParams.js';
+
+type SaplingOutputParamsModule = {
+  saplingOutputParams: string;
+};
+
+type GlobalWithVendoredParams = typeof globalThis & {
+  __taquitoVendoredParams?: {
+    saplingOutputParams?: SaplingOutputParamsModule;
+  };
+};
+
+const loadSaplingOutputParams = (): SaplingOutputParamsModule => {
+  const saplingOutputParams = (globalThis as GlobalWithVendoredParams).__taquitoVendoredParams
+    ?.saplingOutputParams;
+
+  if (!saplingOutputParams) {
+    throw new Error('Vendored sapling output params failed to load');
+  }
+
+  return saplingOutputParams;
+};
+
+export default loadSaplingOutputParams();


### PR DESCRIPTION
## Summary
- externalize the packaged sapling params again in the release bundle
- keep the params shipped as package files instead of inlining them into both bundles and sourcemaps
- restore the sapling npm artifact to the size range that published successfully in v24.3.0-beta.5

## Why
The v24.3.0-beta.6 release failed during npm publish with a 413 on @taquito/sapling after the bundle grew to roughly 209 MB packed. This change keeps the params packaged, but stops rollup from duplicating them into the UMD and ES bundles and their sourcemaps.

## Verification
- npm run -w @taquito/sapling build
- npm run -w @taquito/sapling test
- npm_config_cache=/tmp/npm-cache-taquito npm pack --dry-run --workspace @taquito/sapling