### PR TITLE
fix(website): lazy load ledger docs support

### DIFF
--- a/website/src/components/SimpleCodeRunner.astro
+++ b/website/src/components/SimpleCodeRunner.astro
@@ -83,6 +83,11 @@ const html = Prism.highlight(code, Prism.languages[language] || Prism.languages.
       const sourceCodeContent = this.getAttribute('data-code') || '';
       const isWalletMode = this.getAttribute('data-wallet') === 'true';
       const shouldSkipConfig = this.getAttribute('data-no-config') === 'true';
+      const needsLedgerSupport =
+        sourceCodeContent.includes('TransportWebHID') ||
+        sourceCodeContent.includes('LedgerSigner') ||
+        sourceCodeContent.includes('HDPathTemplate') ||
+        sourceCodeContent.includes('DerivationType');
 
       if (!sourceCodeContent) {
         outputContent.textContent = "Error: No code to execute";
@@ -108,6 +113,12 @@ const html = Prism.highlight(code, Prism.languages[language] || Prism.languages.
         const win = window as any;
         if (!win.Tezos) {
           throw new Error("Taquito failed to load.");
+        }
+
+        if (needsLedgerSupport && win.ensureLedgerSupport) {
+          outputContent.textContent = "Loading Ledger support...";
+          await win.ensureLedgerSupport();
+          outputContent.textContent = "";
         }
 
         // For wallet mode, connect wallet; otherwise configure signer

--- a/website/src/scripts/taquito-init.ts
+++ b/website/src/scripts/taquito-init.ts
@@ -72,8 +72,17 @@ declare global {
     __walletConnected?: boolean;
     __taquitoReady?: Promise<void>;
     __taquitoError?: any;
+    ensureLedgerSupport?: () => Promise<void>;
   }
 }
+
+type BrowserGlobalScope = typeof globalThis & {
+  Buffer?: typeof import('buffer').Buffer;
+  global?: typeof globalThis;
+  process?: {
+    env?: Record<string, string | undefined>;
+  };
+};
 
 // Initialize the ready promise immediately
 let resolveInit: () => void;
@@ -86,9 +95,53 @@ if (!window.__taquitoReady) {
   });
 }
 
+const installBrowserShims = async () => {
+  const browserGlobal = globalThis as BrowserGlobalScope;
+
+  if (!browserGlobal.global) {
+    browserGlobal.global = browserGlobal;
+  }
+
+  if (!browserGlobal.process) {
+    browserGlobal.process = { env: {} };
+  } else if (!browserGlobal.process.env) {
+    browserGlobal.process.env = {};
+  }
+
+  if (!browserGlobal.Buffer) {
+    const { Buffer } = await import('buffer');
+    browserGlobal.Buffer = Buffer;
+  }
+};
+
+let ledgerSupportPromise: Promise<void> | undefined;
+
+const ensureLedgerSupport = async () => {
+  await installBrowserShims();
+
+  if (!ledgerSupportPromise) {
+    ledgerSupportPromise = (async () => {
+      const TransportWebHID = (await import('@ledgerhq/hw-transport-webhid')).default;
+      const { LedgerSigner, DerivationType, HDPathTemplate } = await import(
+        '@taquito/ledger-signer'
+      );
+
+      window.TransportWebHID = TransportWebHID;
+      window.LedgerSigner = LedgerSigner;
+      window.DerivationType = DerivationType;
+      window.HDPathTemplate = HDPathTemplate;
+    })();
+  }
+
+  return ledgerSupportPromise;
+};
+
+window.ensureLedgerSupport = ensureLedgerSupport;
+
 async function init() {
   try {
     console.log("Initializing Taquito dynamically...");
+    await installBrowserShims();
 
     // Dynamic imports
     const { TezosToolkit, compose, MichelsonMap, UnitValue, RpcReadAdapter, getRevealFee, importKey } = await import('@taquito/taquito');
@@ -101,8 +154,6 @@ async function init() {
     const { SigningType } = await import('@taquito/beacon-wallet/types')
     const { Parser, packDataBytes, emitMicheline } = await import('@taquito/michel-codec');
     const { b58Encode, PrefixV2 } = await import('@taquito/utils');
-    const TransportWebHID = (await import('@ledgerhq/hw-transport-webhid')).default;
-    const { LedgerSigner, DerivationType, HDPathTemplate } = await import('@taquito/ledger-signer');
     const { WalletConnect, NetworkType, PermissionScopeMethods } = await import("@taquito/wallet-connect");
 
     const Tezos = new TezosToolkit('https://shadownet.tezos.ecadinfra.com');
@@ -131,10 +182,6 @@ async function init() {
     window.PrefixV2 = PrefixV2;
     window.emitMicheline = emitMicheline;
     window.getRevealFee = getRevealFee;
-    window.TransportWebHID = TransportWebHID;
-    window.LedgerSigner = LedgerSigner;
-    window.DerivationType = DerivationType;
-    window.HDPathTemplate = HDPathTemplate;
     window.WalletConnect = WalletConnect;
     window.NetworkType = NetworkType;
     window.PermissionScopeMethods = PermissionScopeMethods;


### PR DESCRIPTION
## Summary
- install the minimal browser globals Taquito needs before docs runtime imports
- lazy load Ledger browser support so non-Ledger docs pages do not fail during bootstrap
- keep Ledger examples working when they are actually run

## Testing
- npm run build
- local website preview at http://127.0.0.1:4325
- headless browser check for /docs/next/quick_start
- headless browser check for /docs/next/ledger_signer