### PR TITLE
fix(local-forging): use default bignumber import for ESM

### DIFF
--- a/packages/taquito-local-forging/src/michelson/codec.ts
+++ b/packages/taquito-local-forging/src/michelson/codec.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { Decoder } from '../decoder';
 import { Uint8ArrayConsumer } from '../uint8array-consumer';
 import { Encoder } from '../encoder';


### PR DESCRIPTION
## Summary
- replace the named `BigNumber` import in `@taquito/local-forging` Michelson codec with a default import
- avoid generating an invalid ESM bundle form like `import BigNumber$1, { BigNumber } from "bignumber.js"`
- fix browser/runtime failures in consumers such as the Sapling test in the Vue test dApp

## Verification
- confirmed the currently published `@taquito/local-forging` ESM bundle in the Vue test dApp contains the invalid named import
- verified the one-line source fix locally