### PR TITLE
fix: harden bignumber browser ESM imports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,8 @@ jobs:
           cache: npm
       - run: npx -y npm@11 ci
       - run: npm run build
+      - run: npm run test:scripts
+      - run: npm run test:dist:esm-imports
       - run: npm run lint
       - run: npm run build-docs
       - run: npm run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Build release artifacts
         run: npm run -w @taquito/taquito build:release
 
+      - name: Validate release helper scripts
+        run: npm run test:scripts
+
+      - name: Validate built ESM imports
+        run: npm run test:dist:esm-imports
+
       - name: Test
         run: npm test
 

--- a/.github/workflows/release_rehearsal.yml
+++ b/.github/workflows/release_rehearsal.yml
@@ -71,6 +71,12 @@ jobs:
       - name: Build release artifacts
         run: npm run -w @taquito/taquito build:release
 
+      - name: Validate release helper scripts
+        run: npm run test:scripts
+
+      - name: Validate built ESM imports
+        run: npm run test:dist:esm-imports
+
       - name: Test
         run: npm test
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "check:package-catalog": "node ./scripts/package-catalog.js --check",
     "sync:package-catalog": "node ./scripts/package-catalog.js --write",
     "test": "nx run-many --target=test --exclude=integration-tests,@taquito/website -- --coverage",
+    "test:dist:esm-imports": "node ./scripts/check-esm-imports.js",
     "lint": "npm run check:package-catalog && npm run --workspaces --if-present lint",
     "clean": "rimraf node_modules packages/*/node_modules packages/taquito-michel-codec/pack-test-tool/node_modules example/node_modules integration-tests/node_modules website/node_modules",
     "precommit": "npm run --workspaces --if-present precommit",
@@ -52,10 +53,11 @@
     "gh-pages": "gh-pages",
     "integration-tests": "npm -w integration-tests run originate-known-contracts && npm -w integration-tests run test:secret-key",
     "version-stamp": "npm run --workspaces --if-present version-stamp",
-    "test:browser:packages": "npm run build && playwright test --config browser-tests/playwright.config.ts --project=chromium",
-    "test:browser:packages:firefox": "npm run build && playwright test --config browser-tests/playwright.config.ts --project=firefox",
-    "test:browser:packages:webkit": "npm run build && playwright test --config browser-tests/playwright.config.ts --project=webkit",
-    "test:browser:packages:all": "npm run build && playwright test --config browser-tests/playwright.config.ts",
+    "test:scripts": "node --test scripts/*.test.js",
+    "test:browser:packages": "npm run build && npm run test:dist:esm-imports && playwright test --config browser-tests/playwright.config.ts --project=chromium",
+    "test:browser:packages:firefox": "npm run build && npm run test:dist:esm-imports && playwright test --config browser-tests/playwright.config.ts --project=firefox",
+    "test:browser:packages:webkit": "npm run build && npm run test:dist:esm-imports && playwright test --config browser-tests/playwright.config.ts --project=webkit",
+    "test:browser:packages:all": "npm run build && npm run test:dist:esm-imports && playwright test --config browser-tests/playwright.config.ts",
     "test:browser:packages:ci": "npm run test:browser:packages"
   },
   "devDependencies": {

--- a/packages/taquito-contracts-library/src/read-provider-wrapper.ts
+++ b/packages/taquito-contracts-library/src/read-provider-wrapper.ts
@@ -1,4 +1,4 @@
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import {

--- a/packages/taquito-local-forging/src/michelson/codec.ts
+++ b/packages/taquito-local-forging/src/michelson/codec.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import { Decoder } from '../decoder';
 import { Uint8ArrayConsumer } from '../uint8array-consumer';
 import { Encoder } from '../encoder';

--- a/packages/taquito-rpc/src/rpc-client-interface.ts
+++ b/packages/taquito-rpc/src/rpc-client-interface.ts
@@ -1,4 +1,4 @@
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import {

--- a/packages/taquito/src/operations/delegate-operation.ts
+++ b/packages/taquito/src/operations/delegate-operation.ts
@@ -3,7 +3,7 @@ import {
   OperationContentsAndResultDelegation,
   OperationContentsDelegation,
 } from '@taquito/rpc';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import { Context } from '../context';

--- a/packages/taquito/src/operations/origination-operation.ts
+++ b/packages/taquito/src/operations/origination-operation.ts
@@ -3,7 +3,7 @@ import {
   OperationContentsAndResultOrigination,
   OperationContentsOrigination,
 } from '@taquito/rpc';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import { Context } from '../context';

--- a/packages/taquito/src/operations/register-global-constant-operation.ts
+++ b/packages/taquito/src/operations/register-global-constant-operation.ts
@@ -3,7 +3,7 @@ import {
   OperationContentsAndResultRegisterGlobalConstant,
   OperationContentsRegisterGlobalConstant,
 } from '@taquito/rpc';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import { Context } from '../context';

--- a/packages/taquito/src/operations/reveal-operation.ts
+++ b/packages/taquito/src/operations/reveal-operation.ts
@@ -4,7 +4,7 @@ import {
   OperationContentsReveal,
 } from '@taquito/rpc';
 import { ProhibitedActionError } from '@taquito/core';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import { Context } from '../context';

--- a/packages/taquito/src/operations/transfer-ticket-operation.ts
+++ b/packages/taquito/src/operations/transfer-ticket-operation.ts
@@ -4,7 +4,7 @@ import {
   OperationContentsTransferTicket,
   OpKind,
 } from '@taquito/rpc';
-import { BigNumber as BigNumberJs } from 'bignumber.js';
+import BigNumberJs from 'bignumber.js';
 type BigNumber = InstanceType<typeof BigNumberJs>;
 const BigNumber = BigNumberJs;
 import { Context } from '../context';

--- a/scripts/check-esm-imports.js
+++ b/scripts/check-esm-imports.js
@@ -1,0 +1,81 @@
+const { readdirSync, readFileSync } = require('node:fs');
+const { join, resolve } = require('node:path');
+
+const repoRoot = resolve(__dirname, '..');
+const packagesDir = join(repoRoot, 'packages');
+
+const forbiddenImportChecks = [
+  {
+    packageName: 'bignumber.js',
+    pattern:
+      /import\s+(?:[^'";]+,\s*)?\{[^}]+\}\s+from\s+['"]bignumber\.js['"];?/g,
+    reason: 'named imports from bignumber.js are not safe in published browser ESM bundles',
+  },
+];
+
+function findBuiltEsmFiles(rootDir = packagesDir) {
+  return readdirSync(rootDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(rootDir, entry.name, 'dist'))
+    .flatMap((distDir) => {
+      try {
+        return readdirSync(distDir)
+          .filter((fileName) => fileName.endsWith('.es6.js'))
+          .map((fileName) => join(distDir, fileName));
+      } catch {
+        return [];
+      }
+    });
+}
+
+function findForbiddenImports(filePath, source) {
+  const findings = [];
+
+  for (const check of forbiddenImportChecks) {
+    for (const match of source.matchAll(check.pattern)) {
+      findings.push({
+        filePath,
+        packageName: check.packageName,
+        importStatement: match[0],
+        reason: check.reason,
+      });
+    }
+  }
+
+  return findings;
+}
+
+function checkBuiltEsmImports(rootDir = packagesDir) {
+  return findBuiltEsmFiles(rootDir).flatMap((filePath) =>
+    findForbiddenImports(filePath, readFileSync(filePath, 'utf8'))
+  );
+}
+
+function formatFinding(finding) {
+  const relativePath = finding.filePath.startsWith(repoRoot)
+    ? finding.filePath.slice(repoRoot.length + 1)
+    : finding.filePath;
+
+  return `${relativePath}\n  ${finding.importStatement}\n  ${finding.reason}`;
+}
+
+if (require.main === module) {
+  const findings = checkBuiltEsmImports();
+
+  if (findings.length > 0) {
+    console.error('Forbidden ESM import shape found in built artifacts:\n');
+    for (const finding of findings) {
+      console.error(formatFinding(finding));
+    }
+    process.exit(1);
+  }
+
+  console.log('Built ESM import checks passed.');
+}
+
+module.exports = {
+  checkBuiltEsmImports,
+  findBuiltEsmFiles,
+  findForbiddenImports,
+  formatFinding,
+};

--- a/scripts/check-esm-imports.test.js
+++ b/scripts/check-esm-imports.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const os = require('node:os');
+const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = require('node:fs');
+const { join } = require('node:path');
+
+const { checkBuiltEsmImports } = require('./check-esm-imports.js');
+
+test('checkBuiltEsmImports flags named imports from bignumber.js in built esm files', () => {
+  const root = mkdtempSync(join(os.tmpdir(), 'check-esm-imports-'));
+
+  try {
+    const distDir = join(root, 'taquito-local-forging', 'dist');
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(
+      join(distDir, 'taquito-local-forging.es6.js'),
+      "import BigNumber$1, { BigNumber } from 'bignumber.js';\n"
+    );
+
+    const findings = checkBuiltEsmImports(root);
+
+    assert.equal(findings.length, 1);
+    assert.match(findings[0].importStatement, /\{ BigNumber \}/);
+    assert.equal(findings[0].packageName, 'bignumber.js');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('checkBuiltEsmImports ignores default-only imports from bignumber.js in built esm files', () => {
+  const root = mkdtempSync(join(os.tmpdir(), 'check-esm-imports-'));
+
+  try {
+    const distDir = join(root, 'taquito-utils', 'dist');
+    mkdirSync(distDir, { recursive: true });
+    writeFileSync(join(distDir, 'taquito-utils.es6.js'), "import BigNumberJs from 'bignumber.js';\n");
+
+    const findings = checkBuiltEsmImports(root);
+
+    assert.equal(findings.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- switch affected runtime `bignumber.js` imports back to default imports while preserving the v10 type alias pattern
- add an artifact-level check that fails if built ESM bundles contain named imports from `bignumber.js`
- run that new check in main CI and in the release/rehearsal workflows so browser-only regressions cannot slip through release again

## Why
`24.3.0-rc.1` shipped browser ESM bundles where `@taquito/local-forging` and `@taquito/taquito` emitted named imports from `bignumber.js`, for example:

```ts
import BigNumber$1, { BigNumber } from 'bignumber.js';
```

That import shape broke the Vue test dApp's browser path. The root cause was the named-import form introduced during the `bignumber.js` v10 migration. The fix keeps the v10 type workaround (`InstanceType<typeof BigNumberJs>`) but uses default imports so the emitted bundles are browser-safe.

## Validation
- `npx nx test @taquito/local-forging`
- `npx nx test @taquito/rpc`
- `npx nx test @taquito/contracts-library`
- `npx nx test @taquito/taquito`
- `npm run test:scripts`
- `npm run test:dist:esm-imports`
- `npm run test:browser:packages`
