### PR TITLE
chore: bump @ecadlabs/beacon-* to 4.8.1-ecad.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2255,13 +2255,13 @@
       }
     },
     "node_modules/@ecadlabs/beacon-core": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-RF9LviCVOgGc4OFFPzaLd/BsgI3ab0qyoEJtSHrOD7XqsmlOhJ8/1tziesmn9doQ5hgTXM/TWJlePWxGGz3uvw==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-7nO6ROyv8oFjMw/XEHwIy6dM7t3xgVJ7Gq7eIcsvdx6KuvYa/EvzkPfii19yUU3z/V06KQunl+CFxkiWPwJ3mQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.1.0",
         "@stablelib/x25519-session": "^2.0.1",
@@ -2403,76 +2403,75 @@
       }
     },
     "node_modules/@ecadlabs/beacon-dapp": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-VAv1p4Mjyr93Dx3RA8eed+wvJkXgXfrkeQUpA4xiZhNdwJ0xOnSVelCePY7/cFqGLYS61H8c+b6kJC53Eu/DqQ==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-ZDFWslLGgI3PfzD28xBm7e1iy7A3vH3EhFVpqwBgbMp5+zpdX8w/bJ7Uh8dsVLmsI8NZmOMxYlx6rUllqHeAqQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
         "@walletconnect/types": "^2.23.9",
         "broadcast-channel": "^7.3.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-matrix": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-/FIQjIoLfNjpR28zb0eH6pAUW85dZ5pE6GwhYbAzuFaW+gFSachKSShjHjwWML3dU+ckgPJ3XauE6GcnzQWaCw==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-ytwoYLJZHmUKyEakUKXGhCbLvpnz4S1Tt3AqZJIwDLpL/eI7mhN++HMRI/gJVVP3ry/eSQfcRg0CwTP80Ax/+w==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
-        "axios": "^1.15.0"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.7"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-postmessage": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-+bftYCNbhwBGZgz06ge7lmjLIXCPNLItap5au2zp9nwtxlv30vepIqSV6JlelKi3dcgbTFezJIN7smu3eQ1NNg==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-Hpm+YdT0X9lEDfTTpjrSYzyu4ysG9AZXBkbVXlg4D+jgy9kGrN+TNuA7fOBYy/28Skd5RQnKFjD+bb6mE0zwKg==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.6"
+        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.7"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-walletconnect": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-9tmsySa44YjCiYxvsq8KRMTB+HlRBFvQXvewiSRRutfWX+YG4USyuGa8ol4vXDPGLxDE6AndARPCkNY+rV1jqg==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-mhLZ7Emx81IuL66k/nJ5coyi7v509EdY7fAHyvju6ElHpiNqxQP/OIAwra2LVN4znNFg/QNqtETIavsvGx7d7Q==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
         "@walletconnect/sign-client": "^2.23.9",
         "@walletconnect/types": "^2.23.9",
         "@walletconnect/utils": "^2.23.9"
       }
     },
     "node_modules/@ecadlabs/beacon-types": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-OUXWCHgkRZim6DEtTIHXiqroArigB4qWBAgFGqFZWcYZUFwcXWTtqNwqNQ4BNxERXkS4FQRMEDo5sXatCX+n6A==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-kqcV0Fs6PzbC3Hu9Gtc/MxykwnGGx8peqVyAYIwYP5MV6w5D5gf50AEIIBtcU1EX8dpF/OHEJnIJii0HyuZEWw==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "^0.1.40"
       }
     },
     "node_modules/@ecadlabs/beacon-ui": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-CrLk0B6GN3Sm+spE7HlLCCuIrKN71swjhl18lTNBX1jx9RRk0FC0+kKszeMqZUbJ7k3juoK/aJMTNlhVn11A5Q==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-cgHv9g2iqI/98g5q2IdwDTLHZm9lY3VeZwuL9q/n7367Ml9ktZW4JjTwDZVlzrWOAG/pKobBnt6fwqeSQ0WB9g==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
         "@walletconnect/utils": "^2.23.9",
         "qrcode-svg": "^1.1.0",
         "react": "^19.2.5",
@@ -2505,9 +2504,9 @@
       }
     },
     "node_modules/@ecadlabs/beacon-utils": {
-      "version": "4.8.1-ecad.6",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.6.tgz",
-      "integrity": "sha512-OpwbQaZ/WILdguw86UWuRnzKHHt7XQfDNzFRFMAwrryJ0qCKLJq1eic1ibn3JpE8Foh4p+TlIwJNVjk8RqTPQg==",
+      "version": "4.8.1-ecad.7",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.7.tgz",
+      "integrity": "sha512-ZA3yZPR7nIPNkJNbCCmd6V5NzGKsfzxSs7Jg+RvAogcOZ624J0eB5PWB8MElmtlo8yotaucvIru1HxYc7qeP4g==",
       "license": "ISC",
       "dependencies": {
         "@stablelib/ed25519": "^2.1.0",
@@ -7265,6 +7264,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/atomic-sleep": {
@@ -7295,6 +7295,7 @@
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
       "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -7960,6 +7961,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -8408,6 +8410,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -8797,6 +8800,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9952,6 +9956,7 @@
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
       "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -9987,6 +9992,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -12517,6 +12523,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12526,6 +12533,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
@@ -13962,6 +13970,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -17903,8 +17912,8 @@
       "version": "24.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ecadlabs/beacon-dapp": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-dapp": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
         "@taquito/core": "^24.2.0",
         "@taquito/taquito": "^24.2.0",
         "@taquito/utils": "^24.2.0",
@@ -17912,8 +17921,8 @@
         "util": "^0.12.5"
       },
       "devDependencies": {
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.6",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-ui": "4.8.1-ecad.7",
         "@types/bluebird": "^3.5.42",
         "@types/chrome": "0.1.40",
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -104,14 +104,14 @@
     ]
   },
   "overrides": {
-    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.1-ecad.6",
-    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.1-ecad.6",
-    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.1-ecad.6",
-    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.1-ecad.6",
-    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.1-ecad.6",
-    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.1-ecad.6",
-    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.1-ecad.6",
-    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.1-ecad.6",
+    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.1-ecad.7",
+    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.1-ecad.7",
+    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.1-ecad.7",
+    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.1-ecad.7",
+    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.1-ecad.7",
+    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.1-ecad.7",
+    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.1-ecad.7",
+    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.1-ecad.7",
     "axios": "1.15.0",
     "lodash": "4.18.1",
     "anymatch": {

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -70,8 +70,8 @@
     ]
   },
   "dependencies": {
-    "@ecadlabs/beacon-dapp": "4.8.1-ecad.6",
-    "@ecadlabs/beacon-types": "4.8.1-ecad.6",
+    "@ecadlabs/beacon-dapp": "4.8.1-ecad.7",
+    "@ecadlabs/beacon-types": "4.8.1-ecad.7",
     "@taquito/core": "^24.2.0",
     "@taquito/taquito": "^24.2.0",
     "@taquito/utils": "^24.2.0",
@@ -79,8 +79,8 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.6",
-    "@ecadlabs/beacon-ui": "4.8.1-ecad.6",
+    "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
+    "@ecadlabs/beacon-ui": "4.8.1-ecad.7",
     "@types/bluebird": "^3.5.42",
     "@types/chrome": "0.1.40",
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary

Bumps the vendored Beacon SDK fork from `4.8.1-ecad.6` to `4.8.1-ecad.7` across the root overrides and `@taquito/beacon-wallet`.

Upstream release highlights:

- **Security**: drops `axios` + `follow-redirects`, closing [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653). Matrix transport, `WalletClient` push oracle, and `DAppClient` notification send rewritten on native `fetch` + `AbortController`. Public API and Matrix `errcode` error semantics preserved.
- **Bug fixes**: `WalletConnectTransport.connect()` now awaits per-peer `listen()` (no more silently-unattached listeners on reconnect); `MatrixClientStore.updateStorage()` logs preserved-state write failures; `getDAppClientInstance()` surfaces the prior instance's `disconnect()` errors on reset.
- **Breaking (upstream)**: 15 dead `NetworkType` enum values removed (DELPHINET…RIONET). Grepped this repo, no references.
- `NetworkType.GHOSTNET` and `SEOULNET` now deprecated (succeeded by `SHADOWNET` / `TALLINNNET`); still exported.
- New: `NetworkType.TEZOSX_PREVIEWNET`, `NetworkType.USHUAIANET`.
- `BlockExplorer.rpcUrls` map keys are now optional; `getLinkForNetwork` throws on unmapped networks instead of returning `undefined`.

## Scope

- Root `package.json` overrides: 8 `@airgap/beacon-*` → `@ecadlabs/beacon-*@4.8.1-ecad.7`.
- `packages/taquito-beacon-wallet/package.json`: `@ecadlabs/beacon-dapp`, `-types`, `-transport-postmessage`, `-ui` bumped.
- `package-lock.json` refreshed.
- `website/package-lock.json` intentionally left alone — it resolves Beacon transitively through the published `@taquito/beacon-wallet@24.3.0-rc.1` and will roll over with the next website RC bump.

## Test plan

- [x] `npm install` (Node 22.18.0) resolves all `@ecadlabs/beacon-*` to `4.8.1-ecad.7`
- [x] `npm run build --workspace=@taquito/beacon-wallet` clean
- [x] `npm run test --workspace=@taquito/beacon-wallet` — 28/28 passing
- [ ] CI green
- [ ] Smoke test in `taquito-test-dapp-vue` against the new RC once published