### PR TITLE
chore: update ECAD Beacon packages to 4.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,13 +1996,14 @@
       }
     },
     "node_modules/@ecadlabs/beacon-core": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-7nO6ROyv8oFjMw/XEHwIy6dM7t3xgVJ7Gq7eIcsvdx6KuvYa/EvzkPfii19yUU3z/V06KQunl+CFxkiWPwJ3mQ==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.2-ecad.tgz",
+      "integrity": "sha512-u6tfysL+e1JEbNo3H1lKH048wDN9vHKVzunmo+EvzNe7+KaxoEfY5UpXvdQkG5PpGwoNwefvWrak/KhshlOOIQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-utils": "4.8.2-ecad",
+        "@stablelib/blake2b": "^2.0.1",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.1.0",
         "@stablelib/x25519-session": "^2.0.1",
@@ -2144,84 +2145,143 @@
       }
     },
     "node_modules/@ecadlabs/beacon-dapp": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-ZDFWslLGgI3PfzD28xBm7e1iy7A3vH3EhFVpqwBgbMp5+zpdX8w/bJ7Uh8dsVLmsI8NZmOMxYlx6rUllqHeAqQ==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.2-ecad.tgz",
+      "integrity": "sha512-Hut9UH4bJefQH7muJ0hzNtGLBtlav1BUhv54yhymvytaDLeve707S97kfKePWz0w5JPNwt9UEgwwIYIiKX45Ig==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-transport-matrix": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-transport-walletconnect": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-core": "4.8.2-ecad",
+        "@ecadlabs/beacon-transport-matrix": "4.8.2-ecad",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-ui": "4.8.2-ecad",
+        "@ecadlabs/beacon-utils": "4.8.2-ecad",
         "@walletconnect/types": "^2.23.9",
-        "broadcast-channel": "^7.3.0"
+        "broadcast-channel": "^7.3.0",
+        "bs58check": "4.0.0"
+      }
+    },
+    "node_modules/@ecadlabs/beacon-dapp/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
+    "node_modules/@ecadlabs/beacon-dapp/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "node_modules/@ecadlabs/beacon-dapp/node_modules/bs58check": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-4.0.0.tgz",
+      "integrity": "sha512-FsGDOnFg9aVI9erdriULkd/JjEWONV/lQE5aYziB5PoBsXRind56lh8doIZIc9X4HoxT5x4bLjMWN1/NB8Zp5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0",
+        "bs58": "^6.0.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-matrix": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-ytwoYLJZHmUKyEakUKXGhCbLvpnz4S1Tt3AqZJIwDLpL/eI7mhN++HMRI/gJVVP3ry/eSQfcRg0CwTP80Ax/+w==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.2-ecad.tgz",
+      "integrity": "sha512-Qpu847+roKVnpck5cHsYgRm5hh57bogZCRxepWF0PVpYWcByDGwDw7E8DBitXSauTxo5gerx9R1Ubl4UDKRaxA==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.7"
+        "@ecadlabs/beacon-core": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-utils": "4.8.2-ecad",
+        "@stablelib/blake2b": "^2.0.1",
+        "@stablelib/utf8": "^2.1.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-postmessage": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-Hpm+YdT0X9lEDfTTpjrSYzyu4ysG9AZXBkbVXlg4D+jgy9kGrN+TNuA7fOBYy/28Skd5RQnKFjD+bb6mE0zwKg==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.2-ecad.tgz",
+      "integrity": "sha512-0iQx2cCi/PGWsxalWu6776P7VGQKYipR/Xyxuck6hQub3WxQ2vHRzu49QrVvoMiE2K0aORYz4mB+WikI8RigiQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.7"
+        "@ecadlabs/beacon-core": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-utils": "4.8.2-ecad"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-walletconnect": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-mhLZ7Emx81IuL66k/nJ5coyi7v509EdY7fAHyvju6ElHpiNqxQP/OIAwra2LVN4znNFg/QNqtETIavsvGx7d7Q==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.2-ecad.tgz",
+      "integrity": "sha512-WrhBIqpBUIuqyU8B3m+XdtGKNFvBRzEq8Vbhv/Iv0gpgAlU5HjUHKMGYcCUeCrk4UjldKMJEDKZNCEHs7NKeIQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-core": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-utils": "4.8.2-ecad",
         "@walletconnect/sign-client": "^2.23.9",
         "@walletconnect/types": "^2.23.9",
         "@walletconnect/utils": "^2.23.9"
       }
     },
     "node_modules/@ecadlabs/beacon-types": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-kqcV0Fs6PzbC3Hu9Gtc/MxykwnGGx8peqVyAYIwYP5MV6w5D5gf50AEIIBtcU1EX8dpF/OHEJnIJii0HyuZEWw==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.2-ecad.tgz",
+      "integrity": "sha512-VBdn9e41G5FFcVTKmzym5x1rISLaffkxIPhwAjheVhh0a6wrE60MkkeDlqn0Wc+37jsXYhHa1Qa/ezHhka+2JQ==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "^0.1.40"
       }
     },
     "node_modules/@ecadlabs/beacon-ui": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-cgHv9g2iqI/98g5q2IdwDTLHZm9lY3VeZwuL9q/n7367Ml9ktZW4JjTwDZVlzrWOAG/pKobBnt6fwqeSQ0WB9g==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.2-ecad.tgz",
+      "integrity": "sha512-NpLuJ2np3rAH6lbqIF84Xud8UU7UaevTHGo3H2hmLfNk4Q2i4npyzKjt1qijcJsGwiCI1JFwV8rLrVVW3VrJug==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-utils": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-core": "4.8.2-ecad",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-utils": "4.8.2-ecad",
         "@walletconnect/utils": "^2.23.9",
         "qrcode-svg": "^1.1.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
       "optionalDependencies": {
-        "@rollup/rollup-darwin-arm64": "4.60.1",
-        "@rollup/rollup-linux-x64-gnu": "4.60.1"
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2"
       }
+    },
+    "node_modules/@ecadlabs/beacon-ui/node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@ecadlabs/beacon-ui/node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@ecadlabs/beacon-ui/node_modules/react": {
       "version": "19.2.5",
@@ -2245,11 +2305,13 @@
       }
     },
     "node_modules/@ecadlabs/beacon-utils": {
-      "version": "4.8.1-ecad.7",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.1-ecad.7.tgz",
-      "integrity": "sha512-ZA3yZPR7nIPNkJNbCCmd6V5NzGKsfzxSs7Jg+RvAogcOZ624J0eB5PWB8MElmtlo8yotaucvIru1HxYc7qeP4g==",
+      "version": "4.8.2-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.2-ecad.tgz",
+      "integrity": "sha512-gitigcE8qWV7qIMjFsG6BWAgjV3kP+6/5pMpQQm1RHXLx3PHiNKQ7QkR/co5pUqz2OIYcPZ9HaVadN3QdD7qvQ==",
       "license": "ISC",
       "dependencies": {
+        "@stablelib/blake2b": "^2.0.1",
+        "@stablelib/bytes": "^2.0.1",
         "@stablelib/ed25519": "^2.1.0",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/random": "^2.0.1",
@@ -4351,6 +4413,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4560,6 +4623,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17179,8 +17243,8 @@
       "version": "24.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ecadlabs/beacon-dapp": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-types": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-dapp": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.2-ecad",
         "@taquito/core": "^24.3.0",
         "@taquito/taquito": "^24.3.0",
         "@taquito/utils": "^24.3.0",
@@ -17188,8 +17252,8 @@
         "util": "^0.12.5"
       },
       "devDependencies": {
-        "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
-        "@ecadlabs/beacon-ui": "4.8.1-ecad.7",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
+        "@ecadlabs/beacon-ui": "4.8.2-ecad",
         "@types/bluebird": "^3.5.42",
         "@types/chrome": "0.1.40",
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -97,14 +97,14 @@
     "vitest": "^4.1.4"
   },
   "overrides": {
-    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.1-ecad.7",
-    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.1-ecad.7",
-    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.1-ecad.7",
-    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.1-ecad.7",
-    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.1-ecad.7",
-    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.1-ecad.7",
-    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.1-ecad.7",
-    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.1-ecad.7",
+    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.2-ecad",
+    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.2-ecad",
+    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.2-ecad",
+    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.2-ecad",
+    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.2-ecad",
+    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.2-ecad",
+    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.2-ecad",
+    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.2-ecad",
     "follow-redirects": "^1.16.0",
     "lodash": "4.18.1",
     "anymatch": {

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -70,8 +70,8 @@
     ]
   },
   "dependencies": {
-    "@ecadlabs/beacon-dapp": "4.8.1-ecad.7",
-    "@ecadlabs/beacon-types": "4.8.1-ecad.7",
+    "@ecadlabs/beacon-dapp": "4.8.2-ecad",
+    "@ecadlabs/beacon-types": "4.8.2-ecad",
     "@taquito/core": "^24.3.0",
     "@taquito/taquito": "^24.3.0",
     "@taquito/utils": "^24.3.0",
@@ -79,8 +79,8 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@ecadlabs/beacon-transport-postmessage": "4.8.1-ecad.7",
-    "@ecadlabs/beacon-ui": "4.8.1-ecad.7",
+    "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
+    "@ecadlabs/beacon-ui": "4.8.2-ecad",
     "@types/bluebird": "^3.5.42",
     "@types/chrome": "0.1.40",
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- update @taquito/beacon-wallet direct @ecadlabs/beacon-* pins to 4.8.2-ecad
- update root @airgap/beacon-* npm overrides to the matching @ecadlabs/beacon-* 4.8.2-ecad packages
- refresh package-lock metadata for the published 4.8.2-ecad Beacon tarballs

## Notes
- 4.8.2-ecad includes the WalletConnect rejection unwedge fix reported by Kukai.
- DAppClient.init() can now reject instead of hanging forever on rejection paths.
- V3 permissionRequest now throws the raw ErrorResponse, matching V2.
- PERMISSION_REQUEST_ERROR now fires once per WalletConnect rejection with the full ErrorResponse payload.
- WalletClient inbound Disconnect handling is now scoped per peer.

## Verification
- npm install --ignore-scripts
- npm ls @ecadlabs/beacon-dapp @ecadlabs/beacon-core @ecadlabs/beacon-types @ecadlabs/beacon-utils @ecadlabs/beacon-ui @ecadlabs/beacon-transport-matrix @ecadlabs/beacon-transport-postmessage @ecadlabs/beacon-transport-walletconnect --all
- npx nx test @taquito/beacon-wallet
- npx nx lint @taquito/beacon-wallet (passes with existing no-explicit-any warnings)
- npx nx build @taquito/beacon-wallet --excludeTaskDependencies

## Build note
- npx nx build @taquito/beacon-wallet fails when dependency tasks are included because @taquito/signer cannot resolve tslib during its Rollup build. The direct beacon-wallet build passes when dependency tasks are excluded.