### PR TITLE
chore: upgrade ECAD Beacon packages to 4.8.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1996,13 +1996,13 @@
       }
     },
     "node_modules/@ecadlabs/beacon-core": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.2-ecad.tgz",
-      "integrity": "sha512-u6tfysL+e1JEbNo3H1lKH048wDN9vHKVzunmo+EvzNe7+KaxoEfY5UpXvdQkG5PpGwoNwefvWrak/KhshlOOIQ==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-core/-/beacon-core-4.8.3-ecad.tgz",
+      "integrity": "sha512-WA4E2URV8EiSlcBBRyuLO5SRDwspU6N6USkhodY9LUVfyp8ct29iOs1Fv+cUTzgSGnIgf7c9W444lJudPNsXyw==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
-        "@ecadlabs/beacon-utils": "4.8.2-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
+        "@ecadlabs/beacon-utils": "4.8.3-ecad",
         "@stablelib/blake2b": "^2.0.1",
         "@stablelib/nacl": "^2.0.1",
         "@stablelib/utf8": "^2.1.0",
@@ -2145,18 +2145,18 @@
       }
     },
     "node_modules/@ecadlabs/beacon-dapp": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.2-ecad.tgz",
-      "integrity": "sha512-Hut9UH4bJefQH7muJ0hzNtGLBtlav1BUhv54yhymvytaDLeve707S97kfKePWz0w5JPNwt9UEgwwIYIiKX45Ig==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-dapp/-/beacon-dapp-4.8.3-ecad.tgz",
+      "integrity": "sha512-L8Y06KyVKB99yymnMBSFBWMJQhAMgTgnZY/enQANCscGguoNLtPXl1tsVKzRzFYv/Hhi+xWPt0V+hJuT++KwSQ==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.2-ecad",
-        "@ecadlabs/beacon-transport-matrix": "4.8.2-ecad",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
-        "@ecadlabs/beacon-transport-walletconnect": "4.8.2-ecad",
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
-        "@ecadlabs/beacon-ui": "4.8.2-ecad",
-        "@ecadlabs/beacon-utils": "4.8.2-ecad",
+        "@ecadlabs/beacon-core": "4.8.3-ecad",
+        "@ecadlabs/beacon-transport-matrix": "4.8.3-ecad",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.3-ecad",
+        "@ecadlabs/beacon-transport-walletconnect": "4.8.3-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
+        "@ecadlabs/beacon-ui": "4.8.3-ecad",
+        "@ecadlabs/beacon-utils": "4.8.3-ecad",
         "@walletconnect/types": "^2.23.9",
         "broadcast-channel": "^7.3.0",
         "bs58check": "4.0.0"
@@ -2188,64 +2188,61 @@
       }
     },
     "node_modules/@ecadlabs/beacon-transport-matrix": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.2-ecad.tgz",
-      "integrity": "sha512-Qpu847+roKVnpck5cHsYgRm5hh57bogZCRxepWF0PVpYWcByDGwDw7E8DBitXSauTxo5gerx9R1Ubl4UDKRaxA==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-matrix/-/beacon-transport-matrix-4.8.3-ecad.tgz",
+      "integrity": "sha512-ALJWKFMi2ml7hCpxZyn69S90UxdaPLgCXFbXm2+yt55ZqnzUC/+WZLiRHyIAcf6dEb7SApRQKMa1VJU1LnFXxA==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.2-ecad",
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
-        "@ecadlabs/beacon-utils": "4.8.2-ecad",
+        "@ecadlabs/beacon-core": "4.8.3-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
+        "@ecadlabs/beacon-utils": "4.8.3-ecad",
         "@stablelib/blake2b": "^2.0.1",
         "@stablelib/utf8": "^2.1.0"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-postmessage": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.2-ecad.tgz",
-      "integrity": "sha512-0iQx2cCi/PGWsxalWu6776P7VGQKYipR/Xyxuck6hQub3WxQ2vHRzu49QrVvoMiE2K0aORYz4mB+WikI8RigiQ==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-postmessage/-/beacon-transport-postmessage-4.8.3-ecad.tgz",
+      "integrity": "sha512-hJ+wSYJf1Me9V4Efq2YVwQgLyygHqRvKh4njLvQTGcl2c9f5zkEIkrbpf/t32BrQN67jApU3O3QeDqvaupdwBA==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.2-ecad",
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
-        "@ecadlabs/beacon-utils": "4.8.2-ecad"
+        "@ecadlabs/beacon-core": "4.8.3-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
+        "@ecadlabs/beacon-utils": "4.8.3-ecad"
       }
     },
     "node_modules/@ecadlabs/beacon-transport-walletconnect": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.2-ecad.tgz",
-      "integrity": "sha512-WrhBIqpBUIuqyU8B3m+XdtGKNFvBRzEq8Vbhv/Iv0gpgAlU5HjUHKMGYcCUeCrk4UjldKMJEDKZNCEHs7NKeIQ==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-transport-walletconnect/-/beacon-transport-walletconnect-4.8.3-ecad.tgz",
+      "integrity": "sha512-IhAOGEpZmS8qxJeSzKeWBg8wHp60Y8xiOer3Vc5OAYaubyhn7YsBQbLH05kV2hM8T8zQjcrqfweXENNX3nexdA==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.2-ecad",
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
-        "@ecadlabs/beacon-utils": "4.8.2-ecad",
+        "@ecadlabs/beacon-core": "4.8.3-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
+        "@ecadlabs/beacon-utils": "4.8.3-ecad",
         "@walletconnect/sign-client": "^2.23.9",
         "@walletconnect/types": "^2.23.9",
         "@walletconnect/utils": "^2.23.9"
       }
     },
     "node_modules/@ecadlabs/beacon-types": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.2-ecad.tgz",
-      "integrity": "sha512-VBdn9e41G5FFcVTKmzym5x1rISLaffkxIPhwAjheVhh0a6wrE60MkkeDlqn0Wc+37jsXYhHa1Qa/ezHhka+2JQ==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-types/-/beacon-types-4.8.3-ecad.tgz",
+      "integrity": "sha512-fN0sHqhNYD2EhbKk6VlRMPMRsYlMvQdwvRk/ImsCbzLcAY3tQ77teXFhiPjD76GIbbr51fw53dcKxRd2YTK/4g==",
       "license": "ISC",
       "dependencies": {
         "@types/chrome": "^0.1.40"
       }
     },
     "node_modules/@ecadlabs/beacon-ui": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.2-ecad.tgz",
-      "integrity": "sha512-NpLuJ2np3rAH6lbqIF84Xud8UU7UaevTHGo3H2hmLfNk4Q2i4npyzKjt1qijcJsGwiCI1JFwV8rLrVVW3VrJug==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-ui/-/beacon-ui-4.8.3-ecad.tgz",
+      "integrity": "sha512-SDLitKrzxfWoT7VDSyVnnHg+XLIe+lL2B9nwpqatKxvqXsEPSFcMzpHF1nhuXV62DtKCNDRBT5VuLSRxsItS0Q==",
       "license": "ISC",
       "dependencies": {
-        "@ecadlabs/beacon-core": "4.8.2-ecad",
-        "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
-        "@ecadlabs/beacon-utils": "4.8.2-ecad",
-        "@walletconnect/utils": "^2.23.9",
-        "qrcode-svg": "^1.1.0",
+        "@ecadlabs/beacon-core": "4.8.3-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
+        "qrcode": "^1.5.3",
         "react": "^19.2.5",
         "react-dom": "^19.2.5"
       },
@@ -2305,9 +2302,9 @@
       }
     },
     "node_modules/@ecadlabs/beacon-utils": {
-      "version": "4.8.2-ecad",
-      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.2-ecad.tgz",
-      "integrity": "sha512-gitigcE8qWV7qIMjFsG6BWAgjV3kP+6/5pMpQQm1RHXLx3PHiNKQ7QkR/co5pUqz2OIYcPZ9HaVadN3QdD7qvQ==",
+      "version": "4.8.3-ecad",
+      "resolved": "https://registry.npmjs.org/@ecadlabs/beacon-utils/-/beacon-utils-4.8.3-ecad.tgz",
+      "integrity": "sha512-XK18ciKOmp2ay+qbsqYtiOifRbnh0aIeYlRQepp+ipNM3vZWcYCe/4tTunwIwf8hC/aIslHVUAM99F1dyYLBPA==",
       "license": "ISC",
       "dependencies": {
         "@stablelib/blake2b": "^2.0.1",
@@ -13388,15 +13385,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/qrcode-svg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/qrcode-svg/-/qrcode-svg-1.1.0.tgz",
-      "integrity": "sha512-XyQCIXux1zEIA3NPb0AeR8UMYvXZzWEhgdBgBjH9gO7M48H9uoHzviNz8pXw3UzrAcxRRRn9gxHewAVK7bn9qw==",
-      "license": "MIT",
-      "bin": {
-        "qrcode-svg": "bin/qrcode-svg.js"
-      }
-    },
     "node_modules/qrcode/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -17243,8 +17231,8 @@
       "version": "24.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@ecadlabs/beacon-dapp": "4.8.2-ecad",
-        "@ecadlabs/beacon-types": "4.8.2-ecad",
+        "@ecadlabs/beacon-dapp": "4.8.3-ecad",
+        "@ecadlabs/beacon-types": "4.8.3-ecad",
         "@taquito/core": "^24.3.0",
         "@taquito/taquito": "^24.3.0",
         "@taquito/utils": "^24.3.0",
@@ -17252,8 +17240,8 @@
         "util": "^0.12.5"
       },
       "devDependencies": {
-        "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
-        "@ecadlabs/beacon-ui": "4.8.2-ecad",
+        "@ecadlabs/beacon-transport-postmessage": "4.8.3-ecad",
+        "@ecadlabs/beacon-ui": "4.8.3-ecad",
         "@types/bluebird": "^3.5.42",
         "@types/chrome": "0.1.40",
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -97,14 +97,14 @@
     "vitest": "^4.1.4"
   },
   "overrides": {
-    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.2-ecad",
-    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.2-ecad",
-    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.2-ecad",
-    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.2-ecad",
-    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.2-ecad",
-    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.2-ecad",
-    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.2-ecad",
-    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.2-ecad",
+    "@airgap/beacon-dapp": "npm:@ecadlabs/beacon-dapp@4.8.3-ecad",
+    "@airgap/beacon-core": "npm:@ecadlabs/beacon-core@4.8.3-ecad",
+    "@airgap/beacon-types": "npm:@ecadlabs/beacon-types@4.8.3-ecad",
+    "@airgap/beacon-utils": "npm:@ecadlabs/beacon-utils@4.8.3-ecad",
+    "@airgap/beacon-ui": "npm:@ecadlabs/beacon-ui@4.8.3-ecad",
+    "@airgap/beacon-transport-matrix": "npm:@ecadlabs/beacon-transport-matrix@4.8.3-ecad",
+    "@airgap/beacon-transport-postmessage": "npm:@ecadlabs/beacon-transport-postmessage@4.8.3-ecad",
+    "@airgap/beacon-transport-walletconnect": "npm:@ecadlabs/beacon-transport-walletconnect@4.8.3-ecad",
     "follow-redirects": "^1.16.0",
     "lodash": "4.18.1",
     "anymatch": {

--- a/packages/taquito-beacon-wallet/package.json
+++ b/packages/taquito-beacon-wallet/package.json
@@ -70,8 +70,8 @@
     ]
   },
   "dependencies": {
-    "@ecadlabs/beacon-dapp": "4.8.2-ecad",
-    "@ecadlabs/beacon-types": "4.8.2-ecad",
+    "@ecadlabs/beacon-dapp": "4.8.3-ecad",
+    "@ecadlabs/beacon-types": "4.8.3-ecad",
     "@taquito/core": "^24.3.0",
     "@taquito/taquito": "^24.3.0",
     "@taquito/utils": "^24.3.0",
@@ -79,8 +79,8 @@
     "util": "^0.12.5"
   },
   "devDependencies": {
-    "@ecadlabs/beacon-transport-postmessage": "4.8.2-ecad",
-    "@ecadlabs/beacon-ui": "4.8.2-ecad",
+    "@ecadlabs/beacon-transport-postmessage": "4.8.3-ecad",
+    "@ecadlabs/beacon-ui": "4.8.3-ecad",
     "@types/bluebird": "^3.5.42",
     "@types/chrome": "0.1.40",
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Upgrade root Beacon npm overrides from @ecadlabs/* 4.8.2-ecad to 4.8.3-ecad
- Upgrade @taquito/beacon-wallet direct Beacon dependencies and dev dependencies to 4.8.3-ecad
- Regenerate package-lock.json for the updated ECAD Beacon tarballs

## Validation
- npm install
- npx nx test @taquito/beacon-wallet
- npx nx lint @taquito/beacon-wallet (passes with existing no-explicit-any warnings)
- git diff --check

## Note
- npx nx build @taquito/beacon-wallet currently fails before building Beacon wallet in dependency @taquito/signer with TS2354: module 'tslib' cannot be found at packages/taquito-signer/src/in-memory-signer.ts:158. @taquito/signer does not declare tslib directly, so I left that separate dependency issue out of this Beacon bump.