### PR TITLE
Update RPC node docs

### DIFF
--- a/website/public/rpc_nodes.json
+++ b/website/public/rpc_nodes.json
@@ -4,7 +4,8 @@
       "id": "ecadinfra",
       "name": "ECAD Infra",
       "website": "https://www.ecadinfra.com/",
-      "status_page": "https://tezos.status.ecadinfra.com"
+      "status_page": "https://status.ecadinfra.com/",
+      "notice": "ECAD Infra public RPC endpoints will stop serving traffic on May 31, 2026."
     },
     {
       "id": "smartpy",
@@ -29,17 +30,14 @@
     {
       "net": "mainnet",
       "url": "https://mainnet.tezos.ecadinfra.com",
-      "provider": "ecadinfra"
+      "provider": "ecadinfra",
+      "shutdown_date": "2026-05-31"
     },
     {
       "net": "shadownet",
       "url": "https://shadownet.tezos.ecadinfra.com",
-      "provider": "ecadinfra"
-    },
-    {
-      "net": "tallinnnet",
-      "url": "https://tallinnnet.tezos.ecadinfra.com",
-      "provider": "ecadinfra"
+      "provider": "ecadinfra",
+      "shutdown_date": "2026-05-31"
     },
     {
       "net": "mainnet",
@@ -57,8 +55,8 @@
       "provider": "tezosfoundation"
     },
     {
-      "net": "tallinnnet",
-      "url": "https://rpc.tallinnnet.teztnets.com",
+      "net": "ushuaianet",
+      "url": "https://rpc.ushuaianet.teztnets.com",
       "provider": "tezosfoundation"
     },
     {
@@ -69,11 +67,6 @@
     {
       "net": "shadownet",
       "url": "https://rpc.tzkt.io/shadownet",
-      "provider": "tzkt"
-    },
-    {
-      "net": "tallinnnet",
-      "url": "https://rpc.tzkt.io/tallinnnet",
       "provider": "tzkt"
     }
   ]

--- a/website/src/content/docs/24.3.0/rpc_nodes.mdx
+++ b/website/src/content/docs/24.3.0/rpc_nodes.mdx
@@ -8,7 +8,9 @@ import BlockReceivedAgo from '@components/docs/BlockReceivedAgo.astro';
 import BlockLevel from '@components/docs/BlockLevel.astro';
 import BlockProtocol from '@components/docs/BlockProtocol.astro';
 
-An RPC (Remote Procedure Call) node is a server that provides an interface for interacting with the Tezos blockchain. It allows applications like Taquito to query blockchain data (such as account balances, contract storage, and block information) and broadcast transactions to the network. Rather than running your own Tezos node, you can connect to public or commercial RPC nodes to access the blockchain.
+An RPC (Remote Procedure Call) node is a server that provides an interface for interacting with the Tezos blockchain. It allows applications like Taquito to query blockchain data (such as account balances, contract storage, and block information) and broadcast transactions to the network. Rather than running your own Tezos node, you can connect to public RPC nodes to access the blockchain.
+
+**ECAD Infra public RPC shutdown:** ECAD Infra endpoints at `*.tezos.ecadinfra.com` will stop serving traffic on May 31, 2026. If your wallet, dApp, indexer, or tooling uses these endpoints, migrate to another RPC provider before that date. See the [public announcement](https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064).
 
 ## What to consider when choosing a node
 
@@ -20,7 +22,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 ### Community nodes
 
-<Tabs defaultValue="mainnet" values={[{"label": "Mainnet", "value": "mainnet"},{"label": "Shadownet", "value": "shadownet"},{"label": "Tallinnnet", "value": "tallinnnet"}]}>
+<Tabs defaultValue="mainnet" values={[{"label": "Mainnet", "value": "mainnet"},{"label": "Shadownet", "value": "shadownet"},{"label": "Ushuaianet", "value": "ushuaianet"}]}>
 
 <TabItem value="mainnet">
 
@@ -31,7 +33,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 | Provider         | URL                                   | Block | Protocol | Timestamp                                                                           | Received                                                                      |
 | ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ECAD Infra       | https://mainnet.tezos.ecadinfra.com   | <BlockLevel network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockProtocol network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockTimestamp network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> |
+| <s>ECAD Infra</s><br /><small><a href="https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064">Stops May 31, 2026</a></small> | https://mainnet.tezos.ecadinfra.com   | <BlockLevel network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockProtocol network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockTimestamp network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> |
 | SmartPy          | https://mainnet.smartpy.io            | <BlockLevel network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> | <BlockProtocol network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> | <BlockTimestamp network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> |
 | Tezos Foundation | https://rpc.tzbeta.net                | <BlockLevel network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> | <BlockProtocol network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> | <BlockTimestamp network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> |
 | TzKT             | https://rpc.tzkt.io/mainnet           | <BlockLevel network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> | <BlockProtocol network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> | <BlockTimestamp network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> |
@@ -51,7 +53,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 | Provider         | URL                                   | Block | Protocol | Timestamp                                                                           | Received                                                                      |
 | ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ECAD Infra       | https://shadownet.tezos.ecadinfra.com | <BlockLevel network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockProtocol network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockTimestamp network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> |
+| <s>ECAD Infra</s><br /><small><a href="https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064">Stops May 31, 2026</a></small> | https://shadownet.tezos.ecadinfra.com | <BlockLevel network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockProtocol network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockTimestamp network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> |
 | Tezos Foundation | https://rpc.shadownet.teztnets.com    | <BlockLevel network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> | <BlockProtocol network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> | <BlockTimestamp network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> |
 | TzKT             | https://rpc.tzkt.io/shadownet         | <BlockLevel network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> | <BlockProtocol network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> | <BlockTimestamp network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> |
 
@@ -61,7 +63,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 </TabItem>
 
-<TabItem value="tallinnnet">
+<TabItem value="ushuaianet">
 
 <div style={{"overflowX":"auto","width":"100%","display":"block"}}>
 
@@ -70,9 +72,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 | Provider         | URL                                   | Block | Protocol | Timestamp                                                                           | Received                                                                      |
 | ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ECAD Infra       | https://tallinnnet.tezos.ecadinfra.com | <BlockLevel network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> | <BlockProtocol network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> | <BlockTimestamp network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> |
-| Tezos Foundation | https://rpc.tallinnnet.teztnets.com   | <BlockLevel network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> | <BlockProtocol network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> | <BlockTimestamp network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> | <BlockReceivedAgo network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> |
-| TzKT             | https://rpc.tzkt.io/tallinnnet        | <BlockLevel network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> | <BlockProtocol network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> | <BlockTimestamp network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> | <BlockReceivedAgo network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> |
+| Tezos Foundation | https://rpc.ushuaianet.teztnets.com   | <BlockLevel network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> | <BlockProtocol network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> | <BlockTimestamp network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> | <BlockReceivedAgo network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> |
 
 </div>
 
@@ -85,14 +85,6 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 You can find a machine readable list of RPC nodes in [rpc_nodes.json](/rpc_nodes.json).
 
 If you are aware of a public node missing from our list or our information is inaccurate, please let us know by submitting an issue or pull request on our [GitHub page](https://github.com/ecadlabs/taquito).
-
-### Commercial nodes
-
-| Provider | Values                 |
-| -------- | ----------------------- |
-| Exaion   | https://node.exaion.com |
-
-If you are aware of a commercial node missing from our list or our information is inaccurate, please let us know by submitting an issue or pull request on our [GitHub page](https://github.com/ecadlabs/taquito).
 
 ## How to run a node
 

--- a/website/src/content/docs/next/rpc_nodes.mdx
+++ b/website/src/content/docs/next/rpc_nodes.mdx
@@ -8,7 +8,9 @@ import BlockReceivedAgo from '@components/docs/BlockReceivedAgo.astro';
 import BlockLevel from '@components/docs/BlockLevel.astro';
 import BlockProtocol from '@components/docs/BlockProtocol.astro';
 
-An RPC (Remote Procedure Call) node is a server that provides an interface for interacting with the Tezos blockchain. It allows applications like Taquito to query blockchain data (such as account balances, contract storage, and block information) and broadcast transactions to the network. Rather than running your own Tezos node, you can connect to public or commercial RPC nodes to access the blockchain.
+An RPC (Remote Procedure Call) node is a server that provides an interface for interacting with the Tezos blockchain. It allows applications like Taquito to query blockchain data (such as account balances, contract storage, and block information) and broadcast transactions to the network. Rather than running your own Tezos node, you can connect to public RPC nodes to access the blockchain.
+
+**ECAD Infra public RPC shutdown:** ECAD Infra endpoints at `*.tezos.ecadinfra.com` will stop serving traffic on May 31, 2026. If your wallet, dApp, indexer, or tooling uses these endpoints, migrate to another RPC provider before that date. See the [public announcement](https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064).
 
 ## What to consider when choosing a node
 
@@ -20,7 +22,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 ### Community nodes
 
-<Tabs defaultValue="mainnet" values={[{"label": "Mainnet", "value": "mainnet"},{"label": "Shadownet", "value": "shadownet"},{"label": "Tallinnnet", "value": "tallinnnet"}]}>
+<Tabs defaultValue="mainnet" values={[{"label": "Mainnet", "value": "mainnet"},{"label": "Shadownet", "value": "shadownet"},{"label": "Ushuaianet", "value": "ushuaianet"}]}>
 
 <TabItem value="mainnet">
 
@@ -31,7 +33,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 | Provider         | URL                                   | Block | Protocol | Timestamp                                                                           | Received                                                                      |
 | ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ECAD Infra       | https://mainnet.tezos.ecadinfra.com   | <BlockLevel network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockProtocol network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockTimestamp network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> |
+| <s>ECAD Infra</s><br /><small><a href="https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064">Stops May 31, 2026</a></small> | https://mainnet.tezos.ecadinfra.com   | <BlockLevel network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockProtocol network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockTimestamp network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://mainnet.tezos.ecadinfra.com" /> |
 | SmartPy          | https://mainnet.smartpy.io            | <BlockLevel network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> | <BlockProtocol network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> | <BlockTimestamp network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://mainnet.smartpy.io" /> |
 | Tezos Foundation | https://rpc.tzbeta.net                | <BlockLevel network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> | <BlockProtocol network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> | <BlockTimestamp network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://rpc.tzbeta.net" /> |
 | TzKT             | https://rpc.tzkt.io/mainnet           | <BlockLevel network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> | <BlockProtocol network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> | <BlockTimestamp network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> | <BlockReceivedAgo network="mainnet" rpcUrl="https://rpc.tzkt.io/mainnet" /> |
@@ -51,7 +53,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 | Provider         | URL                                   | Block | Protocol | Timestamp                                                                           | Received                                                                      |
 | ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ECAD Infra       | https://shadownet.tezos.ecadinfra.com | <BlockLevel network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockProtocol network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockTimestamp network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> |
+| <s>ECAD Infra</s><br /><small><a href="https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064">Stops May 31, 2026</a></small> | https://shadownet.tezos.ecadinfra.com | <BlockLevel network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockProtocol network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockTimestamp network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://shadownet.tezos.ecadinfra.com" /> |
 | Tezos Foundation | https://rpc.shadownet.teztnets.com    | <BlockLevel network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> | <BlockProtocol network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> | <BlockTimestamp network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://rpc.shadownet.teztnets.com" /> |
 | TzKT             | https://rpc.tzkt.io/shadownet         | <BlockLevel network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> | <BlockProtocol network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> | <BlockTimestamp network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> | <BlockReceivedAgo network="shadownet" rpcUrl="https://rpc.tzkt.io/shadownet" /> |
 
@@ -61,7 +63,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 </TabItem>
 
-<TabItem value="tallinnnet">
+<TabItem value="ushuaianet">
 
 <div style={{"overflowX":"auto","width":"100%","display":"block"}}>
 
@@ -70,9 +72,7 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 
 | Provider         | URL                                   | Block | Protocol | Timestamp                                                                           | Received                                                                      |
 | ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |
-| ECAD Infra       | https://tallinnnet.tezos.ecadinfra.com | <BlockLevel network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> | <BlockProtocol network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> | <BlockTimestamp network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> | <BlockReceivedAgo network="tallinnnet" rpcUrl="https://tallinnnet.tezos.ecadinfra.com" /> |
-| Tezos Foundation | https://rpc.tallinnnet.teztnets.com   | <BlockLevel network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> | <BlockProtocol network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> | <BlockTimestamp network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> | <BlockReceivedAgo network="tallinnnet" rpcUrl="https://rpc.tallinnnet.teztnets.com" /> |
-| TzKT             | https://rpc.tzkt.io/tallinnnet        | <BlockLevel network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> | <BlockProtocol network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> | <BlockTimestamp network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> | <BlockReceivedAgo network="tallinnnet" rpcUrl="https://rpc.tzkt.io/tallinnnet" /> |
+| Tezos Foundation | https://rpc.ushuaianet.teztnets.com   | <BlockLevel network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> | <BlockProtocol network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> | <BlockTimestamp network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> | <BlockReceivedAgo network="ushuaianet" rpcUrl="https://rpc.ushuaianet.teztnets.com" /> |
 
 </div>
 
@@ -85,14 +85,6 @@ An RPC (Remote Procedure Call) node is a server that provides an interface for i
 You can find a machine readable list of RPC nodes in [rpc_nodes.json](/rpc_nodes.json).
 
 If you are aware of a public node missing from our list or our information is inaccurate, please let us know by submitting an issue or pull request on our [GitHub page](https://github.com/ecadlabs/taquito).
-
-### Commercial nodes
-
-| Provider | Values                 |
-| -------- | ----------------------- |
-| Exaion   | https://node.exaion.com |
-
-If you are aware of a commercial node missing from our list or our information is inaccurate, please let us know by submitting an issue or pull request on our [GitHub page](https://github.com/ecadlabs/taquito).
 
 ## How to run a node
 

--- a/website/src/scripts/generate-rpc-table.js
+++ b/website/src/scripts/generate-rpc-table.js
@@ -16,6 +16,7 @@ const __dirname = path.dirname(__filename);
 
 const jsonPath = path.join(__dirname, '../../public/rpc_nodes.json');
 const data = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+const shutdownNoticeUrl = 'https://forum.tezosagora.org/t/public-rpc-service-shutdown-may-31-2026/7064';
 
 // Build a map of provider ID to provider name
 const providerMap = {};
@@ -33,6 +34,7 @@ for (const endpoint of data.rpc_endpoints) {
     provider: providerMap[endpoint.provider] || endpoint.provider,
     url: endpoint.url,
     net: endpoint.net,
+    shutdownDate: endpoint.shutdown_date,
   });
 }
 
@@ -44,7 +46,10 @@ function generateTable(network, endpoints) {
   lines.push(`| ---------------- | ------------------------------------- | ----- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------- |`);
 
   for (const ep of endpoints) {
-    const providerPadded = ep.provider.padEnd(16);
+    const provider = ep.shutdownDate
+      ? `<s>${ep.provider}</s><br /><small><a href="${shutdownNoticeUrl}">Stops ${new Date(`${ep.shutdownDate}T00:00:00Z`).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' })}</a></small>`
+      : ep.provider;
+    const providerPadded = provider.padEnd(16);
     const urlPadded = ep.url.padEnd(37);
     const blockComponent = `<BlockLevel network="${network}" rpcUrl="${ep.url}" />`;
     const protocolComponent = `<BlockProtocol network="${network}" rpcUrl="${ep.url}" />`;

--- a/website/src/scripts/rpc-block-controller.ts
+++ b/website/src/scripts/rpc-block-controller.ts
@@ -17,11 +17,14 @@ export interface ControllerState {
   data: BlockData | null;
   loading: boolean;
   error: boolean;
+  inFlight: boolean;
   subscribers: Set<() => void>;
   intervalId: number | null;
   visibleCount: number;
   network: string;
 }
+
+const REQUEST_TIMEOUT_MS = 3500;
 
 export interface Controller {
   state: ControllerState;
@@ -43,12 +46,12 @@ declare global {
 
 export function getPollingIntervalByNetwork(network: string): number {
   if (network === 'shadownet' || network === 'tallinnnet') {
-    return 4000;
+    return 15000;
   }
   if (network === 'mainnet') {
-    return 8000;
+    return 30000;
   }
-  return 8000;
+  return 30000;
 }
 
 export function getControllers(): Map<string, Controller> {
@@ -77,6 +80,7 @@ export function getController(rpcUrl: string, network: string): Controller {
     data: null,
     loading: true,
     error: false,
+    inFlight: false,
     subscribers: new Set(),
     intervalId: null,
     visibleCount: 0,
@@ -88,13 +92,21 @@ export function getController(rpcUrl: string, network: string): Controller {
   };
 
   const fetchLatestBlock = async () => {
+    if (state.inFlight) return;
+
+    state.inFlight = true;
+    const abortController = new AbortController();
+    const timeoutId = window.setTimeout(() => abortController.abort(), REQUEST_TIMEOUT_MS);
+
     try {
       if (state.data === null) {
         state.loading = true;
         state.error = false;
         notify();
       }
-      const response = await fetch(`${rpcUrl}/chains/main/blocks/head`);
+      const response = await fetch(`${rpcUrl}/chains/main/blocks/head`, {
+        signal: abortController.signal
+      });
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
@@ -110,6 +122,9 @@ export function getController(rpcUrl: string, network: string): Controller {
       state.loading = false;
       state.error = true;
       notify();
+    } finally {
+      window.clearTimeout(timeoutId);
+      state.inFlight = false;
     }
   };
 


### PR DESCRIPTION
## Summary
- mark ECAD Infra public RPC endpoints as shutting down on May 31, 2026
- remove Tallinnnet and commercial node entries from the RPC node docs/list
- add the Tezos Foundation Ushuaianet public RPC endpoint
- make RPC status polling less aggressive and add request timeouts

## Testing
- npm run generate:rpc
- npm run build