### PR TITLE
Initialize RPC status widgets on initial page load

### DIFF
--- a/website/src/components/docs/BlockLevel.astro
+++ b/website/src/components/docs/BlockLevel.astro
@@ -79,6 +79,12 @@ const { network, rpcUrl } = Astro.props;
     });
   }
 
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAllLevels);
+  } else {
+    initAllLevels();
+  }
+
   document.addEventListener('astro:page-load', initAllLevels);
 
   const observer = new MutationObserver(() => {

--- a/website/src/components/docs/BlockProtocol.astro
+++ b/website/src/components/docs/BlockProtocol.astro
@@ -80,6 +80,12 @@ const { network, rpcUrl } = Astro.props;
     });
   }
 
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAllProtocols);
+  } else {
+    initAllProtocols();
+  }
+
   document.addEventListener('astro:page-load', initAllProtocols);
 
   const observer = new MutationObserver(() => {

--- a/website/src/components/docs/BlockReceivedAgo.astro
+++ b/website/src/components/docs/BlockReceivedAgo.astro
@@ -96,6 +96,12 @@ const { network, rpcUrl } = Astro.props;
     });
   }
 
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAllReceivedAgo);
+  } else {
+    initAllReceivedAgo();
+  }
+
   document.addEventListener('astro:page-load', initAllReceivedAgo);
 
   const observer = new MutationObserver(() => {

--- a/website/src/components/docs/BlockTimestamp.astro
+++ b/website/src/components/docs/BlockTimestamp.astro
@@ -75,6 +75,12 @@ const { network, rpcUrl } = Astro.props;
     });
   }
 
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAllTimestamps);
+  } else {
+    initAllTimestamps();
+  }
+
   document.addEventListener('astro:page-load', initAllTimestamps);
 
   const observer = new MutationObserver(() => {


### PR DESCRIPTION
## Summary
- initialize RPC status widgets on normal initial page load, not only Astro page transitions or later DOM mutations
- keeps the existing astro:page-load and MutationObserver handling for client-side navigation and dynamic content

## Why
On the deployed static docs page the status cells can remain at the server-rendered `Loading...` state with no RPC network requests. The widget modules can execute after the initial DOM has already been parsed, leaving no later mutation to trigger initialization.

## Testing
- npm run build