### PR TITLE
ci: migrate shadownet RPC to public teztnets node + add RPC health monitor

### DIFF
--- a/.github/scripts/poll-rpc-health.sh
+++ b/.github/scripts/poll-rpc-health.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Polls a Tezos RPC node's health for a bounded window and emits a JSONL
+# timeline plus a human-readable verdict. Built to run alongside the shadownet
+# integration tests in CI (which can take up to ~30 min) so RPC flakiness can be
+# correlated with test failures after the fact. The node is public HTTPS, so
+# this needs no tailnet access.
+#
+# All knobs are env-driven so it doubles as a local debugging tool:
+#   RPC_URL=https://rpc.shadownet.teztnets.com \
+#   POLL_MAX_DURATION_SECONDS=120 POLL_INTERVAL_SECONDS=10 \
+#   bash .github/scripts/poll-rpc-health.sh
+set -euo pipefail
+
+rpc_url="${RPC_URL:-https://rpc.shadownet.teztnets.com}"
+rpc_url="${rpc_url%/}"
+interval_seconds="${POLL_INTERVAL_SECONDS:-15}"
+# 31 min: a touch over the ~30 min integration-test ceiling so the timeline
+# always covers the whole run rather than cutting off just before the end.
+max_duration_seconds="${POLL_MAX_DURATION_SECONDS:-1860}"
+connect_timeout_seconds="${POLL_CONNECT_TIMEOUT_SECONDS:-5}"
+max_time_seconds="${POLL_MAX_TIME_SECONDS:-15}"
+out_dir="${POLL_OUTPUT_DIR:-ci-metrics}"
+out_file="${POLL_OUTPUT_FILE:-${out_dir}/rpc-health.jsonl}"
+
+mkdir -p "$(dirname "$out_file")"
+: > "$out_file"
+
+probe_url="${rpc_url}/chains/main/blocks/head/header"
+start_epoch="$(date +%s)"
+deadline=$((start_epoch + max_duration_seconds))
+
+printf 'RPC health monitor: polling %s every %ss for up to %ss\n' \
+  "$probe_url" "$interval_seconds" "$max_duration_seconds"
+
+# Summarize on exit no matter how we leave the loop (deadline, SIGTERM when run
+# as a background sidecar, etc.) so a killed monitor still leaves a verdict.
+summarize() {
+  if [ ! -s "$out_file" ]; then
+    echo "RPC health monitor: no samples collected."
+    return 0
+  fi
+
+  local summary
+  summary="$(jq -s -r '
+    (length) as $n
+    | (map(select(.http_code != "200" or .level == null)) | length) as $errs
+    | (map(select(.level != null) | .level)) as $levels
+    | (map(select(.head_lag_s != null) | .head_lag_s)) as $lags
+    | (map(.total_s)) as $totals
+    | {
+        samples: $n,
+        errors: $errs,
+        error_rate_pct: (if $n > 0 then (($errs / $n) * 100 | floor) else 0 end),
+        first_level: ($levels | first),
+        last_level: ($levels | last),
+        levels_advanced: (if ($levels | length) > 1 then (($levels | last) - ($levels | first)) else 0 end),
+        max_head_lag_s: ($lags | max),
+        max_total_s: ($totals | max)
+      }' "$out_file")"
+
+  local samples errors error_rate first_level last_level advanced max_lag max_total
+  samples="$(jq -r '.samples' <<<"$summary")"
+  errors="$(jq -r '.errors' <<<"$summary")"
+  error_rate="$(jq -r '.error_rate_pct' <<<"$summary")"
+  first_level="$(jq -r '.first_level // "n/a"' <<<"$summary")"
+  last_level="$(jq -r '.last_level // "n/a"' <<<"$summary")"
+  advanced="$(jq -r '.levels_advanced' <<<"$summary")"
+  max_lag="$(jq -r '.max_head_lag_s // "n/a"' <<<"$summary")"
+  max_total="$(jq -r '.max_total_s // "n/a"' <<<"$summary")"
+
+  # Verdict: HEALTHY = no failed probes and the head advanced; DEGRADED = some
+  # failures but the chain still moved; OUTAGE = every probe failed or the head
+  # never advanced across the window (node up but stuck).
+  local verdict
+  if [ "$errors" -eq 0 ] && [ "$advanced" -gt 0 ]; then
+    verdict='HEALTHY'
+  elif [ "$errors" -ge "$samples" ] || { [ "$advanced" -le 0 ] && [ "$samples" -gt 1 ]; }; then
+    verdict='OUTAGE'
+  else
+    verdict='DEGRADED'
+  fi
+
+  local report
+  report="$(
+    echo "### RPC health monitor: ${verdict}"
+    echo "- node: ${rpc_url}"
+    echo "- samples: ${samples} (errors: ${errors}, ${error_rate}%)"
+    echo "- level: ${first_level} -> ${last_level} (advanced ${advanced})"
+    echo "- max head lag: ${max_lag}s"
+    echo "- slowest response: ${max_total}s"
+  )"
+  echo "$report"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    echo "$report" >> "$GITHUB_STEP_SUMMARY"
+  fi
+
+  if [ "$verdict" = 'OUTAGE' ] && [ "${POLL_FAIL_ON_OUTAGE:-false}" = 'true' ]; then
+    return 1
+  fi
+  return 0
+}
+trap summarize EXIT
+
+while :; do
+  now="$(date +%s)"
+  [ "$now" -ge "$deadline" ] && break
+
+  iso="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+  body_file="$(mktemp)"
+
+  set +e
+  metrics="$(
+    curl -sS -o "$body_file" \
+      --connect-timeout "$connect_timeout_seconds" \
+      --max-time "$max_time_seconds" \
+      -w '%{http_code} %{time_starttransfer} %{time_total} %{remote_ip}' \
+      "$probe_url" 2>/dev/null
+  )"
+  curl_rc=$?
+  set -e
+  if [ "$curl_rc" -ne 0 ] || [ -z "$metrics" ]; then
+    metrics='000 0 0 -'
+  fi
+  read -r http_code ttfb total remote_ip <<<"$metrics"
+
+  line=''
+  if [ "$http_code" = '200' ]; then
+    # jq parses the head header for level + timestamp and derives head lag
+    # (wall-clock seconds behind the chain) in one pass. A 200 with an
+    # unexpected body fails here and falls through to the error branch below.
+    line="$(
+      jq -c \
+        --arg ts "$iso" \
+        --arg code "$http_code" \
+        --argjson ttfb "$ttfb" \
+        --argjson total "$total" \
+        --arg ip "$remote_ip" \
+        '{ts: $ts, http_code: $code, ttfb_s: $ttfb, total_s: $total, remote_ip: $ip,
+          level: .level, head_ts: .timestamp,
+          head_lag_s: ((now - (.timestamp | fromdateiso8601)) | floor)}' \
+        "$body_file" 2>/dev/null || echo ''
+    )"
+  fi
+  if [ -z "$line" ]; then
+    line="$(
+      jq -nc \
+        --arg ts "$iso" \
+        --arg code "$http_code" \
+        --argjson ttfb "${ttfb:-0}" \
+        --argjson total "${total:-0}" \
+        --arg ip "$remote_ip" \
+        '{ts: $ts, http_code: $code, ttfb_s: $ttfb, total_s: $total, remote_ip: $ip,
+          level: null, head_ts: null, head_lag_s: null}'
+    )"
+  fi
+  echo "$line" >> "$out_file"
+  echo "$line"
+
+  rm -f "$body_file"
+
+  # Stop sleeping if the next interval would run past the deadline anyway.
+  [ "$(( $(date +%s) + interval_seconds ))" -ge "$deadline" ] && break
+  sleep "$interval_seconds"
+done

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,16 +126,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - if: ${{ !github.event.pull_request.head.repo.fork }}
-        name: Tailscale
-        # Pinned to SHA to prevent supply-chain attacks via mutable tags.
-        # Verify before bumping: https://github.com/tailscale/github-action/releases
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
-        with:
-          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
-          tags: tag:github-runner
-          ping: ecad-tezos-shadownet-rolling-1.i.ecadinfra.com
       - name: Probe keygen before shadownet tests
         shell: bash
         run: |
@@ -243,16 +233,6 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - if: ${{ !github.event.pull_request.head.repo.fork }}
-        name: Tailscale
-        # Pinned to SHA to prevent supply-chain attacks via mutable tags.
-        # Verify before bumping: https://github.com/tailscale/github-action/releases
-        uses: tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8 # v4.1.2
-        with:
-          oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_SECRET }}
-          tags: tag:github-runner
-          ping: ecad-tezos-shadownet-rolling-1.i.ecadinfra.com
       - name: Probe keygen before sapling tests
         shell: bash
         run: |
@@ -334,6 +314,33 @@ jobs:
         with:
           name: itest-timing-sapling
           path: ci-metrics/itest-sapling.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  rpc-health-monitor:
+    if: ${{ needs.integration-tests-change-filter.outputs.run_expensive == 'true' }}
+    name: rpc-health-monitor-shadownet
+    needs:
+      - integration-tests-change-filter
+    runs-on: ubuntu-latest
+    # Diagnostics only: this never gates a merge, it just records an RPC weather
+    # report over the test window so failures can be correlated with node health.
+    continue-on-error: true
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v6
+      - name: Poll shadownet RPC health
+        env:
+          RPC_URL: https://rpc.shadownet.teztnets.com
+          POLL_INTERVAL_SECONDS: '15'
+          POLL_MAX_DURATION_SECONDS: '1860'
+        run: bash .github/scripts/poll-rpc-health.sh
+      - name: Upload RPC health timeline
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rpc-health-shadownet
+          path: ci-metrics/rpc-health.jsonl
           if-no-files-found: warn
           retention-days: 30
 

--- a/integration-tests/__tests__/http-backend-request-error-handling.spec.ts
+++ b/integration-tests/__tests__/http-backend-request-error-handling.spec.ts
@@ -2,22 +2,25 @@ import { HttpBackend, HttpResponseError } from '@taquito/http-utils';
 
 describe('HttpBackend request', () => {
   it('should fail with HttpResponseError when a 404 gets returned', async () => {
+    // A nonexistent RPC route reliably 404s on any live node. The old fixture
+    // relied on baking_rights?level=0 against ecadinfra's mainnet node (now
+    // decommissioned); public nodes 401/403 that endpoint behind their proxies.
+    // Assert on status/statusText rather than message body: a 404 body is empty
+    // on most public nodes, so the reason phrase only survives in statusText.
+    const url = 'https://rpc.tzkt.io/mainnet/chains/main/blocks/head/votes/nonexistent_endpoint';
     const http: HttpBackend = new HttpBackend();
     try {
       await http.createRequest<string>({
         method: 'GET',
-        url: 'https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/helpers/baking_rights',
-        query: {
-          level: 0
-        }
+        url,
       });
       expect.fail('should have thrown');
     } catch (err: unknown) {
       expect(err).toBeInstanceOf(HttpResponseError);
       const httpErr = err as HttpResponseError;
       expect(httpErr.status).toEqual(404);
-      expect(httpErr.url).toEqual('https://mainnet.tezos.ecadinfra.com/chains/main/blocks/head/helpers/baking_rights?level=0');
-      expect(httpErr.message).toContain('Not Found');
+      expect(httpErr.statusText).toEqual('Not Found');
+      expect(httpErr.url).toEqual(url);
     }
   });
 });

--- a/integration-tests/__tests__/rpc/get-protocol-constants.spec.ts
+++ b/integration-tests/__tests__/rpc/get-protocol-constants.spec.ts
@@ -10,7 +10,9 @@ CONFIGS().forEach(({ lib, rpc, networkType }) => {
   const tallinnnet = (networkType == NetworkType.TESTNET && rpc.includes('tallinn')) ? test : test.skip;
 
   describe('Test fetching constants for all protocols on Mainnet', () => {
-    const rpcUrl = 'https://mainnet.tezos.ecadinfra.com/';
+    // ecadinfra's public mainnet node is being decommissioned; use a live
+    // public mainnet RPC. Constants are network-wide, so any correct node matches.
+    const rpcUrl = 'https://rpc.tzkt.io/mainnet';
     Tezos.setRpcProvider(rpcUrl);
     it(`should successfully fetch Proto24(Tallinn) constants at head`, async () => {
       const constants: ConstantsResponseProto023 = await Tezos.rpc.getConstants();

--- a/integration-tests/config.ts
+++ b/integration-tests/config.ts
@@ -420,7 +420,7 @@ const defaultConfig = ({
 const shadownetEphemeral: Config = defaultConfig({
   networkName: 'SHADOWNET',
   protocol: Protocols.PtTALLiNt,
-  defaultRpc: 'http://ecad-tezos-shadownet-rolling-1.i.ecadinfra.com/',
+  defaultRpc: 'https://rpc.shadownet.teztnets.com',
   knownContracts: knownContractsShadownet,
   signerConfig: defaultEphemeralConfig('shadownet'),
 });


### PR DESCRIPTION
## What

Switches the shadownet integration-test lane off the internal ecadinfra RPC host and onto the public community node `https://rpc.shadownet.teztnets.com`, removes Tailscale (no longer needed), and adds an RPC health monitor that runs alongside the (up to ~30 min) integration tests.

## Why teztnets and not octez.io

The first cut targeted Trilitech's `tezos-shadownet.octez.io`. CI proved the node is healthy but runs the Octez **default remote RPC ACL**, which 401s a set of endpoints Taquito needs (`ticket_balance`, `script/normalized`, `delegates`, `destination/index`, `protocols`, `baking_rights`, `attestation_rights`, `raw/bytes`) — ~25 tests failed purely on that. `rpc.shadownet.teztnets.com` is the same shadownet (chain_id `NetXsqzbfFenSTS`, same protocol `PtTALLiNt`) and serves the full surface, so it works today without waiting on a Trilitech ACL change.

## Changes

- **`integration-tests/config.ts`** — shadownet `defaultRpc` is now `https://rpc.shadownet.teztnets.com`.
- **`.github/workflows/main.yml`** — Tailscale removed from both integration-test jobs (RPC + keygen are both public now); new `rpc-health-monitor` job polls the node in parallel with the tests.
- **`.github/scripts/poll-rpc-health.sh`** — env-driven poller: hits `/chains/main/blocks/head/header` every 15s for up to ~31 min, writes a JSONL timeline (`ci-metrics/rpc-health.jsonl`, uploaded as an artifact) and a `HEALTHY` / `DEGRADED` / `OUTAGE` verdict to the step summary.

## Keygen

Unchanged — `keygen-direct.ecadinfra.com`, now reached over the public internet rather than the tailnet.

## Notes

- The monitor is **diagnostics only** (`continue-on-error: true`) — it never gates a merge.
- Branch name still says `octez`; kept to avoid PR churn.

